### PR TITLE
feat(core): multi-entity weighted read (Phase 2)

### DIFF
--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -1,7 +1,7 @@
 # Multi-Entity Weighted Retrieval and Librarian Prompt Overrides
 
 **Date:** 2026-05-12  
-**Status:** Draft  
+**Status:** Approved
 **Breaking Change:** No
 
 ## Overview

--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -27,7 +27,7 @@ Curated Thoughts also needs the synthesis prompt to be replaceable. Different pr
 - Preserve backward compatibility for existing single-entity calls.
 - Apply tier/entity weights inside core retrieval before the final top-K slice.
 - Preserve each returned `WikiFact.entity_id` so downstream prompts can explain source provenance.
-- Expose optional `factScores` and metadata when multi-entity or weighted retrieval is used.
+- Expose optional `factScores` and `metadata` when multi-entity (array-shaped `entityId`) retrieval is used.
 - Define a Librarian `systemPrompt` override pattern that can consume weighted retrieval output through stable template variables.
 - Allow developers to tune synthesis behavior, output format, and strictness without changing core retrieval logic.
 - Keep the single-entity hot path clean: no extra metadata for plain calls.
@@ -115,7 +115,7 @@ export interface MemoryBundle {
 
 `factScores` maps fact ID to the final weighted score used for ranking. It is separate from `WikiFact` so the fact type remains a pure persisted-domain type.
 
-For non-empty scored reads, `factScores` and `metadata` are present only when the caller passed an array-shaped `entityId` or provided `tierWeights`. Plain single-string calls keep the existing minimal bundle shape.
+For non-empty scored reads, `factScores` and `metadata` are present only when the caller passed an array-shaped `entityId`. Plain single-string calls keep the existing minimal bundle shape regardless of any other options (including `tierWeights`).
 
 For empty-query recency reads, tier weights are ignored because there is no semantic or keyword score to multiply. Metadata may still echo the requested entities and weights, but `factScores` should be omitted for that path to avoid inventing a score.
 
@@ -303,7 +303,7 @@ Add or update tests in `packages/core/__tests__` to cover:
 3. Multi-entity read returns one merged `facts` array and preserves each fact's `entity_id`.
 4. Tier weights affect final top-K ordering before `maxResults` slicing.
 5. `factScores` is present for scored multi-entity reads and contains every returned fact ID.
-6. `factScores` is present for scored single-entity reads when `tierWeights` is provided.
+6. Single-entity string calls never expose `factScores` or `metadata` regardless of options.
 7. Metadata echoes `query`, normalized `entityIds`, and sanitized tier weights when applicable.
 8. Missing, non-finite, negative, and zero weights behave as specified.
 9. Empty-query multi-entity reads merge by `updated_at DESC` and ignore weights.

--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -127,6 +127,8 @@ For non-empty queries, tier weighting is applied after the current semantic/keyw
 finalScore = retrievalScore * (tierWeights[entity_id] ?? 1.0)
 ```
 
+Weight `0` is special-cased: instead of multiplying by zero (which could produce a score of `0` and incorrectly outrank negative semantic scores), the implementation assigns `-Infinity` as a sentinel. This guarantees zero-weight facts sort below every finite-scored fact regardless of sign. When `factScores` is exposed to callers, the sentinel is coerced back to `0` so the returned value remains a finite number.
+
 `retrievalScore` is the score produced by the active retrieval branch:
 
 - vector ranker semantic score, optionally blended with normalized MiniSearch score via `hybridWeight`

--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -310,7 +310,7 @@ Add or update tests in `packages/core/__tests__` to cover:
 8. Missing, non-finite, negative, and zero weights behave as specified.
 9. Empty-query multi-entity reads merge by `updated_at DESC` and ignore weights.
 10. Tasks and events are returned for all requested entities.
-11. A dimension mismatch in any requested entity causes the whole scored retrieval to use keyword fallback.
+11. A dimension mismatch in any **scored** entity causes the whole scored retrieval to use keyword fallback. Zero-weight entities are excluded from this check (unless `includeZeroWeightEntities` is true) so stale embeddings in skipped entities do not force fallback.
 12. Duplicate entity IDs are deduplicated.
 13. MiniSearch fallback applies tier weights before the final top-K slice.
 14. Ranker fallback to JS cosine preserves entity IDs and applies tier weights.

--- a/packages/core/__tests__/multiEntityRead.test.ts
+++ b/packages/core/__tests__/multiEntityRead.test.ts
@@ -136,6 +136,30 @@ describe('read() multi-entity retrieval', () => {
     expect(result.factScores).toEqual({ 'fact-1': expect.any(Number), 'zero-1': 0 });
   });
 
+  it('zero-weight entities sort below negative-scored non-zero-weight entities', async () => {
+    // Bug: score * 0 = 0 can rank higher than a negative cosine score.
+    // query=[1,0,0], tier_neg=[-1,0,0] → cosine=-1 (weight=1 → score=-1)
+    // tier_zero=[1,0,0] → cosine=1 (weight=0 → score should be -Infinity, not 0)
+    const embedFn = vi.fn(async () => [1, 0, 0]);
+    const { wiki, db } = makeWiki(embedFn);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'neg-1', 'tier_neg', 'apple neg', 'apple', [-1, 0, 0], 1000);
+    await insertFact(db, 'zero-2', 'tier_zero', 'apple zero2', 'apple', [1, 0, 0], 2000);
+
+    const result = await wiki.read(['tier_neg', 'tier_zero'], 'apple', {
+      maxResults: 2,
+      tierWeights: { tier_neg: 1, tier_zero: 0 },
+      includeZeroWeightEntities: true,
+    });
+
+    // neg-1 has cosine=-1 (bad match but non-zero weight); zero-2 has cosine=1 but weight=0
+    // zero-weight must always be bottom filler regardless of raw cosine
+    expect(result.facts.map(f => f.id)).toEqual(['neg-1', 'zero-2']);
+    expect(result.factScores!['neg-1']).toBeLessThan(0);
+    expect(result.factScores!['zero-2']).toBe(0);
+  });
+
   it('empty-query multi-entity reads use global recency and omit factScores', async () => {
     const { wiki, db } = makeWiki(async () => [1, 0, 0]);
     await wiki.setup();

--- a/packages/core/__tests__/multiEntityRead.test.ts
+++ b/packages/core/__tests__/multiEntityRead.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WikiMemory } from '../src/WikiMemory';
+import { openTestDatabase } from './helpers/sqliteAdapter';
+import type { WikiOptions } from '../src/types';
+
+function makeWiki(embedFn?: (text: string) => Promise<number[]>) {
+  const db = openTestDatabase();
+  const options: WikiOptions = {
+    config: { maxResults: 10 },
+    llmProvider: { generateText: async () => '{}', embed: embedFn },
+  };
+  return { wiki: new WikiMemory(db, options), db };
+}
+
+async function insertFact(
+  db: ReturnType<typeof openTestDatabase>,
+  id: string,
+  entityId: string,
+  title: string,
+  body: string,
+  vec: number[] | null,
+  updatedAt: number,
+) {
+  const blob = vec ? new Uint8Array(new Float32Array(vec).buffer) : null;
+  await db.runAsync(
+    `INSERT INTO llm_wiki_entries (id, entity_id, title, body, tags, confidence, source_type, created_at, updated_at, embedding_blob)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, entityId, title, body, '[]', 'certain', 'user_stated', updatedAt, updatedAt, blob],
+  );
+}
+
+describe('read() multi-entity retrieval', () => {
+  it('keeps plain single-string reads minimal', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', 'apple guidance', [1, 0, 0], 1000);
+
+    const result = await wiki.read('tier_wisdom', 'apple');
+
+    expect(result.facts.map(f => f.id)).toEqual(['wisdom-1']);
+    expect(result.factScores).toBeUndefined();
+    expect(result.metadata).toBeUndefined();
+  });
+
+  it('merges multi-entity scored reads and preserves each fact entity_id', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', 'apple', [1, 0, 0], 1000);
+    await insertFact(db, 'fact-1', 'tier_fact', 'apple fact', 'apple', [0.5, 0.5, 0.5], 2000);
+
+    const result = await wiki.read(['tier_wisdom', 'tier_fact'], 'apple', { maxResults: 2 });
+
+    expect(result.facts.map(f => [f.id, f.entity_id])).toEqual([
+      ['wisdom-1', 'tier_wisdom'],
+      ['fact-1', 'tier_fact'],
+    ]);
+    expect(result.metadata).toEqual({ query: 'apple', entityIds: ['tier_wisdom', 'tier_fact'] });
+    expect(result.factScores?.['wisdom-1']).toBeGreaterThan(result.factScores?.['fact-1'] ?? 0);
+  });
+
+  it('applies tier weights before global maxResults slicing', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'working-strong', 'tier_working', 'apple working', 'apple', [0.9, 0, 0], 3000);
+    await insertFact(db, 'wisdom-weak', 'tier_wisdom', 'apple wisdom', 'apple', [0.1, 0.1, 0.1], 1000);
+
+    const result = await wiki.read(['tier_working', 'tier_wisdom'], 'apple', {
+      maxResults: 1,
+      tierWeights: { tier_wisdom: 10, tier_working: 1 },
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['wisdom-weak']);
+    expect(result.metadata?.tierWeights).toEqual({ tier_working: 1, tier_wisdom: 10 });
+    expect(result.factScores).toEqual({ 'wisdom-weak': expect.any(Number) });
+  });
+
+  it('deduplicates entity ids and exposes metadata for single-element arrays', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', 'apple', [1, 0, 0], 1000);
+
+    const result = await wiki.read(['tier_wisdom', 'tier_wisdom'], 'apple');
+
+    expect(result.facts.map(f => f.id)).toEqual(['wisdom-1']);
+    expect(result.metadata?.entityIds).toEqual(['tier_wisdom']);
+  });
+
+  it('returns an empty bundle with metadata for an empty entity id array', async () => {
+    const { wiki } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+
+    const result = await wiki.read([], 'apple');
+
+    expect(result).toEqual({
+      facts: [],
+      tasks: [],
+      events: [],
+      metadata: { query: 'apple', entityIds: [] },
+    });
+  });
+
+  it('skips zero-weight entities by default for scored reads', async () => {
+    const embedFn = vi.fn(async () => [1, 0, 0]);
+    const { wiki, db } = makeWiki(embedFn);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'zero-1', 'tier_zero', 'apple zero', 'apple', [1, 0, 0], 1000);
+    await insertFact(db, 'fact-1', 'tier_fact', 'apple fact', 'apple', [0.8, 0, 0], 2000);
+
+    const result = await wiki.read(['tier_zero', 'tier_fact'], 'apple', {
+      tierWeights: { tier_zero: 0, tier_fact: 1 },
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['fact-1']);
+    expect(result.factScores).toEqual({ 'fact-1': expect.any(Number) });
+  });
+
+  it('includes zero-weight entities as bottom filler when requested', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'zero-1', 'tier_zero', 'apple zero', 'apple', [0.5, 0, 0], 1000);
+    await insertFact(db, 'fact-1', 'tier_fact', 'apple fact', 'apple', [1, 0, 0], 2000);
+
+    const result = await wiki.read(['tier_zero', 'tier_fact'], 'apple', {
+      maxResults: 2,
+      tierWeights: { tier_zero: 0, tier_fact: 1 },
+      includeZeroWeightEntities: true,
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['fact-1', 'zero-1']);
+    expect(result.factScores).toEqual({ 'fact-1': expect.any(Number), 'zero-1': 0 });
+  });
+
+  it('empty-query multi-entity reads use global recency and omit factScores', async () => {
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await insertFact(db, 'old', 'tier_wisdom', 'old', 'body', null, 1000);
+    await insertFact(db, 'new', 'tier_fact', 'new', 'body', null, 3000);
+
+    const result = await wiki.read(['tier_wisdom', 'tier_fact'], '', {
+      maxResults: 2,
+      tierWeights: { tier_wisdom: 10, tier_fact: 0.1 },
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['new', 'old']);
+    expect(result.factScores).toBeUndefined();
+    expect(result.metadata).toEqual({
+      query: '',
+      entityIds: ['tier_wisdom', 'tier_fact'],
+      tierWeights: { tier_wisdom: 10, tier_fact: 0.1 },
+    });
+  });
+
+  it('returns tasks and events for all requested entities in global order', async () => {
+    const { wiki, db } = makeWiki();
+    await wiki.setup();
+    await db.runAsync(
+      `INSERT INTO llm_wiki_tasks (id, entity_id, description, status, priority, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['task-low', 'tier_fact', 'low', 'pending', 1, 1000, 1000],
+    );
+    await db.runAsync(
+      `INSERT INTO llm_wiki_tasks (id, entity_id, description, status, priority, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ['task-high', 'tier_wisdom', 'high', 'in_progress', 5, 2000, 2000],
+    );
+    await db.runAsync(
+      `INSERT INTO llm_wiki_events (id, entity_id, event_type, summary, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      ['event-old', 'tier_fact', 'observation', 'old', 1000],
+    );
+    await db.runAsync(
+      `INSERT INTO llm_wiki_events (id, entity_id, event_type, summary, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      ['event-new', 'tier_wisdom', 'observation', 'new', 3000],
+    );
+
+    const result = await wiki.read(['tier_fact', 'tier_wisdom'], '');
+
+    expect(result.tasks.map(t => t.id)).toEqual(['task-high', 'task-low']);
+    expect(result.events.map(e => e.id)).toEqual(['event-old', 'event-new']);
+  });
+});

--- a/packages/core/__tests__/multiEntityRead.test.ts
+++ b/packages/core/__tests__/multiEntityRead.test.ts
@@ -156,6 +156,68 @@ describe('read() multi-entity retrieval', () => {
     });
   });
 
+  it('applies tier weights in embed-absent keyword fallback and populates factScores', async () => {
+    // No embed function — forces MiniSearch-only path
+    const { wiki } = makeWiki();
+    await wiki.setup();
+    // Use importDump so facts are indexed in MiniSearch
+    await wiki.importDump({
+      generatedAt: Date.now(),
+      entities: {
+        tier_boosted: {
+          facts: [{ id: 'boosted-weak', entity_id: 'tier_boosted', title: 'apple boosted', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 1000, updated_at: 1000, last_accessed_at: null, access_count: 0, deleted_at: null }],
+          tasks: [], events: [],
+        },
+        tier_normal: {
+          facts: [{ id: 'normal-strong', entity_id: 'tier_normal', title: 'apple normal', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 2000, updated_at: 2000, last_accessed_at: null, access_count: 0, deleted_at: null }],
+          tasks: [], events: [],
+        },
+      },
+    });
+
+    const result = await wiki.read(['tier_boosted', 'tier_normal'], 'apple', {
+      maxResults: 1,
+      tierWeights: { tier_boosted: 10, tier_normal: 1 },
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['boosted-weak']);
+    expect(result.factScores?.['boosted-weak']).toBeGreaterThan(0);
+  });
+
+  it('applies tier weights in vectorRankerFallback=keyword path and populates factScores', async () => {
+    const db = openTestDatabase();
+    const options: WikiOptions = {
+      config: { maxResults: 10 },
+      llmProvider: { generateText: async () => '{}', embed: async () => [1, 0, 0] },
+      vectorRanker: { rankBySimilarity: async () => { throw new Error('ranker unavailable'); } },
+      vectorRankerFallback: 'keyword',
+    };
+    const wiki = new WikiMemory(db, options);
+    await wiki.setup();
+    await wiki.importDump({
+      generatedAt: Date.now(),
+      entities: {
+        tier_boosted: {
+          facts: [{ id: 'boosted-weak', entity_id: 'tier_boosted', title: 'apple boosted', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 1000, updated_at: 1000, last_accessed_at: null, access_count: 0, deleted_at: null }],
+          tasks: [], events: [],
+        },
+        tier_normal: {
+          facts: [{ id: 'normal-strong', entity_id: 'tier_normal', title: 'apple normal', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 2000, updated_at: 2000, last_accessed_at: null, access_count: 0, deleted_at: null }],
+          tasks: [], events: [],
+        },
+      },
+    });
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+
+    const result = await wiki.read(['tier_boosted', 'tier_normal'], 'apple', {
+      maxResults: 1,
+      tierWeights: { tier_boosted: 10, tier_normal: 1 },
+    });
+
+    expect(result.facts.map(f => f.id)).toEqual(['boosted-weak']);
+    expect(result.factScores?.['boosted-weak']).toBeGreaterThan(0);
+  });
+
   it('returns tasks and events for all requested entities in global order', async () => {
     const { wiki, db } = makeWiki();
     await wiki.setup();

--- a/packages/core/__tests__/multiEntityRead.test.ts
+++ b/packages/core/__tests__/multiEntityRead.test.ts
@@ -271,4 +271,14 @@ describe('read() multi-entity retrieval', () => {
     expect(result.tasks.map(t => t.id)).toEqual(['task-high', 'task-low']);
     expect(result.events.map(e => e.id)).toEqual(['event-old', 'event-new']);
   });
+
+  it('throws RangeError when more than 100 entity IDs are passed', async () => {
+    const { wiki } = makeWiki();
+    await wiki.setup();
+    const ids = Array.from({ length: 101 }, (_, i) => `entity_${i}`);
+    await expect(wiki.read(ids, 'query')).rejects.toThrow(RangeError);
+    await expect(wiki.read(ids, 'query')).rejects.toThrow(
+      'read() accepts at most 100 entity IDs; received 101',
+    );
+  });
 });

--- a/packages/core/__tests__/multiEntityReadOptions.test.ts
+++ b/packages/core/__tests__/multiEntityReadOptions.test.ts
@@ -52,9 +52,9 @@ describe('multi-entity read option helpers', () => {
     expect(applyTierWeight(0.4, 'tier_fact', { tier_wisdom: 2 })).toBeCloseTo(0.4);
   });
 
-  it('exposes metadata for array-shaped entity ids or explicit weights only', () => {
-    expect(shouldExposeReadMetadata('tier_wisdom', {})).toBe(false);
-    expect(shouldExposeReadMetadata(['tier_wisdom'], {})).toBe(true);
-    expect(shouldExposeReadMetadata('tier_wisdom', { tierWeights: { tier_wisdom: 2 } })).toBe(true);
+  it('exposes metadata only for array-shaped entity ids', () => {
+    expect(shouldExposeReadMetadata('tier_wisdom')).toBe(false);
+    expect(shouldExposeReadMetadata(['tier_wisdom'])).toBe(true);
+    expect(shouldExposeReadMetadata('tier_wisdom', { tierWeights: { tier_wisdom: 2 } })).toBe(false);
   });
 });

--- a/packages/core/__tests__/multiEntityReadOptions.test.ts
+++ b/packages/core/__tests__/multiEntityReadOptions.test.ts
@@ -55,6 +55,6 @@ describe('multi-entity read option helpers', () => {
   it('exposes metadata only for array-shaped entity ids', () => {
     expect(shouldExposeReadMetadata('tier_wisdom')).toBe(false);
     expect(shouldExposeReadMetadata(['tier_wisdom'])).toBe(true);
-    expect(shouldExposeReadMetadata('tier_wisdom')).toBe(false);
+    expect(shouldExposeReadMetadata([])).toBe(true);
   });
 });

--- a/packages/core/__tests__/multiEntityReadOptions.test.ts
+++ b/packages/core/__tests__/multiEntityReadOptions.test.ts
@@ -55,6 +55,6 @@ describe('multi-entity read option helpers', () => {
   it('exposes metadata only for array-shaped entity ids', () => {
     expect(shouldExposeReadMetadata('tier_wisdom')).toBe(false);
     expect(shouldExposeReadMetadata(['tier_wisdom'])).toBe(true);
-    expect(shouldExposeReadMetadata('tier_wisdom', { tierWeights: { tier_wisdom: 2 } })).toBe(false);
+    expect(shouldExposeReadMetadata('tier_wisdom')).toBe(false);
   });
 });

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -915,10 +915,11 @@ describe('VectorRanker integration', () => {
 
   describe('Regression: PR #16 review issues', () => {
     it('should filter out ranker results outside the candidate set before hydration', async () => {
-      // candidateIds is always passed to the ranker so _rankWithVectorRanker filters
-      // out-of-scope IDs via allowedIds before Phase 2 hydration. The misbehaving ranker
-      // returning cross-entity/nonexistent IDs should not trigger the hydration mismatch
-      // warning nor cause result count to drop silently.
+      // Filtering is done via the allowedIds derived from candidateRows in
+      // _rankWithVectorRanker, which catches cross-entity or nonexistent IDs
+      // regardless of whether candidateIds was passed to the ranker. The
+      // misbehaving ranker returning such IDs should not trigger the hydration
+      // mismatch warning nor cause result count to drop silently.
       const db = openTestDatabase();
       const onRetrievalFallback = vi.fn();
       const mockRanker: VectorRanker = {

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -330,9 +330,8 @@ describe('VectorRanker integration', () => {
 
       expect(rankBySimilarity).toHaveBeenCalled();
       const args = rankBySimilarity.mock.calls[0][0];
-      // candidateIds is always passed so the ranker is scoped to the SQLite candidate set,
-      // preventing cross-entity results when entityId is a composite key in multi-entity reads.
-      expect(args.candidateIds).toEqual(['fact-a']);
+      // Single-entity full-scan should omit candidateIds so rankers can scope by entityId.
+      expect(args.candidateIds).toBeUndefined();
     });
   });
 

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -306,7 +306,7 @@ describe('VectorRanker integration', () => {
       expect(args.candidateIds?.length).toBeLessThanOrEqual(2);
     });
 
-    it('should omit candidateIds when preFilterLimit is not set (full scan)', async () => {
+    it('should pass candidateIds even when preFilterLimit is not set (full scan)', async () => {
       const db = openTestDatabase();
       const rankBySimilarity = vi.fn(async (args: VectorRankerRankArgs) => {
         return [{ id: 'fact-a', semanticScore: 0.5 }];
@@ -330,7 +330,9 @@ describe('VectorRanker integration', () => {
 
       expect(rankBySimilarity).toHaveBeenCalled();
       const args = rankBySimilarity.mock.calls[0][0];
-      expect(args.candidateIds).toBeUndefined();
+      // candidateIds is always passed so the ranker is scoped to the SQLite candidate set,
+      // preventing cross-entity results when entityId is a composite key in multi-entity reads.
+      expect(args.candidateIds).toEqual(['fact-a']);
     });
   });
 
@@ -913,19 +915,21 @@ describe('VectorRanker integration', () => {
   });
 
   describe('Regression: PR #16 review issues', () => {
-    it('should detect and report when ranker returns IDs outside entity scope', async () => {
-      // Issue 2: In full-scan mode, a misbehaving ranker can return IDs from other entities.
-      // These get filtered in Phase 2, reducing result count without notification.
+    it('should filter out ranker results outside the candidate set before hydration', async () => {
+      // candidateIds is always passed to the ranker so _rankWithVectorRanker filters
+      // out-of-scope IDs via allowedIds before Phase 2 hydration. The misbehaving ranker
+      // returning cross-entity/nonexistent IDs should not trigger the hydration mismatch
+      // warning nor cause result count to drop silently.
       const db = openTestDatabase();
       const onRetrievalFallback = vi.fn();
       const mockRanker: VectorRanker = {
         rankBySimilarity: async () => {
           // Return mix of valid and invalid IDs
           return [
-            { id: 'fact-a', semanticScore: 0.9 },      // valid
-            { id: 'wrong-entity-1', semanticScore: 0.8 }, // invalid (wrong entity)
-            { id: 'fact-b', semanticScore: 0.7 },      // valid
-            { id: 'nonexistent', semanticScore: 0.6 },   // invalid (doesn't exist)
+            { id: 'fact-a', semanticScore: 0.9 },         // valid (in candidateIds)
+            { id: 'wrong-entity-1', semanticScore: 0.8 },  // filtered by allowedIds
+            { id: 'fact-b', semanticScore: 0.7 },          // valid (in candidateIds)
+            { id: 'nonexistent', semanticScore: 0.6 },     // filtered by allowedIds
           ];
         },
       };
@@ -951,10 +955,11 @@ describe('VectorRanker integration', () => {
       expect(result.facts[0].id).toBe('fact-a');
       expect(result.facts[1].id).toBe('fact-b');
 
-      // Should notify when hydration returns fewer rows than ranked IDs
-      expect(onRetrievalFallback).toHaveBeenCalledWith(
+      // Invalid IDs are filtered by allowedIds in _rankWithVectorRanker — hydration sees
+      // exactly 2 topIds and returns 2 rows, so the mismatch warning is NOT triggered.
+      expect(onRetrievalFallback).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining('Phase 2 fact hydration returned 2 fewer row(s)'),
+          message: expect.stringContaining('Phase 2 fact hydration returned'),
         })
       );
     });

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -306,7 +306,7 @@ describe('VectorRanker integration', () => {
       expect(args.candidateIds?.length).toBeLessThanOrEqual(2);
     });
 
-    it('should pass candidateIds even when preFilterLimit is not set (full scan)', async () => {
+    it('should omit candidateIds for single-entity full-scan', async () => {
       const db = openTestDatabase();
       const rankBySimilarity = vi.fn(async (args: VectorRankerRankArgs) => {
         return [{ id: 'fact-a', semanticScore: 0.5 }];
@@ -956,11 +956,7 @@ describe('VectorRanker integration', () => {
 
       // Invalid IDs are filtered by allowedIds in _rankWithVectorRanker — hydration sees
       // exactly 2 topIds and returns 2 rows, so the mismatch warning is NOT triggered.
-      expect(onRetrievalFallback).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Phase 2 fact hydration returned'),
-        })
-      );
+      expect(onRetrievalFallback).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1040,7 +1040,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       if (!skipEmbed && embedFn) {
         let rankerShouldRethrow = false;
         let pendingRankerFallbackError: Error | undefined;
-        let usedKeywordFallback = false;
         try {
           const queryVec = await embedFn(trimmedQuery);
 
@@ -1420,7 +1419,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                         updated_at: meta?.updated_at ?? null,
                       };
                     });
-                    usedKeywordFallback = true;
                   } else {
                     // policy === 'empty'
                     scored = [];
@@ -1457,7 +1455,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                   score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
                 }));
 
-                // Re-apply tie-break sorting (ranker might not have stable ordering, and weights changed order)
+                // Re-apply tie-break sorting after tier-weight application (applies to all paths including
+                // vectorRankerFallback='keyword': applyTierWeight mutates scores so MiniSearch ordering is no longer valid)
                 this._tieBreakSort(scored);
 
                 // Phase 2: fetch full rows only for the top results

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -990,7 +990,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const config = this.options.config;
     const entityIds = normalizeEntityIds(entityId);
     const sanitizedTierWeights = sanitizeTierWeights(entityIds, options?.tierWeights);
-    const exposeMetadata = shouldExposeReadMetadata(entityId, options);
+    const exposeMetadata = shouldExposeReadMetadata(entityId);
 
     if (entityIds.length === 0) {
       const empty: MemoryBundle = { facts: [], tasks: [], events: [] };
@@ -999,6 +999,11 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         if (sanitizedTierWeights) empty.metadata.tierWeights = sanitizedTierWeights;
       }
       return empty;
+    }
+
+    const MAX_ENTITY_IDS = 100;
+    if (entityIds.length > MAX_ENTITY_IDS) {
+      throw new RangeError(`read() accepts at most ${MAX_ENTITY_IDS} entity IDs; received ${entityIds.length}`);
     }
 
     const rawMaxResults = options?.maxResults ?? config?.maxResults ?? config?.maxFtsResults ?? 10;
@@ -1398,7 +1403,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                     const meta = candidateMap.get(r.id);
                     return {
                       id: r.id,
-                      entity_id: meta?.entity_id ?? entityCacheKey,
+                      entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
                       score: r.score ?? 0,
                       access_count: meta?.access_count ?? null,
                       updated_at: meta?.updated_at ?? null,
@@ -1643,25 +1648,29 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
   }
 
   /**
-   * Hydrate full facts by ID. Pass scopedEntityIds to filter out facts outside the requested
-   * namespaces (defense-in-depth against a rogue VectorRanker returning cross-entity IDs).
+   * Hydrate full facts by ID. Pass scopedEntityIds to restrict to requested namespaces in SQL
+   * (defense-in-depth against a rogue VectorRanker returning cross-entity IDs).
    */
   private async _hydrateFactsByIds(ids: readonly string[], scopedEntityIds?: readonly string[]): Promise<WikiFact[]> {
     const fullRows: Array<WikiFact & { embedding?: unknown; embedding_blob?: unknown }> = [];
     const chunkSize = 500;
+    const entityClause = scopedEntityIds && scopedEntityIds.length > 0
+      ? ` AND entity_id IN (${scopedEntityIds.map(() => '?').join(',')})`
+      : '';
+    const entityParams = scopedEntityIds && scopedEntityIds.length > 0 ? [...scopedEntityIds] : [];
 
     for (let i = 0; i < ids.length; i += chunkSize) {
       const idChunk = ids.slice(i, i + chunkSize);
       const placeholders = idChunk.map(() => '?').join(',');
       const chunkRows = await this.db.getAllAsync<WikiFact & { embedding?: unknown; embedding_blob?: unknown }>(
-        `SELECT * FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-        [...idChunk],
+        `SELECT * FROM ${this.prefix}entries WHERE id IN (${placeholders})${entityClause} AND deleted_at IS NULL`,
+        [...idChunk, ...entityParams],
       );
       fullRows.push(...chunkRows);
     }
 
     const byId = new Map(fullRows.map(row => [row.id, row]));
-    const result = ids
+    return ids
       .map(id => byId.get(id))
       .filter((fact): fact is WikiFact & { embedding?: unknown; embedding_blob?: unknown } => fact !== undefined)
       .map(fact => {
@@ -1671,12 +1680,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
           tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
         };
       });
-
-    if (scopedEntityIds && scopedEntityIds.length > 0) {
-      const scopeSet = new Set(scopedEntityIds);
-      return result.filter(f => scopeSet.has(f.entity_id));
-    }
-    return result;
   }
 
   /**

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1456,7 +1456,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
               // Capture scores for exposure in metadata
               if (exposeMetadata && trimmedQuery) {
-                scoreByFactId = new Map(selectedScored.map(s => [s.id, s.score]));
+                scoreByFactId = new Map(selectedScored.map(s => [s.id, Number.isFinite(s.score) ? s.score : 0]));
               }
 
               if (topIds.length > 0) {
@@ -1537,7 +1537,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         if (topIds.length > 0) {
           facts = await this._hydrateFactsByIds(topIds, entityIds);
           if (exposeMetadata) {
-            scoreByFactId = new Map(topCandidates.map(c => [c.id, c.score]));
+            scoreByFactId = new Map(topCandidates.map(c => [c.id, Number.isFinite(c.score) ? c.score : 0]));
           }
         }
       }
@@ -1632,7 +1632,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     b: { id: string; score: number; updated_at?: number | null; access_count?: number | null },
   ): number {
     const scoreDiff = b.score - a.score;
-    if (scoreDiff !== 0) return scoreDiff;
+    // isNaN guard: -Infinity - (-Infinity) = NaN; fall through to tie-break
+    if (!isNaN(scoreDiff) && scoreDiff !== 0) return scoreDiff;
     const accessCountDiff = (b.access_count ?? 0) - (a.access_count ?? 0);
     if (accessCountDiff !== 0) return accessCountDiff;
     const updatedAtDiff = (b.updated_at ?? 0) - (a.updated_at ?? 0);

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1098,7 +1098,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
           const useRanker = Boolean(this.options.vectorRanker);
           let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
-          let populateCache = true;
+          // Composite cache keys (multi-entity join strings) are never invalidated by write/reembed paths.
+          let populateCache = entityIds.length === 1;
           let miniSearchScores: Map<string, number> | undefined;
 
           if (effectivePreFilterLimit !== undefined) {
@@ -1188,10 +1189,11 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
 
             if (useRanker) {
-              // Use external ranker for semantic scoring
-              // Always pass candidateIds so the ranker scopes to the SQLite candidate set.
-              // Omitting it would let the ranker scope by entityId, which is a composite
-              // join-string for multi-entity reads and may not map to a real namespace.
+              // Use external ranker for semantic scoring.
+              // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
+              // not a real namespace) and pre-filtered reads (results already scoped to subset).
+              // For single-entity full-scan, omit so remote rankers avoid transmitting the full
+              // candidate list and can scope by entityId instead.
               const candidateIds = candidateRows.map(r => r.id);
 
               try {
@@ -1382,6 +1384,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                     miniSearchScores,
                     populateCache,
                     limit: fallbackRows.length,
+                    skipSort: true, // read() re-sorts after applying tier weights
                   });
                 } else if (policy === 'keyword') {
                   // Fall back to keyword-only results from MiniSearch
@@ -1437,6 +1440,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                 // Return all candidates so tier weights can re-rank before the
                 // global slice at the merge step below.
                 limit: candidateRows.length,
+                skipSort: true, // read() re-sorts after applying tier weights
               });
             }
 
@@ -1725,11 +1729,12 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     miniSearchScores: Map<string, number> | undefined;
     populateCache: boolean;
     limit: number;
+    skipSort?: boolean;
   }): Promise<Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }>> {
     const queryVec = args.queryVec instanceof Float32Array
       ? args.queryVec.slice()
       : Array.from(args.queryVec);
-    const { entityId, candidateRows, weight, miniSearchScores, populateCache, limit } = args;
+    const { entityId, candidateRows, weight, miniSearchScores, populateCache, limit, skipSort } = args;
 
     // Cache: reuse parsed vectors from prior full-scan reads
     let entityCache = this.vectorCache.get(entityId);
@@ -1792,8 +1797,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       }
     }
 
-    // Apply tie-break sorting to the scored results and return only the top `limit` items.
-    this._tieBreakSort(scored);
+    // Apply tie-break sorting unless caller will re-sort after applying tier weights.
+    if (!skipSort) this._tieBreakSort(scored);
 
     return scored.slice(0, limit);
   }
@@ -1832,7 +1837,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
     // Normalize ranker output: filter to allowed ids, drop non-finite scores, deduplicate
     // Stop collecting once limit valid results are found to protect against huge result sets
-    const allowedIds = candidateIds ? new Set(candidateIds) : undefined;
+    const allowedIds = new Set(candidateRows.map(row => row.id));
     const seen = new Set<string>();
     const normalized: typeof rankerResults = [];
 

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1354,8 +1354,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                       const idChunk = rowIds.slice(i, i + chunkSize);
                       const placeholders = idChunk.map(() => '?').join(',');
                       const embeddingRows = await this.db.getAllAsync<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null }>(
-                        `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND entity_id = ? AND deleted_at IS NULL`,
-                        [...idChunk, entityId]
+                        `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                        idChunk
                       );
                       for (const row of embeddingRows) {
                         embeddingsMap.set(row.id, { embedding_blob: row.embedding_blob, embedding: row.embedding });
@@ -1383,7 +1383,9 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                     filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
                     combineWith: 'OR',
                   });
-                  const topResults = msResults.slice(0, maxResults);
+                  // Oversample so tier weights can re-rank before the global slice
+                  const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
+                  const topResults = msResults.slice(0, keywordOversampledLimit);
                   // Build metadata map only for returned IDs (not all candidates)
                   const resultIds = new Set(topResults.map(r => r.id));
                   const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
@@ -1439,10 +1441,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               }));
 
               // Re-apply tie-break sorting (ranker might not have stable ordering, and weights changed order)
-              // Skip for keyword-only fallback to preserve MiniSearch ordering
-              if (!usedKeywordFallback) {
-                this._tieBreakSort(scored);
-              }
+              this._tieBreakSort(scored);
 
               // Phase 2: fetch full rows only for the top results
               const selectedScored = scored.slice(0, maxResults);
@@ -1454,13 +1453,13 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               }
 
               if (topIds.length > 0) {
-                const facts2 = await this._hydrateFactsByIds(topIds);
+                const facts2 = await this._hydrateFactsByIds(topIds, entityIds);
 
                 // Hydration can return fewer rows than ranked IDs when rows were concurrently
                 // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
                 if (facts2.length < topIds.length) {
-                  const hydrationByteId = new Set(facts2.map(f => f.id));
-                  const missingIds = topIds.filter(id => !hydrationByteId.has(id));
+                  const hydrationById = new Set(facts2.map(f => f.id));
+                  const missingIds = topIds.filter(id => !hydrationById.has(id));
                   const missingCount = missingIds.length;
                   const sample = missingIds.slice(0, 5);
                   const sampleSuffix = sample.length > 0
@@ -1507,15 +1506,32 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       }
 
       if (!usedEmbed) {
-        // embed absent or threw — fall back to MiniSearch
-        const entityIdSet = new Set(entityIds);
+        // embed absent or threw — fall back to MiniSearch with tier weight application
+        const fallbackEntityIds = entityIds.filter(id => {
+          const w = sanitizedTierWeights?.[id] ?? 1;
+          return options?.includeZeroWeightEntities === true || w !== 0;
+        });
+        const fallbackEntityIdSet = new Set(fallbackEntityIds);
+        const fallbackOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
         const results = this.miniSearch.search(trimmedQuery, {
-          filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
+          filter: (r) => fallbackEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
           combineWith: 'OR',
         });
-        const topIds = results.slice(0, maxResults).map((r: { id: string }) => r.id);
+        const candidates = results.slice(0, fallbackOversampledLimit).map(r => ({
+          id: r.id as string,
+          entity_id: (r as unknown as { entity_id: string }).entity_id,
+          score: applyTierWeight(r.score ?? 0, (r as unknown as { entity_id: string }).entity_id, sanitizedTierWeights),
+          updated_at: null as number | null,
+          access_count: null as number | null,
+        }));
+        this._tieBreakSort(candidates);
+        const topCandidates = candidates.slice(0, maxResults);
+        const topIds = topCandidates.map(c => c.id);
         if (topIds.length > 0) {
-          facts = await this._hydrateFactsByIds(topIds);
+          facts = await this._hydrateFactsByIds(topIds, entityIds);
+          if (exposeMetadata) {
+            scoreByFactId = new Map(topCandidates.map(c => [c.id, c.score]));
+          }
         }
       }
 
@@ -1621,14 +1637,16 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
    * Build SQL IN clause with placeholders for multiple entity IDs.
    */
   private _entityInClause(entityIds: readonly string[]): { clause: string; params: string[] } {
+    if (entityIds.length === 0) return { clause: '1=0', params: [] };
     const placeholders = entityIds.map(() => '?').join(',');
     return { clause: `entity_id IN (${placeholders})`, params: [...entityIds] };
   }
 
   /**
-   * Hydrate full facts by ID without entity_id filtering.
+   * Hydrate full facts by ID. Pass scopedEntityIds to filter out facts outside the requested
+   * namespaces (defense-in-depth against a rogue VectorRanker returning cross-entity IDs).
    */
-  private async _hydrateFactsByIds(ids: readonly string[]): Promise<WikiFact[]> {
+  private async _hydrateFactsByIds(ids: readonly string[], scopedEntityIds?: readonly string[]): Promise<WikiFact[]> {
     const fullRows: Array<WikiFact & { embedding?: unknown; embedding_blob?: unknown }> = [];
     const chunkSize = 500;
 
@@ -1643,7 +1661,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     }
 
     const byId = new Map(fullRows.map(row => [row.id, row]));
-    return ids
+    const result = ids
       .map(id => byId.get(id))
       .filter((fact): fact is WikiFact & { embedding?: unknown; embedding_blob?: unknown } => fact !== undefined)
       .map(fact => {
@@ -1653,6 +1671,12 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
           tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
         };
       });
+
+    if (scopedEntityIds && scopedEntityIds.length > 0) {
+      const scopeSet = new Set(scopedEntityIds);
+      return result.filter(f => scopeSet.has(f.entity_id));
+    }
+    return result;
   }
 
   /**

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1194,7 +1194,9 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               // not a real namespace) and pre-filtered reads (results already scoped to subset).
               // For single-entity full-scan, omit so remote rankers avoid transmitting the full
               // candidate list and can scope by entityId instead.
-              const candidateIds = candidateRows.map(r => r.id);
+              const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
+                ? candidateRows.map(r => r.id)
+                : undefined;
 
               try {
                 // Oversample by max(2x, +50) to preserve recall after re-ranking;

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1508,7 +1508,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               usedEmbed = true;
             }
           } // closes the candidateRows !== null else block
-      } catch (err) {
+        } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
           if (rankerShouldRethrow) {
             throw error;

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1005,6 +1005,10 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     if (entityIds.length > MAX_ENTITY_IDS) {
       throw new RangeError(`read() accepts at most ${MAX_ENTITY_IDS} entity IDs; received ${entityIds.length}`);
     }
+    const nullByteId = entityIds.find(id => id.includes('\x00'));
+    if (nullByteId !== undefined) {
+      throw new TypeError(`entity_id values must not contain the null byte (\\x00); got "${nullByteId}"`);
+    }
 
     const rawMaxResults = options?.maxResults ?? config?.maxResults ?? config?.maxFtsResults ?? 10;
     const maxResults = Number.isFinite(rawMaxResults)
@@ -1036,6 +1040,10 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       // Skip embed(), DB scan, and sort — fall through to tasks/events fetch below.
     } else if (trimmedQuery) {
       let usedEmbed = false;
+      // Hoisted before both the embed and keyword-fallback paths so the zero-weight
+      // fast path (scoredEntityIds.length === 0) is handled consistently regardless
+      // of whether embedFn is present.
+      const scoredEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
 
       if (!skipEmbed && embedFn) {
         let rankerShouldRethrow = false;
@@ -1068,10 +1076,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               );
             }
           }
-
-          // Determine which entities will actually be semantically scored (skip zero-weight unless opt-in).
-          // Computed here so the mismatch check below only scans entities that will be used.
-          const scoredEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
 
           // Check whether any non-deleted fact for any scored entity has a blob whose
           // dimension differs from the query vector. Scoped to scoredEntityIds so a
@@ -1522,10 +1526,9 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         }
       }
 
-      if (!usedEmbed) {
+      if (!usedEmbed && scoredEntityIds.length > 0) {
         // embed absent or threw — fall back to MiniSearch with tier weight application
-        const fallbackEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
-        const fallbackEntityIdSet = new Set(fallbackEntityIds);
+        const fallbackEntityIdSet = new Set(scoredEntityIds);
         const fallbackOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
         const results = this.miniSearch.search(trimmedQuery, {
           filter: (r) => fallbackEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
@@ -1885,7 +1888,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       }
       return {
         id: r.id,
-        entity_id: entityIdByCandidateId.get(r.id) ?? entityId,
+        entity_id: entityIdByCandidateId.get(r.id) ?? (() => { throw new Error(`ranker returned id "${r.id}" outside candidate set`); })(),
         score,
       };
     });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1070,9 +1070,17 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             }
           }
 
-          // Check whether any non-deleted fact for any requested entity has a blob whose
-          // dimension differs from the query vector. Fall back to keyword if any mismatch found.
-          const entityScope = this._entityInClause(entityIds);
+          // Determine which entities will actually be semantically scored (skip zero-weight unless opt-in).
+          // Computed here so the mismatch check below only scans entities that will be used.
+          const scoredEntityIds = entityIds.filter(id => {
+            const weightForEntity = sanitizedTierWeights?.[id] ?? 1;
+            return options?.includeZeroWeightEntities === true || weightForEntity !== 0;
+          });
+
+          // Check whether any non-deleted fact for any scored entity has a blob whose
+          // dimension differs from the query vector. Scoped to scoredEntityIds so a
+          // zero-weight entity's stale embeddings don't force keyword fallback.
+          const entityScope = this._entityInClause(scoredEntityIds);
           const mismatchedCount = await this.db.getFirstAsync<{ cnt: number }>(
             `SELECT COUNT(*) AS cnt FROM ${this.prefix}entries
              WHERE ${entityScope.clause} AND deleted_at IS NULL
@@ -1087,13 +1095,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               `Call runReembed() to rebuild all embeddings consistently.`
             );
           }
-
-          // Determine candidate rows
-          // For multi-entity reads, compute which entities to score (skip zero-weight unless includeZeroWeightEntities)
-          const scoredEntityIds = entityIds.filter(id => {
-            const weightForEntity = sanitizedTierWeights?.[id] ?? 1;
-            return options?.includeZeroWeightEntities === true || weightForEntity !== 0;
-          });
 
           const useRanker = Boolean(this.options.vectorRanker);
           let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
@@ -1188,9 +1189,10 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
             if (useRanker) {
               // Use external ranker for semantic scoring
-              const candidateIds = effectivePreFilterLimit !== undefined
-                ? candidateRows.map(r => r.id)
-                : undefined;
+              // Always pass candidateIds so the ranker scopes to the SQLite candidate set.
+              // Omitting it would let the ranker scope by entityId, which is a composite
+              // join-string for multi-entity reads and may not map to a real namespace.
+              const candidateIds = candidateRows.map(r => r.id);
 
               try {
                 // Oversample by max(2x, +50) to preserve recall after re-ranking;

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -996,7 +996,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       const empty: MemoryBundle = { facts: [], tasks: [], events: [] };
       if (exposeMetadata) {
         empty.metadata = { query, entityIds: [] };
-        if (sanitizedTierWeights) empty.metadata.tierWeights = sanitizedTierWeights;
+        if (sanitizedTierWeights && Object.keys(sanitizedTierWeights).length > 0) empty.metadata.tierWeights = sanitizedTierWeights;
       }
       return empty;
     }
@@ -1072,10 +1072,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
           // Determine which entities will actually be semantically scored (skip zero-weight unless opt-in).
           // Computed here so the mismatch check below only scans entities that will be used.
-          const scoredEntityIds = entityIds.filter(id => {
-            const weightForEntity = sanitizedTierWeights?.[id] ?? 1;
-            return options?.includeZeroWeightEntities === true || weightForEntity !== 0;
-          });
+          const scoredEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
 
           // Check whether any non-deleted fact for any scored entity has a blob whose
           // dimension differs from the query vector. Scoped to scoredEntityIds so a
@@ -1527,10 +1524,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
       if (!usedEmbed) {
         // embed absent or threw — fall back to MiniSearch with tier weight application
-        const fallbackEntityIds = entityIds.filter(id => {
-          const w = sanitizedTierWeights?.[id] ?? 1;
-          return options?.includeZeroWeightEntities === true || w !== 0;
-        });
+        const fallbackEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
         const fallbackEntityIdSet = new Set(fallbackEntityIds);
         const fallbackOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
         const results = this.miniSearch.search(trimmedQuery, {
@@ -1571,15 +1565,23 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         }
       }
     } else {
-      // Empty query: use global recency ordering, ignore tier weights
+      // Empty query: use global recency ordering, ignore tier weights.
+      // Raw SELECT * — normalize here since _hydrateFactsByIds is not used.
       const entityScope = this._entityInClause(entityIds);
-      facts = await this.db.getAllAsync<WikiFact>(
+      const rawFacts = await this.db.getAllAsync<WikiFact & { embedding?: unknown; embedding_blob?: unknown }>(
         `SELECT * FROM ${this.prefix}entries
          WHERE ${entityScope.clause} AND deleted_at IS NULL
          ORDER BY updated_at DESC
          LIMIT ?`,
         [...entityScope.params, maxResults]
       );
+      facts = rawFacts.map(f => {
+        const { embedding: _embedding, embedding_blob: _blob, ...rest } = f;
+        return {
+          ...rest,
+          tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
+        } as WikiFact;
+      });
     }
 
     const [tasks, events] = await Promise.all([
@@ -1594,31 +1596,25 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       })(),
       (async () => {
         const entityScope = this._entityInClause(entityIds);
+        // Scale limit so each entity can contribute up to 10 events (capped at 100).
+        const eventsLimit = Math.min(10 * entityIds.length, 100);
         return this.db.getAllAsync<WikiEvent>(
           `SELECT * FROM ${this.prefix}events
            WHERE ${entityScope.clause}
            ORDER BY created_at DESC
-           LIMIT 10`,
-          entityScope.params
+           LIMIT ?`,
+          [...entityScope.params, eventsLimit]
         );
       })(),
     ]);
 
-    const parsedFacts = facts.map(f => {
-      const { embedding: _embedding, embedding_blob: _blob, ...rest } = f as WikiFact & { embedding?: unknown; embedding_blob?: unknown };
-      return {
-        ...rest,
-        tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
-      };
-    });
-
     // Build factScores from captured scores
     let factScores: Record<string, number> | undefined;
     if (exposeMetadata && trimmedQuery && scoreByFactId) {
-      factScores = Object.fromEntries(parsedFacts.map(fact => [fact.id, scoreByFactId!.get(fact.id) ?? 0]));
+      factScores = Object.fromEntries(facts.map(fact => [fact.id, scoreByFactId!.get(fact.id) ?? 0]));
     }
 
-    const bundle: MemoryBundle = { facts: parsedFacts, tasks, events: events.reverse() };
+    const bundle: MemoryBundle = { facts, tasks, events: events.reverse() };
 
     if (exposeMetadata) {
       bundle.metadata = { query, entityIds };
@@ -1627,6 +1623,21 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     }
 
     return bundle;
+  }
+
+  /**
+   * Returns entity IDs that will participate in scored retrieval.
+   * Excludes zero-weight entities unless includeZeroWeightEntities is true.
+   */
+  private _filterScoredEntities(
+    entityIds: readonly string[],
+    sanitizedTierWeights: Record<string, number> | undefined,
+    includeZeroWeightEntities?: boolean,
+  ): string[] {
+    return entityIds.filter(id => {
+      const w = sanitizedTierWeights?.[id] ?? 1;
+      return includeZeroWeightEntities === true || w !== 0;
+    });
   }
 
   /**

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1040,12 +1040,13 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       // Skip embed(), DB scan, and sort — fall through to tasks/events fetch below.
     } else if (trimmedQuery) {
       let usedEmbed = false;
-      // Hoisted before both the embed and keyword-fallback paths so the zero-weight
-      // fast path (scoredEntityIds.length === 0) is handled consistently regardless
-      // of whether embedFn is present.
       const scoredEntityIds = this._filterScoredEntities(entityIds, sanitizedTierWeights, options?.includeZeroWeightEntities);
 
-      if (!skipEmbed && embedFn) {
+      // Fast-path: all entities zero-weight — skip embedFn, DB mismatch query, and
+      // cosine work entirely. usedEmbed=true suppresses the keyword fallback below.
+      if (scoredEntityIds.length === 0) {
+        usedEmbed = true;
+      } else if (!skipEmbed && embedFn) {
         let rankerShouldRethrow = false;
         let pendingRankerFallbackError: Error | undefined;
         try {
@@ -1096,171 +1097,203 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             );
           }
 
-          // Fast-path: no entities need semantic scoring (all have weight=0 and
-          // includeZeroWeightEntities is false). Skip embedding+DB work entirely.
-          // usedEmbed=true suppresses the !usedEmbed keyword fallback below, so
-          // zero-weight reads return an empty facts list (tasks/events still fetched).
-          if (scoredEntityIds.length === 0) {
-            usedEmbed = true; // semantic path intentionally skipped, not failed
-          } else {
-            const useRanker = Boolean(this.options.vectorRanker);
-            let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
-            // Composite cache keys (multi-entity join strings) are never invalidated by write/reembed paths.
-            let populateCache = entityIds.length === 1;
-            let miniSearchScores: Map<string, number> | undefined;
+          const useRanker = Boolean(this.options.vectorRanker);
+          let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
+          // Composite cache keys (multi-entity join strings) are never invalidated by write/reembed paths.
+          let populateCache = entityIds.length === 1;
+          let miniSearchScores: Map<string, number> | undefined;
 
-            if (effectivePreFilterLimit !== undefined) {
-              populateCache = false; // partial scan — do not populate cache
+          if (effectivePreFilterLimit !== undefined) {
+            populateCache = false; // partial scan — do not populate cache
+            const entityIdSet = new Set(scoredEntityIds);
+            const preResults = this.miniSearch.search(trimmedQuery, {
+              filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
+              combineWith: 'OR',
+            });
+            if (preResults.length === 0) {
+              candidateRows = null; // empty pre-filter
+            } else {
+              const topKResults = preResults.slice(0, effectivePreFilterLimit);
+              if (topKResults.length === 0) {
+                // effectivePreFilterLimit is 0 — treat the same as no candidates
+                // (avoids constructing an invalid "WHERE id IN ()" SQL clause)
+                candidateRows = null;
+              } else {
+                const topKIds = topKResults.map(r => r.id);
+                const inClauseChunkSize = 500;
+                if (useRanker) {
+                  const rows: ReadCandidateRowMetadata[] = [];
+                  for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
+                    const idChunk = topKIds.slice(i, i + inClauseChunkSize);
+                    const placeholders = idChunk.map(() => '?').join(',');
+                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                      `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                      idChunk
+                    );
+                    rows.push(...chunkRows);
+                  }
+                  candidateRows = rows;
+                } else {
+                  const rows: ReadCandidateRowWithEmbeddings[] = [];
+                  for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
+                    const idChunk = topKIds.slice(i, i + inClauseChunkSize);
+                    const placeholders = idChunk.map(() => '?').join(',');
+                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                      `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                      idChunk
+                    );
+                    rows.push(...chunkRows);
+                  }
+                  candidateRows = rows;
+                }
+                if (weight !== undefined && weight < 1) {
+                  const maxMsScore = Math.max(1, topKResults[0]?.score ?? 1);
+                  miniSearchScores = new Map(topKResults.map(r => [r.id, r.score / maxMsScore]));
+                }
+              }
+            }
+          } else {
+            // Full scan of scored entities
+            // If vectorRanker is configured, skip embedding load for now (ranker will provide ranking)
+            // Otherwise fetch embeddings for JS cosine ranking
+            if (useRanker) {
+              const entityScope = this._entityInClause(scoredEntityIds);
+              candidateRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                entityScope.params
+              );
+            } else {
+              const entityScope = this._entityInClause(scoredEntityIds);
+              candidateRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                entityScope.params
+              );
+            }
+            // Collect MiniSearch scores for hybrid blend if weight is set and <1
+            if (weight !== undefined && weight < 1) {
               const entityIdSet = new Set(scoredEntityIds);
-              const preResults = this.miniSearch.search(trimmedQuery, {
+              const msResults = this.miniSearch.search(trimmedQuery, {
                 filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
                 combineWith: 'OR',
               });
-              if (preResults.length === 0) {
-                candidateRows = null; // empty pre-filter
-              } else {
-                const topKResults = preResults.slice(0, effectivePreFilterLimit);
-                if (topKResults.length === 0) {
-                  // effectivePreFilterLimit is 0 — treat the same as no candidates
-                  // (avoids constructing an invalid "WHERE id IN ()" SQL clause)
-                  candidateRows = null;
-                } else {
-                  const topKIds = topKResults.map(r => r.id);
-                  const inClauseChunkSize = 500;
-                  if (useRanker) {
-                    const rows: ReadCandidateRowMetadata[] = [];
-                    for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
-                      const idChunk = topKIds.slice(i, i + inClauseChunkSize);
-                      const placeholders = idChunk.map(() => '?').join(',');
-                      const chunkRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
-                        `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                        idChunk
-                      );
-                      rows.push(...chunkRows);
-                    }
-                    candidateRows = rows;
-                  } else {
-                    const rows: ReadCandidateRowWithEmbeddings[] = [];
-                    for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
-                      const idChunk = topKIds.slice(i, i + inClauseChunkSize);
-                      const placeholders = idChunk.map(() => '?').join(',');
-                      const chunkRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
-                        `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                        idChunk
-                      );
-                      rows.push(...chunkRows);
-                    }
-                    candidateRows = rows;
-                  }
-                  if (weight !== undefined && weight < 1) {
-                    const maxMsScore = Math.max(1, topKResults[0]?.score ?? 1);
-                    miniSearchScores = new Map(topKResults.map(r => [r.id, r.score / maxMsScore]));
-                  }
-                }
-              }
-            } else {
-              // Full scan of scored entities
-              // If vectorRanker is configured, skip embedding load for now (ranker will provide ranking)
-              // Otherwise fetch embeddings for JS cosine ranking
-              if (useRanker) {
-                const entityScope = this._entityInClause(scoredEntityIds);
-                candidateRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
-                  `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
-                  entityScope.params
-                );
-              } else {
-                const entityScope = this._entityInClause(scoredEntityIds);
-                candidateRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
-                  `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
-                  entityScope.params
-                );
-              }
-              // Collect MiniSearch scores for hybrid blend if weight is set and <1
-              if (weight !== undefined && weight < 1) {
-                const entityIdSet = new Set(scoredEntityIds);
-                const msResults = this.miniSearch.search(trimmedQuery, {
-                  filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
-                  combineWith: 'OR',
-                });
-                const maxMsScore = Math.max(1, msResults[0]?.score ?? 1);
-                miniSearchScores = new Map(msResults.map(r => [r.id, r.score / maxMsScore]));
-              }
+              const maxMsScore = Math.max(1, msResults[0]?.score ?? 1);
+              miniSearchScores = new Map(msResults.map(r => [r.id, r.score / maxMsScore]));
             }
+          }
 
-            if (candidateRows === null) {
-              // pre-filter returned 0 candidates — facts = [], skip phase 2, skip access tracking
-              usedEmbed = true;
-            } else {
-              // Rank candidates: use vectorRanker if present, otherwise use JS cosine
-              const entityCacheKey = entityIds.length === 1 ? entityIds[0] : entityIds.join('\x00');
-              let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
+          if (candidateRows === null) {
+            // pre-filter returned 0 candidates — facts = [], skip phase 2, skip access tracking
+            usedEmbed = true;
+          } else {
+            // Rank candidates: use vectorRanker if present, otherwise use JS cosine
+            const entityCacheKey = entityIds.length === 1 ? entityIds[0] : entityIds.join('\x00');
+            let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
 
-              if (useRanker) {
-                // Use external ranker for semantic scoring.
-                // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
-                // not a real namespace) and pre-filtered reads (results already scoped to subset).
-                // For single-entity full-scan, omit so remote rankers avoid transmitting the full
-                // candidate list and can scope by entityId instead.
-                const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
-                  ? candidateRows.map(r => r.id)
-                  : undefined;
+            if (useRanker) {
+              // Use external ranker for semantic scoring.
+              // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
+              // not a real namespace) and pre-filtered reads (results already scoped to subset).
+              // For single-entity full-scan, omit so remote rankers avoid transmitting the full
+              // candidate list and can scope by entityId instead.
+              const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
+                ? candidateRows.map(r => r.id)
+                : undefined;
 
-                try {
-                  // Oversample by max(2x, +50) to preserve recall after re-ranking;
-                  // caller slices final output to maxResults.
-                  const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
-                  scored = await this._rankWithVectorRanker({
-                    entityId: entityCacheKey,
-                    queryVec,
-                    candidateIds,
-                    candidateRows: candidateRows as ReadCandidateRowMetadata[],
-                    weight,
-                    miniSearchScores,
-                    limit: oversampledLimit,
-                  });
+              try {
+                // Oversample by max(2x, +50) to preserve recall after re-ranking;
+                // caller slices final output to maxResults.
+                const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
+                scored = await this._rankWithVectorRanker({
+                  entityId: entityCacheKey,
+                  queryVec,
+                  candidateIds,
+                  candidateRows: candidateRows as ReadCandidateRowMetadata[],
+                  weight,
+                  miniSearchScores,
+                  limit: oversampledLimit,
+                });
 
-                  // Attach tie-break metadata from candidateRows (only for IDs returned by ranker)
-                  if (scored.length > 0) {
-                    const scoredIds = new Set(scored.map(s => s.id));
-                    const metaMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
-                    for (const r of candidateRows) {
-                      if (scoredIds.has(r.id)) {
-                        metaMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
-                      }
-                    }
-                    scored = scored.map(s => {
-                      const meta = metaMap.get(s.id);
-                      return { ...s, updated_at: meta?.updated_at ?? null, access_count: meta?.access_count ?? null };
-                    });
-                  }
-
-                  // Backfill ranker-omitted rows per VectorRanker contract:
-                  // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
+                // Attach tie-break metadata from candidateRows (only for IDs returned by ranker)
+                if (scored.length > 0) {
                   const scoredIds = new Set(scored.map(s => s.id));
+                  const metaMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
+                  for (const r of candidateRows) {
+                    if (scoredIds.has(r.id)) {
+                      metaMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
+                    }
+                  }
+                  scored = scored.map(s => {
+                    const meta = metaMap.get(s.id);
+                    return { ...s, updated_at: meta?.updated_at ?? null, access_count: meta?.access_count ?? null };
+                  });
+                }
 
-                  // Compute backfill budget up-front.
-                  // Hybrid mode: allow up to maxResults keyword-only rows to compete.
-                  // Pure semantic: only fill the remaining result slots.
-                  const isHybrid = weight !== undefined && weight < 1;
-                  const maxBackfill = isHybrid
-                    ? maxResults
-                    : Math.max(0, maxResults - scored.length);
+                // Backfill ranker-omitted rows per VectorRanker contract:
+                // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
+                const scoredIds = new Set(scored.map(s => s.id));
 
-                  if (maxBackfill > 0) {
-                    if (isHybrid) {
-                      // Hybrid mode: prioritize by keyword score using O(N log K) top-K selection
-                      // instead of O(N log N) full sort, since K (maxBackfill) is typically << N.
-                      type CandidateRow = typeof candidateRows[number];
-                      const topK: Array<{ row: CandidateRow; kwScore: number }> = [];
+                // Compute backfill budget up-front.
+                // Hybrid mode: allow up to maxResults keyword-only rows to compete.
+                // Pure semantic: only fill the remaining result slots.
+                const isHybrid = weight !== undefined && weight < 1;
+                const maxBackfill = isHybrid
+                  ? maxResults
+                  : Math.max(0, maxResults - scored.length);
 
-                      for (const row of candidateRows) {
-                        if (scoredIds.has(row.id)) continue;
-                        const kwScore = miniSearchScores?.get(row.id) ?? 0;
-                        const candidate = { row, kwScore };
+                if (maxBackfill > 0) {
+                  if (isHybrid) {
+                    // Hybrid mode: prioritize by keyword score using O(N log K) top-K selection
+                    // instead of O(N log N) full sort, since K (maxBackfill) is typically << N.
+                    type CandidateRow = typeof candidateRows[number];
+                    const topK: Array<{ row: CandidateRow; kwScore: number }> = [];
 
-                        if (topK.length < maxBackfill) {
-                          // Array not full yet - insert in sorted position (descending order)
-                          let insertIdx = topK.length;
+                    for (const row of candidateRows) {
+                      if (scoredIds.has(row.id)) continue;
+                      const kwScore = miniSearchScores?.get(row.id) ?? 0;
+                      const candidate = { row, kwScore };
+
+                      if (topK.length < maxBackfill) {
+                        // Array not full yet - insert in sorted position (descending order)
+                        let insertIdx = topK.length;
+                        for (let i = 0; i < topK.length; i++) {
+                          const cmp = this._compareScoredRows(
+                            {
+                              id: candidate.row.id,
+                              score: candidate.kwScore,
+                              updated_at: candidate.row.updated_at,
+                              access_count: candidate.row.access_count,
+                            },
+                            {
+                              id: topK[i].row.id,
+                              score: topK[i].kwScore,
+                              updated_at: topK[i].row.updated_at,
+                              access_count: topK[i].row.access_count,
+                            }
+                          );
+                          if (cmp < 0) {
+                            insertIdx = i;
+                            break;
+                          }
+                        }
+                        topK.splice(insertIdx, 0, candidate);
+                      } else {
+                        const cmpWorst = this._compareScoredRows(
+                          {
+                            id: candidate.row.id,
+                            score: candidate.kwScore,
+                            updated_at: candidate.row.updated_at,
+                            access_count: candidate.row.access_count,
+                          },
+                          {
+                            id: topK[maxBackfill - 1].row.id,
+                            score: topK[maxBackfill - 1].kwScore,
+                            updated_at: topK[maxBackfill - 1].row.updated_at,
+                            access_count: topK[maxBackfill - 1].row.access_count,
+                          }
+                        );
+                        if (cmpWorst < 0) {
+                          // Found better candidate than current worst - replace worst and re-insert
+                          let insertIdx = maxBackfill - 1;
                           for (let i = 0; i < topK.length; i++) {
                             const cmp = this._compareScoredRows(
                               {
@@ -1282,235 +1315,199 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                             }
                           }
                           topK.splice(insertIdx, 0, candidate);
-                        } else {
-                          const cmpWorst = this._compareScoredRows(
-                            {
-                              id: candidate.row.id,
-                              score: candidate.kwScore,
-                              updated_at: candidate.row.updated_at,
-                              access_count: candidate.row.access_count,
-                            },
-                            {
-                              id: topK[maxBackfill - 1].row.id,
-                              score: topK[maxBackfill - 1].kwScore,
-                              updated_at: topK[maxBackfill - 1].row.updated_at,
-                              access_count: topK[maxBackfill - 1].row.access_count,
-                            }
-                          );
-                          if (cmpWorst < 0) {
-                            // Found better candidate than current worst - replace worst and re-insert
-                            let insertIdx = maxBackfill - 1;
-                            for (let i = 0; i < topK.length; i++) {
-                              const cmp = this._compareScoredRows(
-                                {
-                                  id: candidate.row.id,
-                                  score: candidate.kwScore,
-                                  updated_at: candidate.row.updated_at,
-                                  access_count: candidate.row.access_count,
-                                },
-                                {
-                                  id: topK[i].row.id,
-                                  score: topK[i].kwScore,
-                                  updated_at: topK[i].row.updated_at,
-                                  access_count: topK[i].row.access_count,
-                                }
-                              );
-                              if (cmp < 0) {
-                                insertIdx = i;
-                                break;
-                              }
-                            }
-                            topK.splice(insertIdx, 0, candidate);
-                            topK.pop(); // Remove worst element
-                          }
+                          topK.pop(); // Remove worst element
                         }
                       }
-
-                      for (const { row, kwScore } of topK) {
-                        scored.push({
-                          id: row.id,
-                          entity_id: row.entity_id,
-                          score: (1 - weight) * kwScore,
-                          updated_at: row.updated_at,
-                          access_count: row.access_count,
-                        });
-                      }
-                    } else {
-                      // Pure semantic: all omitted rows share score -2.
-                      // Tie-break omitted rows deterministically before truncating.
-                      const omitted: Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
-                      for (const row of candidateRows) {
-                        if (scoredIds.has(row.id)) continue;
-                        omitted.push({ id: row.id, entity_id: row.entity_id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
-                      }
-                      if (omitted.length > 0) {
-                        this._tieBreakSort(omitted);
-                        scored.push(...omitted.slice(0, maxBackfill));
-                      }
                     }
-                  }
-                } catch (rankerErr) {
-                  const rankerError = rankerErr instanceof Error ? rankerErr : new Error(String(rankerErr));
-                  const policy = this.options.vectorRankerFallback ?? 'js-cosine';
 
-                  this.options.onVectorRankerFallback?.({
-                    error: this._sanitizeRankerError(rankerError),
-                    policy,
-                  });
-
-                  if (policy === 'throw') {
-                    rankerShouldRethrow = true;
-                    throw rankerError;
-                  } else if (policy === 'js-cosine') {
-                    // If embeddings were skipped (vectorRanker was configured), fetch them now for fallback
-                    let fallbackRows = candidateRows;
-                    if (fallbackRows && fallbackRows.length > 0 && !('embedding_blob' in fallbackRows[0])) {
-                      const rowIds = fallbackRows.map(r => r.id);
-                      const embeddingsMap = new Map<string, { embedding_blob: Uint8Array | null; embedding: string | null }>();
-                      const chunkSize = 500;
-                      for (let i = 0; i < rowIds.length; i += chunkSize) {
-                        const idChunk = rowIds.slice(i, i + chunkSize);
-                        const placeholders = idChunk.map(() => '?').join(',');
-                        const embeddingRows = await this.db.getAllAsync<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null }>(
-                          `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                          idChunk
-                        );
-                        for (const row of embeddingRows) {
-                          embeddingsMap.set(row.id, { embedding_blob: row.embedding_blob, embedding: row.embedding });
-                        }
-                      }
-                      fallbackRows = fallbackRows.map(r => ({
-                        ...r,
-                        embedding_blob: embeddingsMap.get(r.id)?.embedding_blob ?? null,
-                        embedding: embeddingsMap.get(r.id)?.embedding ?? null,
-                      })) as ReadCandidateRowWithEmbeddings[];
+                    for (const { row, kwScore } of topK) {
+                      scored.push({
+                        id: row.id,
+                        entity_id: row.entity_id,
+                        score: (1 - weight) * kwScore,
+                        updated_at: row.updated_at,
+                        access_count: row.access_count,
+                      });
                     }
-                    scored = await this._rankWithJsCosine({
-                      entityId: entityCacheKey,
-                      queryVec,
-                      candidateRows: fallbackRows as ReadCandidateRowWithEmbeddings[],
-                      weight,
-                      miniSearchScores,
-                      populateCache,
-                      limit: fallbackRows.length,
-                      skipSort: true, // read() re-sorts after applying tier weights
-                    });
-                  } else if (policy === 'keyword') {
-                    // Fall back to keyword-only results from MiniSearch
-                    const scoredEntityIdSet = new Set(scoredEntityIds);
-                    const msResults = this.miniSearch.search(trimmedQuery, {
-                      filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
-                      combineWith: 'OR',
-                    });
-                    // Oversample so tier weights can re-rank before the global slice
-                    const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
-                    const topResults = msResults.slice(0, keywordOversampledLimit);
-                    // Build metadata map only for returned IDs (not all candidates)
-                    const resultIds = new Set(topResults.map(r => r.id));
-                    const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
-                    for (const r of candidateRows) {
-                      if (resultIds.has(r.id)) {
-                        candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
-                      }
-                    }
-                    scored = topResults.map(r => {
-                      const meta = candidateMap.get(r.id);
-                      return {
-                        id: r.id,
-                        entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
-                        score: r.score ?? 0,
-                        access_count: meta?.access_count ?? null,
-                        updated_at: meta?.updated_at ?? null,
-                      };
-                    });
                   } else {
-                    // policy === 'empty'
-                    scored = [];
-                  }
-
-                  if (this.options.propagateRankerFailureToRetrievalFallback) {
-                    const mirrored = new Error('Vector ranker failed, falling back', {
-                      cause: this._sanitizeRankerError(rankerErr),
-                    });
-                    pendingRankerFallbackError = mirrored;
+                    // Pure semantic: all omitted rows share score -2.
+                    // Tie-break omitted rows deterministically before truncating.
+                    const omitted: Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
+                    for (const row of candidateRows) {
+                      if (scoredIds.has(row.id)) continue;
+                      omitted.push({ id: row.id, entity_id: row.entity_id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
+                    }
+                    if (omitted.length > 0) {
+                      this._tieBreakSort(omitted);
+                      scored.push(...omitted.slice(0, maxBackfill));
+                    }
                   }
                 }
-              } else {
-                // Use in-process JS cosine similarity
-                // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
-                scored = await this._rankWithJsCosine({
-                  entityId: entityCacheKey,
-                  queryVec,
-                  candidateRows: candidateRows as ReadCandidateRowWithEmbeddings[],
-                  weight,
-                  miniSearchScores,
-                  populateCache,
-                  // Return all candidates so tier weights can re-rank before the
-                  // global slice at the merge step below.
-                  limit: candidateRows.length,
-                  skipSort: true, // read() re-sorts after applying tier weights
+              } catch (rankerErr) {
+                const rankerError = rankerErr instanceof Error ? rankerErr : new Error(String(rankerErr));
+                const policy = this.options.vectorRankerFallback ?? 'js-cosine';
+
+                this.options.onVectorRankerFallback?.({
+                  error: this._sanitizeRankerError(rankerError),
+                  policy,
                 });
-              }
 
-              if (scored.length > 0) {
-                // Apply tier weights before global sort and slice
-                scored = scored.map(row => ({
-                  ...row,
-                  score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
-                }));
-
-                // Re-apply tie-break sorting after tier-weight application (applies to all paths including
-                // vectorRankerFallback='keyword': applyTierWeight mutates scores so MiniSearch ordering is no longer valid)
-                this._tieBreakSort(scored);
-
-                // Phase 2: fetch full rows only for the top results
-                const selectedScored = scored.slice(0, maxResults);
-                const topIds = selectedScored.map(s => s.id);
-
-                // Capture scores for exposure in metadata
-                if (exposeMetadata && trimmedQuery) {
-                  scoreByFactId = new Map(selectedScored.map(s => [s.id, Number.isFinite(s.score) ? s.score : 0]));
-                }
-
-                if (topIds.length > 0) {
-                  const facts2 = await this._hydrateFactsByIds(topIds, entityIds);
-
-                  // Hydration can return fewer rows than ranked IDs when rows were concurrently
-                  // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
-                  if (facts2.length < topIds.length) {
-                    const hydrationById = new Set(facts2.map(f => f.id));
-                    const missingIds = topIds.filter(id => !hydrationById.has(id));
-                    const missingCount = missingIds.length;
-                    const sample = missingIds.slice(0, 5);
-                    const sampleSuffix = sample.length > 0
-                      ? ` Missing ID sample: ${sample.join(', ')}${missingIds.length > sample.length ? ', ...' : ''}.`
-                      : '';
-                    const error = new Error(
-                      `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs. ` +
-                      `Rows may have been concurrently soft-deleted or filtered by deleted_at during hydration, ` +
-                      `or vector ranker output may include IDs that do not exist in requested entities.` +
-                      sampleSuffix
-                    );
-                    this.options.onRetrievalFallback?.(error);
+                if (policy === 'throw') {
+                  rankerShouldRethrow = true;
+                  throw rankerError;
+                } else if (policy === 'js-cosine') {
+                  // If embeddings were skipped (vectorRanker was configured), fetch them now for fallback
+                  let fallbackRows = candidateRows;
+                  if (fallbackRows && fallbackRows.length > 0 && !('embedding_blob' in fallbackRows[0])) {
+                    const rowIds = fallbackRows.map(r => r.id);
+                    const embeddingsMap = new Map<string, { embedding_blob: Uint8Array | null; embedding: string | null }>();
+                    const chunkSize = 500;
+                    for (let i = 0; i < rowIds.length; i += chunkSize) {
+                      const idChunk = rowIds.slice(i, i + chunkSize);
+                      const placeholders = idChunk.map(() => '?').join(',');
+                      const embeddingRows = await this.db.getAllAsync<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null }>(
+                        `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                        idChunk
+                      );
+                      for (const row of embeddingRows) {
+                        embeddingsMap.set(row.id, { embedding_blob: row.embedding_blob, embedding: row.embedding });
+                      }
+                    }
+                    fallbackRows = fallbackRows.map(r => ({
+                      ...r,
+                      embedding_blob: embeddingsMap.get(r.id)?.embedding_blob ?? null,
+                      embedding: embeddingsMap.get(r.id)?.embedding ?? null,
+                    })) as ReadCandidateRowWithEmbeddings[];
                   }
-                  facts = facts2;
+                  scored = await this._rankWithJsCosine({
+                    entityId: entityCacheKey,
+                    queryVec,
+                    candidateRows: fallbackRows as ReadCandidateRowWithEmbeddings[],
+                    weight,
+                    miniSearchScores,
+                    populateCache,
+                    limit: fallbackRows.length,
+                    skipSort: true, // read() re-sorts after applying tier weights
+                  });
+                } else if (policy === 'keyword') {
+                  // Fall back to keyword-only results from MiniSearch
+                  const scoredEntityIdSet = new Set(scoredEntityIds);
+                  const msResults = this.miniSearch.search(trimmedQuery, {
+                    filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
+                    combineWith: 'OR',
+                  });
+                  // Oversample so tier weights can re-rank before the global slice
+                  const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
+                  const topResults = msResults.slice(0, keywordOversampledLimit);
+                  // Build metadata map only for returned IDs (not all candidates)
+                  const resultIds = new Set(topResults.map(r => r.id));
+                  const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
+                  for (const r of candidateRows) {
+                    if (resultIds.has(r.id)) {
+                      candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
+                    }
+                  }
+                  scored = topResults.map(r => {
+                    const meta = candidateMap.get(r.id);
+                    return {
+                      id: r.id,
+                      entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
+                      score: r.score ?? 0,
+                      access_count: meta?.access_count ?? null,
+                      updated_at: meta?.updated_at ?? null,
+                    };
+                  });
+                } else {
+                  // policy === 'empty'
+                  scored = [];
                 }
-                // Phase 2 succeeded — now safe to notify that ranker fallback occurred
-                if (pendingRankerFallbackError) {
-                  this.options.onRetrievalFallback?.(pendingRankerFallbackError);
-                  pendingRankerFallbackError = undefined;
+
+                if (this.options.propagateRankerFailureToRetrievalFallback) {
+                  const mirrored = new Error('Vector ranker failed, falling back', {
+                    cause: this._sanitizeRankerError(rankerErr),
+                  });
+                  pendingRankerFallbackError = mirrored;
                 }
-                usedEmbed = true;
-              } else {
-                // Empty scored results (ranker returned no matches)
-                if (pendingRankerFallbackError) {
-                  this.options.onRetrievalFallback?.(pendingRankerFallbackError);
-                  pendingRankerFallbackError = undefined;
-                }
-                usedEmbed = true;
               }
-            } // closes the candidateRows !== null else block
-          } // closes the scoredEntityIds.length === 0 else block
+            } else {
+              // Use in-process JS cosine similarity
+              // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
+              // When tier weights are active, materialize all candidates so weights can re-rank
+              // before the global slice. Without tier weights, use limit: maxResults to keep the
+              // prior hot-path behavior and avoid O(N) materialization for large single-entity reads.
+              const jsCosineNeedsTierSort = sanitizedTierWeights !== undefined;
+              scored = await this._rankWithJsCosine({
+                entityId: entityCacheKey,
+                queryVec,
+                candidateRows: candidateRows as ReadCandidateRowWithEmbeddings[],
+                weight,
+                miniSearchScores,
+                populateCache,
+                limit: jsCosineNeedsTierSort ? candidateRows.length : maxResults,
+                skipSort: jsCosineNeedsTierSort, // read() re-sorts after applying tier weights
+              });
+            }
+
+            if (scored.length > 0) {
+              // Apply tier weights before global sort and slice
+              scored = scored.map(row => ({
+                ...row,
+                score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
+              }));
+
+              // Re-apply tie-break sorting after tier-weight application (applies to all paths including
+              // vectorRankerFallback='keyword': applyTierWeight mutates scores so MiniSearch ordering is no longer valid)
+              this._tieBreakSort(scored);
+
+              // Phase 2: fetch full rows only for the top results
+              const selectedScored = scored.slice(0, maxResults);
+              const topIds = selectedScored.map(s => s.id);
+
+              // Capture scores for exposure in metadata
+              if (exposeMetadata && trimmedQuery) {
+                scoreByFactId = new Map(selectedScored.map(s => [s.id, Number.isFinite(s.score) ? s.score : 0]));
+              }
+
+              if (topIds.length > 0) {
+                const facts2 = await this._hydrateFactsByIds(topIds, entityIds);
+
+                // Hydration can return fewer rows than ranked IDs when rows were concurrently
+                // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
+                if (facts2.length < topIds.length) {
+                  const hydrationById = new Set(facts2.map(f => f.id));
+                  const missingIds = topIds.filter(id => !hydrationById.has(id));
+                  const missingCount = missingIds.length;
+                  const sample = missingIds.slice(0, 5);
+                  const sampleSuffix = sample.length > 0
+                    ? ` Missing ID sample: ${sample.join(', ')}${missingIds.length > sample.length ? ', ...' : ''}.`
+                    : '';
+                  const error = new Error(
+                    `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs. ` +
+                    `Rows may have been concurrently soft-deleted or filtered by deleted_at during hydration, ` +
+                    `or vector ranker output may include IDs that do not exist in requested entities.` +
+                    sampleSuffix
+                  );
+                  this.options.onRetrievalFallback?.(error);
+                }
+                facts = facts2;
+              }
+              // Ranker path completed — notify of any prior fallback now that hydration is done.
+              // Fires outside the topIds.length>0 guard since scored.length>0 && maxResults>0
+              // means topIds is always non-empty here, but the notification is harmless either way.
+              if (pendingRankerFallbackError) {
+                this.options.onRetrievalFallback?.(pendingRankerFallbackError);
+                pendingRankerFallbackError = undefined;
+              }
+              usedEmbed = true;
+            } else {
+              // Empty scored results (ranker returned no matches)
+              if (pendingRankerFallbackError) {
+                this.options.onRetrievalFallback?.(pendingRankerFallbackError);
+                pendingRankerFallbackError = undefined;
+              }
+              usedEmbed = true;
+            }
+          } // closes the candidateRows !== null else block
       } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
           if (rankerShouldRethrow) {
@@ -1590,7 +1587,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const [tasks, events] = await Promise.all([
       (async () => {
         const entityScope = this._entityInClause(entityIds);
-        // Scale limit so each entity can contribute up to 20 tasks (capped at 200).
+        // Scaled global cap: 20× entity count, max 200. Not a per-entity guarantee —
+        // a single high-volume entity can fill the entire budget.
         const tasksLimit = Math.min(20 * entityIds.length, 200);
         return this.db.getAllAsync<WikiTask>(
           `SELECT * FROM ${this.prefix}tasks
@@ -1602,7 +1600,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       })(),
       (async () => {
         const entityScope = this._entityInClause(entityIds);
-        // Scale limit so each entity can contribute up to 10 events (capped at 100).
+        // Scaled global cap: 10× entity count, max 100. Not a per-entity guarantee —
+        // a single high-volume entity can fill the entire budget.
         const eventsLimit = Math.min(10 * entityIds.length, 100);
         return this.db.getAllAsync<WikiEvent>(
           `SELECT * FROM ${this.prefix}events
@@ -1888,7 +1887,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       }
       return {
         id: r.id,
-        entity_id: entityIdByCandidateId.get(r.id) ?? (() => { throw new Error(`ranker returned id "${r.id}" outside candidate set`); })(),
+        entity_id: entityIdByCandidateId.get(r.id)!, // allowedIds filter above guarantees membership
         score,
       };
     });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1432,10 +1432,11 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             } else {
               // Use in-process JS cosine similarity
               // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
-              // When tier weights are active, materialize all candidates so weights can re-rank
-              // before the global slice. Without tier weights, use limit: maxResults to keep the
-              // prior hot-path behavior and avoid O(N) materialization for large single-entity reads.
-              const jsCosineNeedsTierSort = sanitizedTierWeights !== undefined;
+              // Materialize all candidates only when tier weights will actually change ranking —
+              // i.e., at least one entity has a weight other than 1. A no-op weights object
+              // (all values === 1, or empty after sanitization) preserves the hot-path behavior.
+              const jsCosineNeedsTierSort = sanitizedTierWeights !== undefined &&
+                Object.values(sanitizedTierWeights).some(w => w !== 1);
               scored = await this._rankWithJsCosine({
                 entityId: entityCacheKey,
                 queryVec,
@@ -1587,15 +1588,14 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const [tasks, events] = await Promise.all([
       (async () => {
         const entityScope = this._entityInClause(entityIds);
-        // Scaled global cap: 20× entity count, max 200. Not a per-entity guarantee —
-        // a single high-volume entity can fill the entire budget.
-        const tasksLimit = Math.min(20 * entityIds.length, 200);
+        // Single-entity reads preserve the pre-Phase-2 unbounded behavior.
+        // Multi-entity reads cap at 20× entity count (max 200) to bound result size.
+        const tasksLimit = entityIds.length === 1 ? undefined : Math.min(20 * entityIds.length, 200);
         return this.db.getAllAsync<WikiTask>(
           `SELECT * FROM ${this.prefix}tasks
            WHERE ${entityScope.clause} AND status IN ('pending', 'in_progress') AND deleted_at IS NULL
-           ORDER BY priority DESC, created_at ASC
-           LIMIT ?`,
-          [...entityScope.params, tasksLimit]
+           ORDER BY priority DESC, created_at ASC${tasksLimit !== undefined ? '\n           LIMIT ?' : ''}`,
+          tasksLimit !== undefined ? [...entityScope.params, tasksLimit] : entityScope.params
         );
       })(),
       (async () => {

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -6,6 +6,7 @@ import { LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT, INGEST_SYSTEM_PROMPT } fro
 import MiniSearch from 'minisearch';
 import { cosineSimilarity } from './utils/cosine';
 import { parseEmbedding } from './utils/embedding';
+import { applyTierWeight, normalizeEntityIds, sanitizeTierWeights, shouldExposeReadMetadata } from './readOptions';
 
 export { WikiBusyError, PrunePartialFailureError } from './types';
 
@@ -14,6 +15,19 @@ export { WikiBusyError, PrunePartialFailureError } from './types';
  * Used to distinguish WikiMemory's own timeout errors from ranker errors that might contain "timed out" in message.
  */
 const HOOK_TIMEOUT_MARKER = Symbol('WikiMemoryHookTimeout');
+
+type ReadCandidateRowMetadata = {
+  id: string;
+  entity_id: string;
+  updated_at: number | null;
+  access_count: number | null;
+};
+
+type ReadCandidateRowWithEmbeddings = ReadCandidateRowMetadata & {
+  embedding_blob: Uint8Array | null;
+  embedding: string | null;
+};
+
 
 function parseJsonResponse<T>(text: string): T {
   const firstBrace = text.indexOf('{');
@@ -972,8 +986,21 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     }
   }
 
-  async read(entityId: string, query: string, options?: ReadOptions): Promise<MemoryBundle> {
+  async read(entityId: string | string[], query: string, options?: ReadOptions): Promise<MemoryBundle> {
     const config = this.options.config;
+    const entityIds = normalizeEntityIds(entityId);
+    const sanitizedTierWeights = sanitizeTierWeights(entityIds, options?.tierWeights);
+    const exposeMetadata = shouldExposeReadMetadata(entityId, options);
+
+    if (entityIds.length === 0) {
+      const empty: MemoryBundle = { facts: [], tasks: [], events: [] };
+      if (exposeMetadata) {
+        empty.metadata = { query, entityIds: [] };
+        if (sanitizedTierWeights) empty.metadata.tierWeights = sanitizedTierWeights;
+      }
+      return empty;
+    }
+
     const rawMaxResults = options?.maxResults ?? config?.maxResults ?? config?.maxFtsResults ?? 10;
     const maxResults = Number.isFinite(rawMaxResults)
       ? Math.max(0, Math.trunc(rawMaxResults))
@@ -997,6 +1024,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const trimmedQuery = query.trim();
 
     let facts: WikiFact[] = [];
+    let scoreByFactId: Map<string, number> | undefined;
 
     if (maxResults === 0) {
       // Fast-path: a zero-capacity result window can never return any facts.
@@ -1008,7 +1036,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         let rankerShouldRethrow = false;
         let pendingRankerFallbackError: Error | undefined;
         let usedKeywordFallback = false;
-        let scoredAlreadySortedAndLimited = false;
         try {
           const queryVec = await embedFn(trimmedQuery);
 
@@ -1038,17 +1065,16 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             }
           }
 
-          // Check whether any non-deleted fact for this entity has a blob whose
-          // dimension differs from the query vector. A global meta flag would block
-          // all entities when only one was imported with a mismatched model, so we
-          // do a direct per-entity SQL count here instead.
+          // Check whether any non-deleted fact for any requested entity has a blob whose
+          // dimension differs from the query vector. Fall back to keyword if any mismatch found.
+          const entityScope = this._entityInClause(entityIds);
           const mismatchedCount = await this.db.getFirstAsync<{ cnt: number }>(
             `SELECT COUNT(*) AS cnt FROM ${this.prefix}entries
-             WHERE entity_id = ? AND deleted_at IS NULL
+             WHERE ${entityScope.clause} AND deleted_at IS NULL
                AND embedding_blob IS NOT NULL
                AND (CAST(length(embedding_blob) AS INTEGER) % 4 = 0)
                AND (CAST(length(embedding_blob) AS INTEGER) / 4) != ?`,
-            [entityId, queryVec.length]
+            [...entityScope.params, queryVec.length]
           );
           if (mismatchedCount && mismatchedCount.cnt > 0) {
             throw new Error(
@@ -1058,17 +1084,22 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
           }
 
           // Determine candidate rows
-          type CandidateRowMetadata = { id: string; updated_at: number | null; access_count: number | null };
-          type CandidateRowWithEmbeddings = CandidateRowMetadata & { embedding_blob: Uint8Array | null; embedding: string | null };
+          // For multi-entity reads, compute which entities to score (skip zero-weight unless includeZeroWeightEntities)
+          const scoredEntityIds = entityIds.filter(id => {
+            const weightForEntity = sanitizedTierWeights?.[id] ?? 1;
+            return options?.includeZeroWeightEntities === true || weightForEntity !== 0;
+          });
+
           const useRanker = Boolean(this.options.vectorRanker);
-          let candidateRows: CandidateRowMetadata[] | CandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
+          let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
           let populateCache = true;
           let miniSearchScores: Map<string, number> | undefined;
 
           if (effectivePreFilterLimit !== undefined) {
             populateCache = false; // partial scan — do not populate cache
+            const entityIdSet = new Set(scoredEntityIds);
             const preResults = this.miniSearch.search(trimmedQuery, {
-              filter: (r) => (r as unknown as { entity_id: string }).entity_id === entityId,
+              filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
               combineWith: 'OR',
             });
             if (preResults.length === 0) {
@@ -1083,24 +1114,24 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                 const topKIds = topKResults.map(r => r.id);
                 const inClauseChunkSize = 500;
                 if (useRanker) {
-                  const rows: CandidateRowMetadata[] = [];
+                  const rows: ReadCandidateRowMetadata[] = [];
                   for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
                     const idChunk = topKIds.slice(i, i + inClauseChunkSize);
                     const placeholders = idChunk.map(() => '?').join(',');
-                    const chunkRows = await this.db.getAllAsync<CandidateRowMetadata>(
-                      `SELECT id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                      `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
                       idChunk
                     );
                     rows.push(...chunkRows);
                   }
                   candidateRows = rows;
                 } else {
-                  const rows: CandidateRowWithEmbeddings[] = [];
+                  const rows: ReadCandidateRowWithEmbeddings[] = [];
                   for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
                     const idChunk = topKIds.slice(i, i + inClauseChunkSize);
                     const placeholders = idChunk.map(() => '?').join(',');
-                    const chunkRows = await this.db.getAllAsync<CandidateRowWithEmbeddings>(
-                      `SELECT id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                      `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
                       idChunk
                     );
                     rows.push(...chunkRows);
@@ -1114,25 +1145,27 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               }
             }
           } else {
-            // Full entity scan
+            // Full scan of scored entities
             // If vectorRanker is configured, skip embedding load for now (ranker will provide ranking)
             // Otherwise fetch embeddings for JS cosine ranking
             if (useRanker) {
-              candidateRows = await this.db.getAllAsync<CandidateRowMetadata>(
-                `SELECT id, updated_at, access_count FROM ${this.prefix}entries WHERE entity_id = ? AND deleted_at IS NULL`,
-                [entityId]
+              const entityScope = this._entityInClause(scoredEntityIds);
+              candidateRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                entityScope.params
               );
             } else {
-              candidateRows = await this.db.getAllAsync<CandidateRowWithEmbeddings>(
-                `SELECT id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE entity_id = ? AND deleted_at IS NULL`,
-                [entityId]
+              const entityScope = this._entityInClause(scoredEntityIds);
+              candidateRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                entityScope.params
               );
             }
             // Collect MiniSearch scores for hybrid blend if weight is set and <1
-            // (weight=1 is all-semantic with clamped scores; pure semantic [-1,1] requires weight undefined)
             if (weight !== undefined && weight < 1) {
+              const entityIdSet = new Set(scoredEntityIds);
               const msResults = this.miniSearch.search(trimmedQuery, {
-                filter: (r) => (r as unknown as { entity_id: string }).entity_id === entityId,
+                filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
                 combineWith: 'OR',
               });
               const maxMsScore = Math.max(1, msResults[0]?.score ?? 1);
@@ -1145,7 +1178,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             usedEmbed = true;
           } else {
             // Rank candidates: use vectorRanker if present, otherwise use JS cosine
-            let scored: Array<{ id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
+            const entityCacheKey = entityIds.length === 1 ? entityIds[0] : entityIds.join('\x00');
+            let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
 
             if (useRanker) {
               // Use external ranker for semantic scoring
@@ -1158,9 +1192,10 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                 // caller slices final output to maxResults.
                 const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
                 scored = await this._rankWithVectorRanker({
-                  entityId,
+                  entityId: entityCacheKey,
                   queryVec,
                   candidateIds,
+                  candidateRows: candidateRows as ReadCandidateRowMetadata[],
                   weight,
                   miniSearchScores,
                   limit: oversampledLimit,
@@ -1276,6 +1311,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                     for (const { row, kwScore } of topK) {
                       scored.push({
                         id: row.id,
+                        entity_id: row.entity_id,
                         score: (1 - weight) * kwScore,
                         updated_at: row.updated_at,
                         access_count: row.access_count,
@@ -1284,10 +1320,10 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                   } else {
                     // Pure semantic: all omitted rows share score -2.
                     // Tie-break omitted rows deterministically before truncating.
-                    const omitted: Array<{ id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
+                    const omitted: Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
                     for (const row of candidateRows) {
                       if (scoredIds.has(row.id)) continue;
-                      omitted.push({ id: row.id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
+                      omitted.push({ id: row.id, entity_id: row.entity_id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
                     }
                     if (omitted.length > 0) {
                       this._tieBreakSort(omitted);
@@ -1329,37 +1365,38 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                       ...r,
                       embedding_blob: embeddingsMap.get(r.id)?.embedding_blob ?? null,
                       embedding: embeddingsMap.get(r.id)?.embedding ?? null,
-                    })) as CandidateRowWithEmbeddings[];
+                    })) as ReadCandidateRowWithEmbeddings[];
                   }
                   scored = await this._rankWithJsCosine({
-                    entityId,
+                    entityId: entityCacheKey,
                     queryVec,
-                    candidateRows: fallbackRows as CandidateRowWithEmbeddings[],
+                    candidateRows: fallbackRows as ReadCandidateRowWithEmbeddings[],
                     weight,
                     miniSearchScores,
                     populateCache,
-                    limit: maxResults,
+                    limit: fallbackRows.length,
                   });
-                  scoredAlreadySortedAndLimited = true;
                 } else if (policy === 'keyword') {
                   // Fall back to keyword-only results from MiniSearch
+                  const scoredEntityIdSet = new Set(scoredEntityIds);
                   const msResults = this.miniSearch.search(trimmedQuery, {
-                    filter: (r) => (r as unknown as { entity_id: string }).entity_id === entityId,
+                    filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
                     combineWith: 'OR',
                   });
                   const topResults = msResults.slice(0, maxResults);
                   // Build metadata map only for returned IDs (not all candidates)
                   const resultIds = new Set(topResults.map(r => r.id));
-                  const candidateMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
+                  const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
                   for (const r of candidateRows) {
                     if (resultIds.has(r.id)) {
-                      candidateMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
+                      candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
                     }
                   }
                   scored = topResults.map(r => {
                     const meta = candidateMap.get(r.id);
                     return {
                       id: r.id,
+                      entity_id: meta?.entity_id ?? entityCacheKey,
                       score: r.score ?? 0,
                       access_count: meta?.access_count ?? null,
                       updated_at: meta?.updated_at ?? null,
@@ -1382,58 +1419,62 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               // Use in-process JS cosine similarity
               // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
               scored = await this._rankWithJsCosine({
-                entityId,
+                entityId: entityCacheKey,
                 queryVec,
-                candidateRows: candidateRows as CandidateRowWithEmbeddings[],
+                candidateRows: candidateRows as ReadCandidateRowWithEmbeddings[],
                 weight,
                 miniSearchScores,
                 populateCache,
-                limit: maxResults,
+                // Return all candidates so tier weights can re-rank before the
+                // global slice at the merge step below.
+                limit: candidateRows.length,
               });
-              scoredAlreadySortedAndLimited = true;
             }
 
             if (scored.length > 0) {
-              // Re-apply tie-break sorting (ranker might not have stable ordering)
+              // Apply tier weights before global sort and slice
+              scored = scored.map(row => ({
+                ...row,
+                score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
+              }));
+
+              // Re-apply tie-break sorting (ranker might not have stable ordering, and weights changed order)
               // Skip for keyword-only fallback to preserve MiniSearch ordering
-              if (!usedKeywordFallback && !scoredAlreadySortedAndLimited) {
+              if (!usedKeywordFallback) {
                 this._tieBreakSort(scored);
               }
 
               // Phase 2: fetch full rows only for the top results
-              const topIds = (scoredAlreadySortedAndLimited ? scored : scored.slice(0, maxResults)).map(s => s.id);
+              const selectedScored = scored.slice(0, maxResults);
+              const topIds = selectedScored.map(s => s.id);
+
+              // Capture scores for exposure in metadata
+              if (exposeMetadata && trimmedQuery) {
+                scoreByFactId = new Map(selectedScored.map(s => [s.id, s.score]));
+              }
+
               if (topIds.length > 0) {
-                const fullRows: Array<WikiFact & { embedding: string | null; embedding_blob: Uint8Array | null }> = [];
-                const phase2ChunkSize = 500;
-                for (let i = 0; i < topIds.length; i += phase2ChunkSize) {
-                  const idChunk = topIds.slice(i, i + phase2ChunkSize);
-                  const placeholders = idChunk.map(() => '?').join(',');
-                  const chunkRows = await this.db.getAllAsync<WikiFact & { embedding: string | null; embedding_blob: Uint8Array | null }>(
-                    `SELECT * FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND entity_id = ? AND deleted_at IS NULL`,
-                    [...idChunk, entityId]
-                  );
-                  fullRows.push(...chunkRows);
-                }
-                const byId = new Map(fullRows.map(r => [r.id, r]));
-                facts = topIds.map(id => byId.get(id)).filter((f): f is WikiFact & { embedding: string | null; embedding_blob: Uint8Array | null } => f !== undefined);
+                const facts2 = await this._hydrateFactsByIds(topIds);
 
                 // Hydration can return fewer rows than ranked IDs when rows were concurrently
                 // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
-                if (facts.length < topIds.length) {
-                  const missingIds = topIds.filter(id => !byId.has(id));
+                if (facts2.length < topIds.length) {
+                  const hydrationByteId = new Set(facts2.map(f => f.id));
+                  const missingIds = topIds.filter(id => !hydrationByteId.has(id));
                   const missingCount = missingIds.length;
                   const sample = missingIds.slice(0, 5);
                   const sampleSuffix = sample.length > 0
                     ? ` Missing ID sample: ${sample.join(', ')}${missingIds.length > sample.length ? ', ...' : ''}.`
                     : '';
                   const error = new Error(
-                    `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs for entity ${entityId}. ` +
+                    `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs. ` +
                     `Rows may have been concurrently soft-deleted or filtered by deleted_at during hydration, ` +
-                    `or vector ranker output may include IDs that do not exist for this entity.` +
+                    `or vector ranker output may include IDs that do not exist in requested entities.` +
                     sampleSuffix
                   );
                   this.options.onRetrievalFallback?.(error);
                 }
+                facts = facts2;
               }
               // Phase 2 succeeded — now safe to notify that ranker fallback occurred
               if (pendingRankerFallbackError) {
@@ -1467,25 +1508,14 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
       if (!usedEmbed) {
         // embed absent or threw — fall back to MiniSearch
+        const entityIdSet = new Set(entityIds);
         const results = this.miniSearch.search(trimmedQuery, {
-          filter: (r) => (r as unknown as { entity_id: string }).entity_id === entityId,
+          filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
           combineWith: 'OR',
         });
         const topIds = results.slice(0, maxResults).map((r: { id: string }) => r.id);
         if (topIds.length > 0) {
-          const kwRows: WikiFact[] = [];
-          const kwChunkSize = 500;
-          for (let i = 0; i < topIds.length; i += kwChunkSize) {
-            const idChunk = topIds.slice(i, i + kwChunkSize);
-            const placeholders = idChunk.map(() => '?').join(',');
-            const chunkRows = await this.db.getAllAsync<WikiFact>(
-              `SELECT * FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND entity_id = ? AND deleted_at IS NULL`,
-              [...idChunk, entityId]
-            );
-            kwRows.push(...chunkRows);
-          }
-          const byId = new Map(kwRows.map(r => [r.id, r]));
-          facts = topIds.map(id => byId.get(id)).filter((f): f is WikiFact => f !== undefined);
+          facts = await this._hydrateFactsByIds(topIds);
         }
       }
 
@@ -1505,29 +1535,37 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         }
       }
     } else {
+      // Empty query: use global recency ordering, ignore tier weights
+      const entityScope = this._entityInClause(entityIds);
       facts = await this.db.getAllAsync<WikiFact>(
         `SELECT * FROM ${this.prefix}entries
-         WHERE entity_id = ? AND deleted_at IS NULL
+         WHERE ${entityScope.clause} AND deleted_at IS NULL
          ORDER BY updated_at DESC
          LIMIT ?`,
-        [entityId, maxResults]
+        [...entityScope.params, maxResults]
       );
     }
 
     const [tasks, events] = await Promise.all([
-      this.db.getAllAsync<WikiTask>(
-        `SELECT * FROM ${this.prefix}tasks
-         WHERE entity_id = ? AND status IN ('pending', 'in_progress') AND deleted_at IS NULL
-         ORDER BY priority DESC, created_at ASC`,
-        [entityId]
-      ),
-      this.db.getAllAsync<WikiEvent>(
-        `SELECT * FROM ${this.prefix}events
-         WHERE entity_id = ?
-         ORDER BY created_at DESC
-         LIMIT 10`,
-        [entityId]
-      ),
+      (async () => {
+        const entityScope = this._entityInClause(entityIds);
+        return this.db.getAllAsync<WikiTask>(
+          `SELECT * FROM ${this.prefix}tasks
+           WHERE ${entityScope.clause} AND status IN ('pending', 'in_progress') AND deleted_at IS NULL
+           ORDER BY priority DESC, created_at ASC`,
+          entityScope.params
+        );
+      })(),
+      (async () => {
+        const entityScope = this._entityInClause(entityIds);
+        return this.db.getAllAsync<WikiEvent>(
+          `SELECT * FROM ${this.prefix}events
+           WHERE ${entityScope.clause}
+           ORDER BY created_at DESC
+           LIMIT 10`,
+          entityScope.params
+        );
+      })(),
     ]);
 
     const parsedFacts = facts.map(f => {
@@ -1538,7 +1576,21 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       };
     });
 
-    return { facts: parsedFacts, tasks, events: events.reverse() };
+    // Build factScores from captured scores
+    let factScores: Record<string, number> | undefined;
+    if (exposeMetadata && trimmedQuery && scoreByFactId) {
+      factScores = Object.fromEntries(parsedFacts.map(fact => [fact.id, scoreByFactId!.get(fact.id) ?? 0]));
+    }
+
+    const bundle: MemoryBundle = { facts: parsedFacts, tasks, events: events.reverse() };
+
+    if (exposeMetadata) {
+      bundle.metadata = { query, entityIds };
+      if (sanitizedTierWeights) bundle.metadata.tierWeights = sanitizedTierWeights;
+      if (factScores && Object.keys(factScores).length > 0) bundle.factScores = factScores;
+    }
+
+    return bundle;
   }
 
   /**
@@ -1563,6 +1615,44 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const updatedAtDiff = (b.updated_at ?? 0) - (a.updated_at ?? 0);
     if (updatedAtDiff !== 0) return updatedAtDiff;
     return a.id.localeCompare(b.id);
+  }
+
+  /**
+   * Build SQL IN clause with placeholders for multiple entity IDs.
+   */
+  private _entityInClause(entityIds: readonly string[]): { clause: string; params: string[] } {
+    const placeholders = entityIds.map(() => '?').join(',');
+    return { clause: `entity_id IN (${placeholders})`, params: [...entityIds] };
+  }
+
+  /**
+   * Hydrate full facts by ID without entity_id filtering.
+   */
+  private async _hydrateFactsByIds(ids: readonly string[]): Promise<WikiFact[]> {
+    const fullRows: Array<WikiFact & { embedding?: unknown; embedding_blob?: unknown }> = [];
+    const chunkSize = 500;
+
+    for (let i = 0; i < ids.length; i += chunkSize) {
+      const idChunk = ids.slice(i, i + chunkSize);
+      const placeholders = idChunk.map(() => '?').join(',');
+      const chunkRows = await this.db.getAllAsync<WikiFact & { embedding?: unknown; embedding_blob?: unknown }>(
+        `SELECT * FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+        [...idChunk],
+      );
+      fullRows.push(...chunkRows);
+    }
+
+    const byId = new Map(fullRows.map(row => [row.id, row]));
+    return ids
+      .map(id => byId.get(id))
+      .filter((fact): fact is WikiFact & { embedding?: unknown; embedding_blob?: unknown } => fact !== undefined)
+      .map(fact => {
+        const { embedding: _embedding, embedding_blob: _blob, ...rest } = fact;
+        return {
+          ...rest,
+          tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
+        };
+      });
   }
 
   /**
@@ -1600,12 +1690,12 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
   private async _rankWithJsCosine(args: {
     entityId: string;
     queryVec: Float32Array | number[];
-    candidateRows: Array<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null; updated_at: number | null; access_count: number | null }>;
+    candidateRows: Array<{ id: string; entity_id: string; embedding_blob: Uint8Array | null; embedding: string | null; updated_at: number | null; access_count: number | null }>;
     weight: number | undefined;
     miniSearchScores: Map<string, number> | undefined;
     populateCache: boolean;
     limit: number;
-  }): Promise<Array<{ id: string; score: number; updated_at: number | null; access_count: number | null }>> {
+  }): Promise<Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }>> {
     const queryVec = args.queryVec instanceof Float32Array
       ? args.queryVec.slice()
       : Array.from(args.queryVec);
@@ -1651,7 +1741,13 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         // even when every cosine score is negative.
         score = -2;
       }
-      return { id: row.id, score, updated_at: row.updated_at, access_count: row.access_count };
+      return {
+        id: row.id,
+        entity_id: row.entity_id,
+        score,
+        updated_at: row.updated_at,
+        access_count: row.access_count,
+      };
     });
 
     if (canCache && entityCache && entityCache.size > 0) {
@@ -1681,11 +1777,12 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     entityId: string;
     queryVec: Float32Array | number[];
     candidateIds: readonly string[] | undefined;
+    candidateRows: ReadCandidateRowMetadata[];
     weight: number | undefined;
     miniSearchScores: Map<string, number> | undefined;
     limit: number;
-  }): Promise<Array<{ id: string; score: number }>> {
-    const { entityId, candidateIds, weight, miniSearchScores, limit } = args;
+  }): Promise<Array<{ id: string; entity_id: string; score: number }>> {
+    const { entityId, candidateIds, candidateRows, weight, miniSearchScores, limit } = args;
 
     const ranker = this.options.vectorRanker;
     if (!ranker) {
@@ -1718,6 +1815,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
       normalized.push(r);
     }
 
+    const entityIdByCandidateId = new Map(candidateRows.map(row => [row.id, row.entity_id]));
+
     // Convert ranker results to scored format, applying hybrid blending if weight is set
     const scored = normalized.map(r => {
       let score = r.semanticScore;
@@ -1726,7 +1825,11 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
         const kwScore = miniSearchScores?.get(r.id) ?? 0;
         score = weight * Math.max(0, r.semanticScore) + (1 - weight) * kwScore;
       }
-      return { id: r.id, score };
+      return {
+        id: r.id,
+        entity_id: entityIdByCandidateId.get(r.id) ?? entityId,
+        score,
+      };
     });
 
     // Caller handles backfill, metadata attachment, tie-break sorting, and final slice

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1587,11 +1587,14 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
     const [tasks, events] = await Promise.all([
       (async () => {
         const entityScope = this._entityInClause(entityIds);
+        // Scale limit so each entity can contribute up to 20 tasks (capped at 200).
+        const tasksLimit = Math.min(20 * entityIds.length, 200);
         return this.db.getAllAsync<WikiTask>(
           `SELECT * FROM ${this.prefix}tasks
            WHERE ${entityScope.clause} AND status IN ('pending', 'in_progress') AND deleted_at IS NULL
-           ORDER BY priority DESC, created_at ASC`,
-          entityScope.params
+           ORDER BY priority DESC, created_at ASC
+           LIMIT ?`,
+          [...entityScope.params, tasksLimit]
         );
       })(),
       (async () => {

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1096,11 +1096,17 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             );
           }
 
-          const useRanker = Boolean(this.options.vectorRanker);
-          let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
-          // Composite cache keys (multi-entity join strings) are never invalidated by write/reembed paths.
-          let populateCache = entityIds.length === 1;
-          let miniSearchScores: Map<string, number> | undefined;
+          // Fast-path: no entities need semantic scoring (all have weight=0 and
+          // includeZeroWeightEntities is false). Skip embedding+DB work and fall
+          // through to the keyword-only path below, while still fetching tasks/events.
+          if (scoredEntityIds.length === 0) {
+            usedEmbed = true; // semantic path intentionally skipped, not failed
+          } else {
+            const useRanker = Boolean(this.options.vectorRanker);
+            let candidateRows: ReadCandidateRowMetadata[] | ReadCandidateRowWithEmbeddings[] | null; // null = pre-filter returned 0 results
+            // Composite cache keys (multi-entity join strings) are never invalidated by write/reembed paths.
+            let populateCache = entityIds.length === 1;
+            let miniSearchScores: Map<string, number> | undefined;
 
           if (effectivePreFilterLimit !== undefined) {
             populateCache = false; // partial scan — do not populate cache
@@ -1503,7 +1509,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
               usedEmbed = true;
             }
           } // closes the candidateRows !== null else block
-        } catch (err) {
+        } // closes the scoredEntityIds.length === 0 else block
+      } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
           if (rankerShouldRethrow) {
             throw error;
@@ -1639,7 +1646,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
   ): number {
     const scoreDiff = b.score - a.score;
     // isNaN guard: -Infinity - (-Infinity) = NaN; fall through to tie-break
-    if (!isNaN(scoreDiff) && scoreDiff !== 0) return scoreDiff;
+    if (!Number.isNaN(scoreDiff) && scoreDiff !== 0) return scoreDiff;
     const accessCountDiff = (b.access_count ?? 0) - (a.access_count ?? 0);
     if (accessCountDiff !== 0) return accessCountDiff;
     const updatedAtDiff = (b.updated_at ?? 0) - (a.updated_at ?? 0);

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1094,8 +1094,9 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
           }
 
           // Fast-path: no entities need semantic scoring (all have weight=0 and
-          // includeZeroWeightEntities is false). Skip embedding+DB work and fall
-          // through to the keyword-only path below, while still fetching tasks/events.
+          // includeZeroWeightEntities is false). Skip embedding+DB work entirely.
+          // usedEmbed=true suppresses the !usedEmbed keyword fallback below, so
+          // zero-weight reads return an empty facts list (tasks/events still fetched).
           if (scoredEntityIds.length === 0) {
             usedEmbed = true; // semantic path intentionally skipped, not failed
           } else {
@@ -1105,197 +1106,158 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             let populateCache = entityIds.length === 1;
             let miniSearchScores: Map<string, number> | undefined;
 
-          if (effectivePreFilterLimit !== undefined) {
-            populateCache = false; // partial scan — do not populate cache
-            const entityIdSet = new Set(scoredEntityIds);
-            const preResults = this.miniSearch.search(trimmedQuery, {
-              filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
-              combineWith: 'OR',
-            });
-            if (preResults.length === 0) {
-              candidateRows = null; // empty pre-filter
-            } else {
-              const topKResults = preResults.slice(0, effectivePreFilterLimit);
-              if (topKResults.length === 0) {
-                // effectivePreFilterLimit is 0 — treat the same as no candidates
-                // (avoids constructing an invalid "WHERE id IN ()" SQL clause)
-                candidateRows = null;
-              } else {
-                const topKIds = topKResults.map(r => r.id);
-                const inClauseChunkSize = 500;
-                if (useRanker) {
-                  const rows: ReadCandidateRowMetadata[] = [];
-                  for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
-                    const idChunk = topKIds.slice(i, i + inClauseChunkSize);
-                    const placeholders = idChunk.map(() => '?').join(',');
-                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
-                      `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                      idChunk
-                    );
-                    rows.push(...chunkRows);
-                  }
-                  candidateRows = rows;
-                } else {
-                  const rows: ReadCandidateRowWithEmbeddings[] = [];
-                  for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
-                    const idChunk = topKIds.slice(i, i + inClauseChunkSize);
-                    const placeholders = idChunk.map(() => '?').join(',');
-                    const chunkRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
-                      `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                      idChunk
-                    );
-                    rows.push(...chunkRows);
-                  }
-                  candidateRows = rows;
-                }
-                if (weight !== undefined && weight < 1) {
-                  const maxMsScore = Math.max(1, topKResults[0]?.score ?? 1);
-                  miniSearchScores = new Map(topKResults.map(r => [r.id, r.score / maxMsScore]));
-                }
-              }
-            }
-          } else {
-            // Full scan of scored entities
-            // If vectorRanker is configured, skip embedding load for now (ranker will provide ranking)
-            // Otherwise fetch embeddings for JS cosine ranking
-            if (useRanker) {
-              const entityScope = this._entityInClause(scoredEntityIds);
-              candidateRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
-                `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
-                entityScope.params
-              );
-            } else {
-              const entityScope = this._entityInClause(scoredEntityIds);
-              candidateRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
-                `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
-                entityScope.params
-              );
-            }
-            // Collect MiniSearch scores for hybrid blend if weight is set and <1
-            if (weight !== undefined && weight < 1) {
+            if (effectivePreFilterLimit !== undefined) {
+              populateCache = false; // partial scan — do not populate cache
               const entityIdSet = new Set(scoredEntityIds);
-              const msResults = this.miniSearch.search(trimmedQuery, {
+              const preResults = this.miniSearch.search(trimmedQuery, {
                 filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
                 combineWith: 'OR',
               });
-              const maxMsScore = Math.max(1, msResults[0]?.score ?? 1);
-              miniSearchScores = new Map(msResults.map(r => [r.id, r.score / maxMsScore]));
-            }
-          }
-
-          if (candidateRows === null) {
-            // pre-filter returned 0 candidates — facts = [], skip phase 2, skip access tracking
-            usedEmbed = true;
-          } else {
-            // Rank candidates: use vectorRanker if present, otherwise use JS cosine
-            const entityCacheKey = entityIds.length === 1 ? entityIds[0] : entityIds.join('\x00');
-            let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
-
-            if (useRanker) {
-              // Use external ranker for semantic scoring.
-              // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
-              // not a real namespace) and pre-filtered reads (results already scoped to subset).
-              // For single-entity full-scan, omit so remote rankers avoid transmitting the full
-              // candidate list and can scope by entityId instead.
-              const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
-                ? candidateRows.map(r => r.id)
-                : undefined;
-
-              try {
-                // Oversample by max(2x, +50) to preserve recall after re-ranking;
-                // caller slices final output to maxResults.
-                const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
-                scored = await this._rankWithVectorRanker({
-                  entityId: entityCacheKey,
-                  queryVec,
-                  candidateIds,
-                  candidateRows: candidateRows as ReadCandidateRowMetadata[],
-                  weight,
-                  miniSearchScores,
-                  limit: oversampledLimit,
-                });
-
-                // Attach tie-break metadata from candidateRows (only for IDs returned by ranker)
-                if (scored.length > 0) {
-                  const scoredIds = new Set(scored.map(s => s.id));
-                  const metaMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
-                  for (const r of candidateRows) {
-                    if (scoredIds.has(r.id)) {
-                      metaMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
+              if (preResults.length === 0) {
+                candidateRows = null; // empty pre-filter
+              } else {
+                const topKResults = preResults.slice(0, effectivePreFilterLimit);
+                if (topKResults.length === 0) {
+                  // effectivePreFilterLimit is 0 — treat the same as no candidates
+                  // (avoids constructing an invalid "WHERE id IN ()" SQL clause)
+                  candidateRows = null;
+                } else {
+                  const topKIds = topKResults.map(r => r.id);
+                  const inClauseChunkSize = 500;
+                  if (useRanker) {
+                    const rows: ReadCandidateRowMetadata[] = [];
+                    for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
+                      const idChunk = topKIds.slice(i, i + inClauseChunkSize);
+                      const placeholders = idChunk.map(() => '?').join(',');
+                      const chunkRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                        `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                        idChunk
+                      );
+                      rows.push(...chunkRows);
                     }
+                    candidateRows = rows;
+                  } else {
+                    const rows: ReadCandidateRowWithEmbeddings[] = [];
+                    for (let i = 0; i < topKIds.length; i += inClauseChunkSize) {
+                      const idChunk = topKIds.slice(i, i + inClauseChunkSize);
+                      const placeholders = idChunk.map(() => '?').join(',');
+                      const chunkRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                        `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                        idChunk
+                      );
+                      rows.push(...chunkRows);
+                    }
+                    candidateRows = rows;
                   }
-                  scored = scored.map(s => {
-                    const meta = metaMap.get(s.id);
-                    return { ...s, updated_at: meta?.updated_at ?? null, access_count: meta?.access_count ?? null };
-                  });
+                  if (weight !== undefined && weight < 1) {
+                    const maxMsScore = Math.max(1, topKResults[0]?.score ?? 1);
+                    miniSearchScores = new Map(topKResults.map(r => [r.id, r.score / maxMsScore]));
+                  }
                 }
+              }
+            } else {
+              // Full scan of scored entities
+              // If vectorRanker is configured, skip embedding load for now (ranker will provide ranking)
+              // Otherwise fetch embeddings for JS cosine ranking
+              if (useRanker) {
+                const entityScope = this._entityInClause(scoredEntityIds);
+                candidateRows = await this.db.getAllAsync<ReadCandidateRowMetadata>(
+                  `SELECT id, entity_id, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                  entityScope.params
+                );
+              } else {
+                const entityScope = this._entityInClause(scoredEntityIds);
+                candidateRows = await this.db.getAllAsync<ReadCandidateRowWithEmbeddings>(
+                  `SELECT id, entity_id, embedding_blob, embedding, updated_at, access_count FROM ${this.prefix}entries WHERE ${entityScope.clause} AND deleted_at IS NULL`,
+                  entityScope.params
+                );
+              }
+              // Collect MiniSearch scores for hybrid blend if weight is set and <1
+              if (weight !== undefined && weight < 1) {
+                const entityIdSet = new Set(scoredEntityIds);
+                const msResults = this.miniSearch.search(trimmedQuery, {
+                  filter: (r) => entityIdSet.has((r as unknown as { entity_id: string }).entity_id),
+                  combineWith: 'OR',
+                });
+                const maxMsScore = Math.max(1, msResults[0]?.score ?? 1);
+                miniSearchScores = new Map(msResults.map(r => [r.id, r.score / maxMsScore]));
+              }
+            }
 
-                // Backfill ranker-omitted rows per VectorRanker contract:
-                // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
-                const scoredIds = new Set(scored.map(s => s.id));
+            if (candidateRows === null) {
+              // pre-filter returned 0 candidates — facts = [], skip phase 2, skip access tracking
+              usedEmbed = true;
+            } else {
+              // Rank candidates: use vectorRanker if present, otherwise use JS cosine
+              const entityCacheKey = entityIds.length === 1 ? entityIds[0] : entityIds.join('\x00');
+              let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
 
-                // Compute backfill budget up-front.
-                // Hybrid mode: allow up to maxResults keyword-only rows to compete.
-                // Pure semantic: only fill the remaining result slots.
-                const isHybrid = weight !== undefined && weight < 1;
-                const maxBackfill = isHybrid
-                  ? maxResults
-                  : Math.max(0, maxResults - scored.length);
+              if (useRanker) {
+                // Use external ranker for semantic scoring.
+                // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
+                // not a real namespace) and pre-filtered reads (results already scoped to subset).
+                // For single-entity full-scan, omit so remote rankers avoid transmitting the full
+                // candidate list and can scope by entityId instead.
+                const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
+                  ? candidateRows.map(r => r.id)
+                  : undefined;
 
-                if (maxBackfill > 0) {
-                  if (isHybrid) {
-                    // Hybrid mode: prioritize by keyword score using O(N log K) top-K selection
-                    // instead of O(N log N) full sort, since K (maxBackfill) is typically << N.
-                    type CandidateRow = typeof candidateRows[number];
-                    const topK: Array<{ row: CandidateRow; kwScore: number }> = [];
+                try {
+                  // Oversample by max(2x, +50) to preserve recall after re-ranking;
+                  // caller slices final output to maxResults.
+                  const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
+                  scored = await this._rankWithVectorRanker({
+                    entityId: entityCacheKey,
+                    queryVec,
+                    candidateIds,
+                    candidateRows: candidateRows as ReadCandidateRowMetadata[],
+                    weight,
+                    miniSearchScores,
+                    limit: oversampledLimit,
+                  });
 
-                    for (const row of candidateRows) {
-                      if (scoredIds.has(row.id)) continue;
-                      const kwScore = miniSearchScores?.get(row.id) ?? 0;
-                      const candidate = { row, kwScore };
+                  // Attach tie-break metadata from candidateRows (only for IDs returned by ranker)
+                  if (scored.length > 0) {
+                    const scoredIds = new Set(scored.map(s => s.id));
+                    const metaMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
+                    for (const r of candidateRows) {
+                      if (scoredIds.has(r.id)) {
+                        metaMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
+                      }
+                    }
+                    scored = scored.map(s => {
+                      const meta = metaMap.get(s.id);
+                      return { ...s, updated_at: meta?.updated_at ?? null, access_count: meta?.access_count ?? null };
+                    });
+                  }
 
-                      if (topK.length < maxBackfill) {
-                        // Array not full yet - insert in sorted position (descending order)
-                        let insertIdx = topK.length;
-                        for (let i = 0; i < topK.length; i++) {
-                          const cmp = this._compareScoredRows(
-                            {
-                              id: candidate.row.id,
-                              score: candidate.kwScore,
-                              updated_at: candidate.row.updated_at,
-                              access_count: candidate.row.access_count,
-                            },
-                            {
-                              id: topK[i].row.id,
-                              score: topK[i].kwScore,
-                              updated_at: topK[i].row.updated_at,
-                              access_count: topK[i].row.access_count,
-                            }
-                          );
-                          if (cmp < 0) {
-                            insertIdx = i;
-                            break;
-                          }
-                        }
-                        topK.splice(insertIdx, 0, candidate);
-                      } else {
-                        const cmpWorst = this._compareScoredRows(
-                          {
-                            id: candidate.row.id,
-                            score: candidate.kwScore,
-                            updated_at: candidate.row.updated_at,
-                            access_count: candidate.row.access_count,
-                          },
-                          {
-                            id: topK[maxBackfill - 1].row.id,
-                            score: topK[maxBackfill - 1].kwScore,
-                            updated_at: topK[maxBackfill - 1].row.updated_at,
-                            access_count: topK[maxBackfill - 1].row.access_count,
-                          }
-                        );
-                        if (cmpWorst < 0) {
-                          // Found better candidate than current worst - replace worst and re-insert
-                          let insertIdx = maxBackfill - 1;
+                  // Backfill ranker-omitted rows per VectorRanker contract:
+                  // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
+                  const scoredIds = new Set(scored.map(s => s.id));
+
+                  // Compute backfill budget up-front.
+                  // Hybrid mode: allow up to maxResults keyword-only rows to compete.
+                  // Pure semantic: only fill the remaining result slots.
+                  const isHybrid = weight !== undefined && weight < 1;
+                  const maxBackfill = isHybrid
+                    ? maxResults
+                    : Math.max(0, maxResults - scored.length);
+
+                  if (maxBackfill > 0) {
+                    if (isHybrid) {
+                      // Hybrid mode: prioritize by keyword score using O(N log K) top-K selection
+                      // instead of O(N log N) full sort, since K (maxBackfill) is typically << N.
+                      type CandidateRow = typeof candidateRows[number];
+                      const topK: Array<{ row: CandidateRow; kwScore: number }> = [];
+
+                      for (const row of candidateRows) {
+                        if (scoredIds.has(row.id)) continue;
+                        const kwScore = miniSearchScores?.get(row.id) ?? 0;
+                        const candidate = { row, kwScore };
+
+                        if (topK.length < maxBackfill) {
+                          // Array not full yet - insert in sorted position (descending order)
+                          let insertIdx = topK.length;
                           for (let i = 0; i < topK.length; i++) {
                             const cmp = this._compareScoredRows(
                               {
@@ -1317,196 +1279,235 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                             }
                           }
                           topK.splice(insertIdx, 0, candidate);
-                          topK.pop(); // Remove worst element
+                        } else {
+                          const cmpWorst = this._compareScoredRows(
+                            {
+                              id: candidate.row.id,
+                              score: candidate.kwScore,
+                              updated_at: candidate.row.updated_at,
+                              access_count: candidate.row.access_count,
+                            },
+                            {
+                              id: topK[maxBackfill - 1].row.id,
+                              score: topK[maxBackfill - 1].kwScore,
+                              updated_at: topK[maxBackfill - 1].row.updated_at,
+                              access_count: topK[maxBackfill - 1].row.access_count,
+                            }
+                          );
+                          if (cmpWorst < 0) {
+                            // Found better candidate than current worst - replace worst and re-insert
+                            let insertIdx = maxBackfill - 1;
+                            for (let i = 0; i < topK.length; i++) {
+                              const cmp = this._compareScoredRows(
+                                {
+                                  id: candidate.row.id,
+                                  score: candidate.kwScore,
+                                  updated_at: candidate.row.updated_at,
+                                  access_count: candidate.row.access_count,
+                                },
+                                {
+                                  id: topK[i].row.id,
+                                  score: topK[i].kwScore,
+                                  updated_at: topK[i].row.updated_at,
+                                  access_count: topK[i].row.access_count,
+                                }
+                              );
+                              if (cmp < 0) {
+                                insertIdx = i;
+                                break;
+                              }
+                            }
+                            topK.splice(insertIdx, 0, candidate);
+                            topK.pop(); // Remove worst element
+                          }
                         }
                       }
-                    }
 
-                    for (const { row, kwScore } of topK) {
-                      scored.push({
-                        id: row.id,
-                        entity_id: row.entity_id,
-                        score: (1 - weight) * kwScore,
-                        updated_at: row.updated_at,
-                        access_count: row.access_count,
-                      });
-                    }
-                  } else {
-                    // Pure semantic: all omitted rows share score -2.
-                    // Tie-break omitted rows deterministically before truncating.
-                    const omitted: Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
-                    for (const row of candidateRows) {
-                      if (scoredIds.has(row.id)) continue;
-                      omitted.push({ id: row.id, entity_id: row.entity_id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
-                    }
-                    if (omitted.length > 0) {
-                      this._tieBreakSort(omitted);
-                      scored.push(...omitted.slice(0, maxBackfill));
-                    }
-                  }
-                }
-              } catch (rankerErr) {
-                const rankerError = rankerErr instanceof Error ? rankerErr : new Error(String(rankerErr));
-                const policy = this.options.vectorRankerFallback ?? 'js-cosine';
-
-                this.options.onVectorRankerFallback?.({
-                  error: this._sanitizeRankerError(rankerError),
-                  policy,
-                });
-
-                if (policy === 'throw') {
-                  rankerShouldRethrow = true;
-                  throw rankerError;
-                } else if (policy === 'js-cosine') {
-                  // If embeddings were skipped (vectorRanker was configured), fetch them now for fallback
-                  let fallbackRows = candidateRows;
-                  if (fallbackRows && fallbackRows.length > 0 && !('embedding_blob' in fallbackRows[0])) {
-                    const rowIds = fallbackRows.map(r => r.id);
-                    const embeddingsMap = new Map<string, { embedding_blob: Uint8Array | null; embedding: string | null }>();
-                    const chunkSize = 500;
-                    for (let i = 0; i < rowIds.length; i += chunkSize) {
-                      const idChunk = rowIds.slice(i, i + chunkSize);
-                      const placeholders = idChunk.map(() => '?').join(',');
-                      const embeddingRows = await this.db.getAllAsync<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null }>(
-                        `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
-                        idChunk
-                      );
-                      for (const row of embeddingRows) {
-                        embeddingsMap.set(row.id, { embedding_blob: row.embedding_blob, embedding: row.embedding });
+                      for (const { row, kwScore } of topK) {
+                        scored.push({
+                          id: row.id,
+                          entity_id: row.entity_id,
+                          score: (1 - weight) * kwScore,
+                          updated_at: row.updated_at,
+                          access_count: row.access_count,
+                        });
+                      }
+                    } else {
+                      // Pure semantic: all omitted rows share score -2.
+                      // Tie-break omitted rows deterministically before truncating.
+                      const omitted: Array<{ id: string; entity_id: string; score: number; updated_at: number | null; access_count: number | null }> = [];
+                      for (const row of candidateRows) {
+                        if (scoredIds.has(row.id)) continue;
+                        omitted.push({ id: row.id, entity_id: row.entity_id, score: -2, updated_at: row.updated_at, access_count: row.access_count });
+                      }
+                      if (omitted.length > 0) {
+                        this._tieBreakSort(omitted);
+                        scored.push(...omitted.slice(0, maxBackfill));
                       }
                     }
-                    fallbackRows = fallbackRows.map(r => ({
-                      ...r,
-                      embedding_blob: embeddingsMap.get(r.id)?.embedding_blob ?? null,
-                      embedding: embeddingsMap.get(r.id)?.embedding ?? null,
-                    })) as ReadCandidateRowWithEmbeddings[];
                   }
-                  scored = await this._rankWithJsCosine({
-                    entityId: entityCacheKey,
-                    queryVec,
-                    candidateRows: fallbackRows as ReadCandidateRowWithEmbeddings[],
-                    weight,
-                    miniSearchScores,
-                    populateCache,
-                    limit: fallbackRows.length,
-                    skipSort: true, // read() re-sorts after applying tier weights
+                } catch (rankerErr) {
+                  const rankerError = rankerErr instanceof Error ? rankerErr : new Error(String(rankerErr));
+                  const policy = this.options.vectorRankerFallback ?? 'js-cosine';
+
+                  this.options.onVectorRankerFallback?.({
+                    error: this._sanitizeRankerError(rankerError),
+                    policy,
                   });
-                } else if (policy === 'keyword') {
-                  // Fall back to keyword-only results from MiniSearch
-                  const scoredEntityIdSet = new Set(scoredEntityIds);
-                  const msResults = this.miniSearch.search(trimmedQuery, {
-                    filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
-                    combineWith: 'OR',
-                  });
-                  // Oversample so tier weights can re-rank before the global slice
-                  const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
-                  const topResults = msResults.slice(0, keywordOversampledLimit);
-                  // Build metadata map only for returned IDs (not all candidates)
-                  const resultIds = new Set(topResults.map(r => r.id));
-                  const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
-                  for (const r of candidateRows) {
-                    if (resultIds.has(r.id)) {
-                      candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
+
+                  if (policy === 'throw') {
+                    rankerShouldRethrow = true;
+                    throw rankerError;
+                  } else if (policy === 'js-cosine') {
+                    // If embeddings were skipped (vectorRanker was configured), fetch them now for fallback
+                    let fallbackRows = candidateRows;
+                    if (fallbackRows && fallbackRows.length > 0 && !('embedding_blob' in fallbackRows[0])) {
+                      const rowIds = fallbackRows.map(r => r.id);
+                      const embeddingsMap = new Map<string, { embedding_blob: Uint8Array | null; embedding: string | null }>();
+                      const chunkSize = 500;
+                      for (let i = 0; i < rowIds.length; i += chunkSize) {
+                        const idChunk = rowIds.slice(i, i + chunkSize);
+                        const placeholders = idChunk.map(() => '?').join(',');
+                        const embeddingRows = await this.db.getAllAsync<{ id: string; embedding_blob: Uint8Array | null; embedding: string | null }>(
+                          `SELECT id, embedding_blob, embedding FROM ${this.prefix}entries WHERE id IN (${placeholders}) AND deleted_at IS NULL`,
+                          idChunk
+                        );
+                        for (const row of embeddingRows) {
+                          embeddingsMap.set(row.id, { embedding_blob: row.embedding_blob, embedding: row.embedding });
+                        }
+                      }
+                      fallbackRows = fallbackRows.map(r => ({
+                        ...r,
+                        embedding_blob: embeddingsMap.get(r.id)?.embedding_blob ?? null,
+                        embedding: embeddingsMap.get(r.id)?.embedding ?? null,
+                      })) as ReadCandidateRowWithEmbeddings[];
                     }
+                    scored = await this._rankWithJsCosine({
+                      entityId: entityCacheKey,
+                      queryVec,
+                      candidateRows: fallbackRows as ReadCandidateRowWithEmbeddings[],
+                      weight,
+                      miniSearchScores,
+                      populateCache,
+                      limit: fallbackRows.length,
+                      skipSort: true, // read() re-sorts after applying tier weights
+                    });
+                  } else if (policy === 'keyword') {
+                    // Fall back to keyword-only results from MiniSearch
+                    const scoredEntityIdSet = new Set(scoredEntityIds);
+                    const msResults = this.miniSearch.search(trimmedQuery, {
+                      filter: (r) => scoredEntityIdSet.has((r as unknown as { entity_id: string }).entity_id),
+                      combineWith: 'OR',
+                    });
+                    // Oversample so tier weights can re-rank before the global slice
+                    const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
+                    const topResults = msResults.slice(0, keywordOversampledLimit);
+                    // Build metadata map only for returned IDs (not all candidates)
+                    const resultIds = new Set(topResults.map(r => r.id));
+                    const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
+                    for (const r of candidateRows) {
+                      if (resultIds.has(r.id)) {
+                        candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
+                      }
+                    }
+                    scored = topResults.map(r => {
+                      const meta = candidateMap.get(r.id);
+                      return {
+                        id: r.id,
+                        entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
+                        score: r.score ?? 0,
+                        access_count: meta?.access_count ?? null,
+                        updated_at: meta?.updated_at ?? null,
+                      };
+                    });
+                    usedKeywordFallback = true;
+                  } else {
+                    // policy === 'empty'
+                    scored = [];
                   }
-                  scored = topResults.map(r => {
-                    const meta = candidateMap.get(r.id);
-                    return {
-                      id: r.id,
-                      entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
-                      score: r.score ?? 0,
-                      access_count: meta?.access_count ?? null,
-                      updated_at: meta?.updated_at ?? null,
-                    };
-                  });
-                  usedKeywordFallback = true;
-                } else {
-                  // policy === 'empty'
-                  scored = [];
+
+                  if (this.options.propagateRankerFailureToRetrievalFallback) {
+                    const mirrored = new Error('Vector ranker failed, falling back', {
+                      cause: this._sanitizeRankerError(rankerErr),
+                    });
+                    pendingRankerFallbackError = mirrored;
+                  }
+                }
+              } else {
+                // Use in-process JS cosine similarity
+                // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
+                scored = await this._rankWithJsCosine({
+                  entityId: entityCacheKey,
+                  queryVec,
+                  candidateRows: candidateRows as ReadCandidateRowWithEmbeddings[],
+                  weight,
+                  miniSearchScores,
+                  populateCache,
+                  // Return all candidates so tier weights can re-rank before the
+                  // global slice at the merge step below.
+                  limit: candidateRows.length,
+                  skipSort: true, // read() re-sorts after applying tier weights
+                });
+              }
+
+              if (scored.length > 0) {
+                // Apply tier weights before global sort and slice
+                scored = scored.map(row => ({
+                  ...row,
+                  score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
+                }));
+
+                // Re-apply tie-break sorting (ranker might not have stable ordering, and weights changed order)
+                this._tieBreakSort(scored);
+
+                // Phase 2: fetch full rows only for the top results
+                const selectedScored = scored.slice(0, maxResults);
+                const topIds = selectedScored.map(s => s.id);
+
+                // Capture scores for exposure in metadata
+                if (exposeMetadata && trimmedQuery) {
+                  scoreByFactId = new Map(selectedScored.map(s => [s.id, Number.isFinite(s.score) ? s.score : 0]));
                 }
 
-                if (this.options.propagateRankerFailureToRetrievalFallback) {
-                  const mirrored = new Error('Vector ranker failed, falling back', {
-                    cause: this._sanitizeRankerError(rankerErr),
-                  });
-                  pendingRankerFallbackError = mirrored;
+                if (topIds.length > 0) {
+                  const facts2 = await this._hydrateFactsByIds(topIds, entityIds);
+
+                  // Hydration can return fewer rows than ranked IDs when rows were concurrently
+                  // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
+                  if (facts2.length < topIds.length) {
+                    const hydrationById = new Set(facts2.map(f => f.id));
+                    const missingIds = topIds.filter(id => !hydrationById.has(id));
+                    const missingCount = missingIds.length;
+                    const sample = missingIds.slice(0, 5);
+                    const sampleSuffix = sample.length > 0
+                      ? ` Missing ID sample: ${sample.join(', ')}${missingIds.length > sample.length ? ', ...' : ''}.`
+                      : '';
+                    const error = new Error(
+                      `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs. ` +
+                      `Rows may have been concurrently soft-deleted or filtered by deleted_at during hydration, ` +
+                      `or vector ranker output may include IDs that do not exist in requested entities.` +
+                      sampleSuffix
+                    );
+                    this.options.onRetrievalFallback?.(error);
+                  }
+                  facts = facts2;
                 }
-              }
-            } else {
-              // Use in-process JS cosine similarity
-              // At this point candidateRows must have embeddings (we fetched them because vectorRanker is not configured)
-              scored = await this._rankWithJsCosine({
-                entityId: entityCacheKey,
-                queryVec,
-                candidateRows: candidateRows as ReadCandidateRowWithEmbeddings[],
-                weight,
-                miniSearchScores,
-                populateCache,
-                // Return all candidates so tier weights can re-rank before the
-                // global slice at the merge step below.
-                limit: candidateRows.length,
-                skipSort: true, // read() re-sorts after applying tier weights
-              });
-            }
-
-            if (scored.length > 0) {
-              // Apply tier weights before global sort and slice
-              scored = scored.map(row => ({
-                ...row,
-                score: applyTierWeight(row.score, row.entity_id, sanitizedTierWeights),
-              }));
-
-              // Re-apply tie-break sorting (ranker might not have stable ordering, and weights changed order)
-              this._tieBreakSort(scored);
-
-              // Phase 2: fetch full rows only for the top results
-              const selectedScored = scored.slice(0, maxResults);
-              const topIds = selectedScored.map(s => s.id);
-
-              // Capture scores for exposure in metadata
-              if (exposeMetadata && trimmedQuery) {
-                scoreByFactId = new Map(selectedScored.map(s => [s.id, Number.isFinite(s.score) ? s.score : 0]));
-              }
-
-              if (topIds.length > 0) {
-                const facts2 = await this._hydrateFactsByIds(topIds, entityIds);
-
-                // Hydration can return fewer rows than ranked IDs when rows were concurrently
-                // soft-deleted or filtered by deleted_at before phase 2 hydration completes.
-                if (facts2.length < topIds.length) {
-                  const hydrationById = new Set(facts2.map(f => f.id));
-                  const missingIds = topIds.filter(id => !hydrationById.has(id));
-                  const missingCount = missingIds.length;
-                  const sample = missingIds.slice(0, 5);
-                  const sampleSuffix = sample.length > 0
-                    ? ` Missing ID sample: ${sample.join(', ')}${missingIds.length > sample.length ? ', ...' : ''}.`
-                    : '';
-                  const error = new Error(
-                    `Phase 2 fact hydration returned ${missingCount} fewer row(s) than ranked IDs. ` +
-                    `Rows may have been concurrently soft-deleted or filtered by deleted_at during hydration, ` +
-                    `or vector ranker output may include IDs that do not exist in requested entities.` +
-                    sampleSuffix
-                  );
-                  this.options.onRetrievalFallback?.(error);
+                // Phase 2 succeeded — now safe to notify that ranker fallback occurred
+                if (pendingRankerFallbackError) {
+                  this.options.onRetrievalFallback?.(pendingRankerFallbackError);
+                  pendingRankerFallbackError = undefined;
                 }
-                facts = facts2;
+                usedEmbed = true;
+              } else {
+                // Empty scored results (ranker returned no matches)
+                if (pendingRankerFallbackError) {
+                  this.options.onRetrievalFallback?.(pendingRankerFallbackError);
+                  pendingRankerFallbackError = undefined;
+                }
+                usedEmbed = true;
               }
-              // Phase 2 succeeded — now safe to notify that ranker fallback occurred
-              if (pendingRankerFallbackError) {
-                this.options.onRetrievalFallback?.(pendingRankerFallbackError);
-                pendingRankerFallbackError = undefined;
-              }
-              usedEmbed = true;
-            } else {
-              // Empty scored results (ranker returned no matches)
-              if (pendingRankerFallbackError) {
-                this.options.onRetrievalFallback?.(pendingRankerFallbackError);
-                pendingRankerFallbackError = undefined;
-              }
-              usedEmbed = true;
-            }
-          } // closes the candidateRows !== null else block
-        } // closes the scoredEntityIds.length === 0 else block
+            } // closes the candidateRows !== null else block
+          } // closes the scoredEntityIds.length === 0 else block
       } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
           if (rankerShouldRethrow) {
@@ -1618,7 +1619,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
     if (exposeMetadata) {
       bundle.metadata = { query, entityIds };
-      if (sanitizedTierWeights) bundle.metadata.tierWeights = sanitizedTierWeights;
+      if (sanitizedTierWeights && Object.keys(sanitizedTierWeights).length > 0) bundle.metadata.tierWeights = sanitizedTierWeights;
       if (factScores && Object.keys(factScores).length > 0) bundle.factScores = factScores;
     }
 

--- a/packages/core/src/readOptions.ts
+++ b/packages/core/src/readOptions.ts
@@ -35,7 +35,11 @@ export function applyTierWeight(
   entityId: string,
   sanitizedTierWeights: Record<string, number> | undefined,
 ): number {
-  return score * (sanitizedTierWeights?.[entityId] ?? 1);
+  const weight = sanitizedTierWeights?.[entityId] ?? 1;
+  // Weight=0 → sentinel -Infinity so zero-weight entities always sort below any
+  // finite score, including negative cosine values from the pure-semantic path.
+  if (weight === 0) return -Infinity;
+  return score * weight;
 }
 
 export function shouldExposeReadMetadata(

--- a/packages/core/src/readOptions.ts
+++ b/packages/core/src/readOptions.ts
@@ -44,7 +44,6 @@ export function applyTierWeight(
 
 export function shouldExposeReadMetadata(
   entityId: string | string[],
-  _options?: unknown,
 ): boolean {
   return Array.isArray(entityId);
 }

--- a/packages/core/src/readOptions.ts
+++ b/packages/core/src/readOptions.ts
@@ -40,7 +40,7 @@ export function applyTierWeight(
 
 export function shouldExposeReadMetadata(
   entityId: string | string[],
-  options: { tierWeights?: Record<string, number> } | undefined,
+  _options?: unknown,
 ): boolean {
-  return Array.isArray(entityId) || options?.tierWeights !== undefined;
+  return Array.isArray(entityId);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,16 +52,17 @@ export interface ReadOptions {
   preFilterLimit?: number | null;
   hybridWeight?: number;
   /**
-   * (Reserved for Phase 2+ multi-entity weighted retrieval)
-   * entity_id -> score multiplier. Missing entries default to 1.0.
-   * Currently ignored by WikiMemory.read(); planned for implementation in Phase 2.
+   * Per-entity score multiplier for multi-entity reads. Missing entries default to 1.0.
+   * Entities with weight 0 are skipped during scored retrieval unless
+   * `includeZeroWeightEntities` is true; in that case they rank below all finite scores.
+   * Only meaningful when `entityId` is an array; ignored for single-string calls.
    */
   tierWeights?: Record<string, number>;
   /**
-   * (Reserved for Phase 2+ multi-entity weighted retrieval)
-   * false/default -> skip zero-weight entities during scored retrieval.
-   * true -> retrieve zero-weight entities and let them fill only if the pool is small.
-   * Currently ignored by WikiMemory.read(); planned for implementation in Phase 2.
+   * When true, entities with a tier weight of 0 are included in scored retrieval
+   * as bottom fillers (ranked below every finite-scored candidate).
+   * When false (default), zero-weight entities are skipped entirely.
+   * Only meaningful when `entityId` is an array; ignored for single-string calls.
    */
   includeZeroWeightEntities?: boolean;
 }


### PR DESCRIPTION
Implements Phase 2 of the [multi-entity weighted retrieval spec](docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md).

## Changes

- `WikiMemory.read()` now accepts `string | string[]` as the first argument
- Per-entity `tierWeights` applied before global `maxResults` slice — fixes ranking so boosted entities can win against higher raw-cosine competitors
- Zero-weight entities skipped by default; opt-in via `includeZeroWeightEntities`
- Empty entity array returns fast with metadata
- Tasks and events fetched across all requested entities in one query
- `metadata` and `factScores` exposed when input is array (backward-compatible: single-string callers see no change)
- Fixes `entity_id` propagation through vector ranker backfill and keyword-fallback paths

## Test plan

- [ ] `pnpm --filter @equationalapplications/core-llm-wiki test` — 285 tests pass
- [ ] `pnpm --filter @equationalapplications/core-llm-wiki typecheck` — clean
- [ ] New `__tests__/multiEntityRead.test.ts` covers: API compat, tier weighting, zero-weight skip/include, empty-query recency, tasks/events, dedup, empty entity array