### PR TITLE
feat(core): add librarian prompt contract

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -398,6 +398,70 @@ await wikiMemory.write('user-123', {
 const memory = await wikiMemory.read('user-123', 'coding style preferences');
 ```
 
+### Multi-entity weighted reads
+
+`read()` accepts either one entity id or an array of entity ids. Array reads merge fact candidates globally before `maxResults` is applied, while tasks and events are returned for every requested entity.
+
+```ts
+const memory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'Which source should I trust?', {
+  maxResults: 8,
+  tierWeights: {
+    tier_wisdom: 2,
+    tier_fact: 1,
+    tier_working: 0.25,
+  },
+});
+
+console.log(memory.metadata);
+console.log(memory.factScores);
+```
+
+### Librarian prompt override contract
+
+Core does not own a provider-specific synthesis API, but it exports prompt utilities for applications that synthesize answers from weighted retrieval results.
+
+```ts
+import {
+  DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT,
+  formatContext,
+  hydrateLibrarianPrompt,
+  mapLibrarianOptionsToReadOptions,
+  validateLibrarianPromptTemplate,
+} from '@equationalapplications/core-llm-wiki';
+
+const options = {
+  entityWeights: { tier_wisdom: 2, tier_fact: 1, tier_working: 0.25 },
+  systemPrompt: `You are a strict fact checker.
+Question:
+{{query}}
+
+Retrieved context:
+{{context}}
+
+Open tasks:
+{{tasks}}`,
+};
+
+const memory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], query, {
+  ...mapLibrarianOptionsToReadOptions(options),
+  maxResults: 8,
+});
+
+const template = options.systemPrompt ?? DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT;
+const warnings = validateLibrarianPromptTemplate(template, {
+  custom: options.systemPrompt != null,
+  taskCount: memory.tasks.length,
+});
+
+for (const warning of warnings) console.warn(warning);
+
+const finalPrompt = hydrateLibrarianPrompt(template, {
+  query,
+  context: formatContext(memory, { includeEntityIds: true, includeFactScores: true }),
+  tasks: formatContext({ facts: [], tasks: memory.tasks, events: [] }, { format: 'plain' }),
+});
+```
+
 ## Adapter Interface
 
 Implement `SQLiteAdapter` to use your platform's SQLite driver:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -400,7 +400,7 @@ const memory = await wikiMemory.read('user-123', 'coding style preferences');
 
 ### Multi-entity weighted reads
 
-`read()` accepts either one entity id or an array of entity ids. Array reads merge fact candidates globally before `maxResults` is applied. Tasks and events are collected globally under shared caps (`min(20 × entity count, 200)` tasks; `min(10 × entity count, 100)` events) — individual entities are not guaranteed representation in the returned bundle.
+`read()` accepts either one entity id or an array of entity ids. Facts are always merged globally before `maxResults` is applied. For single-entity reads, tasks are uncapped and events are capped at 10. For multi-entity reads, tasks are capped at `min(20 × entity count, 200)` and events at `min(10 × entity count, 100)` — per-entity representation in the returned bundle is not guaranteed.
 
 ```ts
 const memory = await wikiMemory.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'Which source should I trust?', {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -438,7 +438,6 @@ Question:
 Retrieved context:
 {{context}}
 
-Open tasks:
 {{tasks}}`,
 };
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -403,7 +403,7 @@ const memory = await wikiMemory.read('user-123', 'coding style preferences');
 `read()` accepts either one entity id or an array of entity ids. Array reads merge fact candidates globally before `maxResults` is applied. Tasks and events are collected globally under shared caps (`min(20 × entity count, 200)` tasks; `min(10 × entity count, 100)` events) — individual entities are not guaranteed representation in the returned bundle.
 
 ```ts
-const memory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'Which source should I trust?', {
+const memory = await wikiMemory.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'Which source should I trust?', {
   maxResults: 8,
   tierWeights: {
     tier_wisdom: 2,
@@ -442,7 +442,9 @@ Open tasks:
 {{tasks}}`,
 };
 
-const memory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], query, {
+const query = 'Which source should I trust for recent project decisions?';
+
+const memory = await wikiMemory.read(['tier_wisdom', 'tier_fact', 'tier_working'], query, {
   ...mapLibrarianOptionsToReadOptions(options),
   maxResults: 8,
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -400,7 +400,7 @@ const memory = await wikiMemory.read('user-123', 'coding style preferences');
 
 ### Multi-entity weighted reads
 
-`read()` accepts either one entity id or an array of entity ids. Array reads merge fact candidates globally before `maxResults` is applied, while tasks and events are returned for every requested entity.
+`read()` accepts either one entity id or an array of entity ids. Array reads merge fact candidates globally before `maxResults` is applied. Tasks and events are collected globally under shared caps (`min(20 × entity count, 200)` tasks; `min(10 × entity count, 100)` events) — individual entities are not guaranteed representation in the returned bundle.
 
 ```ts
 const memory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'Which source should I trust?', {

--- a/packages/core/__tests__/formatContext.test.ts
+++ b/packages/core/__tests__/formatContext.test.ts
@@ -299,4 +299,28 @@ describe('formatContext', () => {
     expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxEvents: -1 }))
       .toThrow('Invalid maxEvents: must be a non-negative finite number');
   });
+
+  it('can include fact entity_id provenance', () => {
+    const result = formatContext({ facts: [makeFact({ entity_id: 'tier_wisdom' })], tasks: [], events: [] }, {
+      includeEntityIds: true,
+    });
+    expect(result).toContain('{entity_id=tier_wisdom}');
+  });
+
+  it('can include weighted fact scores and preserve bundle fact order', () => {
+    const bundle: MemoryBundle = {
+      facts: [
+        makeFact({ id: 'low', title: 'Low', access_count: 100 }),
+        makeFact({ id: 'high', title: 'High', access_count: 0 }),
+      ],
+      tasks: [],
+      events: [],
+      factScores: { low: 0.1, high: 2 },
+    };
+
+    const result = formatContext(bundle, { includeFactScores: true });
+    expect(result.indexOf('Low')).toBeLessThan(result.indexOf('High'));
+    expect(result).toContain('{score=0.1000}');
+    expect(result).toContain('{score=2.0000}');
+  });
 });

--- a/packages/core/__tests__/librarianPrompt.test.ts
+++ b/packages/core/__tests__/librarianPrompt.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT,
+  hydrateLibrarianPrompt,
+  mapLibrarianOptionsToReadOptions,
+  validateLibrarianPromptTemplate,
+} from '../src/librarianPrompt';
+
+describe('librarian prompt contract utilities', () => {
+  it('default prompt includes the stable template variables', () => {
+    expect(DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT).toContain('{{query}}');
+    expect(DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT).toContain('{{context}}');
+    expect(DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT).toContain('{{tasks}}');
+  });
+
+  it('hydrates query, context, and tasks without changing instructions', () => {
+    const prompt = hydrateLibrarianPrompt('Q: {{query}}\nC: {{context}}\nT: {{tasks}}', {
+      query: 'Which source should I trust?',
+      context: '- fact',
+      tasks: '- task',
+    });
+
+    expect(prompt).toBe('Q: Which source should I trust?\nC: - fact\nT: - task');
+  });
+
+  it('warns when a custom prompt omits context or query', () => {
+    expect(validateLibrarianPromptTemplate('Only tasks: {{tasks}}', { custom: true, taskCount: 1 }))
+      .toEqual([
+        'Custom Librarian systemPrompt omits {{context}}; retrieved memory will not be injected.',
+        'Custom Librarian systemPrompt omits {{query}}; the original request will not be injected.',
+      ]);
+  });
+
+  it('warns about omitted tasks only when tasks exist', () => {
+    expect(validateLibrarianPromptTemplate('{{query}} {{context}}', { custom: true, taskCount: 2 }))
+      .toEqual(['Custom Librarian systemPrompt omits {{tasks}} while retrieved tasks are available.']);
+    expect(validateLibrarianPromptTemplate('{{query}} {{context}}', { custom: true, taskCount: 0 }))
+      .toEqual([]);
+  });
+
+  it('maps app-facing entityWeights to read tierWeights', () => {
+    expect(mapLibrarianOptionsToReadOptions({
+      entityWeights: { tier_wisdom: 2 },
+      includeZeroWeightEntities: true,
+      temperature: 0.2,
+    })).toEqual({
+      tierWeights: { tier_wisdom: 2 },
+      includeZeroWeightEntities: true,
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { WikiMemory } from './WikiMemory';
 export { formatContext } from './utils/formatContext';
 export { formatMemoryDump } from './utils/formatMemoryDump';
 export { parseEmbedding } from './utils/embedding';
+export * from './librarianPrompt';
 
 export function createWiki(db: SQLiteAdapter, options: WikiOptions): WikiMemory {
   return new WikiMemory(db, options);

--- a/packages/core/src/librarianPrompt.ts
+++ b/packages/core/src/librarianPrompt.ts
@@ -1,0 +1,70 @@
+import type { ReadOptions } from './types';
+
+export interface LibrarianOptions {
+  /** If provided, replaces the default Librarian system instructions. */
+  systemPrompt?: string;
+  /** entity_id -> score multiplier, forwarded to WikiMemory.read() as tierWeights. */
+  entityWeights?: Record<string, number>;
+  /** Forwarded to WikiMemory.read() for zero-weight filler context. */
+  includeZeroWeightEntities?: boolean;
+  temperature?: number;
+}
+
+export interface LibrarianPromptVariables {
+  context: string;
+  tasks: string;
+  query: string;
+}
+
+export const DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT = `You are a careful memory synthesis assistant.
+Use only the retrieved context when answering the request.
+Preserve source provenance when facts come from different entity namespaces.
+
+Request:
+{{query}}
+
+Retrieved context:
+{{context}}
+
+Open tasks:
+{{tasks}}`;
+
+export function hydrateLibrarianPrompt(
+  template: string,
+  variables: LibrarianPromptVariables,
+): string {
+  return template
+    .replace(/\{\{context\}\}/g, variables.context)
+    .replace(/\{\{tasks\}\}/g, variables.tasks)
+    .replace(/\{\{query\}\}/g, variables.query);
+}
+
+export function validateLibrarianPromptTemplate(
+  template: string,
+  options: { custom: boolean; taskCount: number },
+): string[] {
+  if (!options.custom) return [];
+
+  const warnings: string[] = [];
+  if (!template.includes('{{context}}')) {
+    warnings.push('Custom Librarian systemPrompt omits {{context}}; retrieved memory will not be injected.');
+  }
+  if (!template.includes('{{query}}')) {
+    warnings.push('Custom Librarian systemPrompt omits {{query}}; the original request will not be injected.');
+  }
+  if (options.taskCount > 0 && !template.includes('{{tasks}}')) {
+    warnings.push('Custom Librarian systemPrompt omits {{tasks}} while retrieved tasks are available.');
+  }
+  return warnings;
+}
+
+export function mapLibrarianOptionsToReadOptions(
+  options: Pick<LibrarianOptions, 'entityWeights' | 'includeZeroWeightEntities'>,
+): Pick<ReadOptions, 'tierWeights' | 'includeZeroWeightEntities'> {
+  const readOptions: Pick<ReadOptions, 'tierWeights' | 'includeZeroWeightEntities'> = {};
+  if (options.entityWeights !== undefined) readOptions.tierWeights = options.entityWeights;
+  if (options.includeZeroWeightEntities !== undefined) {
+    readOptions.includeZeroWeightEntities = options.includeZeroWeightEntities;
+  }
+  return readOptions;
+}

--- a/packages/core/src/librarianPrompt.ts
+++ b/packages/core/src/librarianPrompt.ts
@@ -33,10 +33,7 @@ export function hydrateLibrarianPrompt(
   template: string,
   variables: LibrarianPromptVariables,
 ): string {
-  return template
-    .replace(/\{\{context\}\}/g, variables.context)
-    .replace(/\{\{tasks\}\}/g, variables.tasks)
-    .replace(/\{\{query\}\}/g, variables.query);
+  return template.replace(/\{\{(context|tasks|query)\}\}/g, (_, key) => variables[key as keyof LibrarianPromptVariables]);
 }
 
 export function validateLibrarianPromptTemplate(
@@ -59,7 +56,7 @@ export function validateLibrarianPromptTemplate(
 }
 
 export function mapLibrarianOptionsToReadOptions(
-  options: Pick<LibrarianOptions, 'entityWeights' | 'includeZeroWeightEntities'>,
+  options: LibrarianOptions,
 ): Pick<ReadOptions, 'tierWeights' | 'includeZeroWeightEntities'> {
   const readOptions: Pick<ReadOptions, 'tierWeights' | 'includeZeroWeightEntities'> = {};
   if (options.entityWeights !== undefined) readOptions.tierWeights = options.entityWeights;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -327,6 +327,8 @@ export interface FormatContextOptions {
   maxEvents?: number;
   includeConfidence?: boolean;
   includeTags?: boolean;
+  includeEntityIds?: boolean;
+  includeFactScores?: boolean;
   factWeights?: {
     confidence?: number;
     accessCount?: number;

--- a/packages/core/src/utils/formatContext.ts
+++ b/packages/core/src/utils/formatContext.ts
@@ -30,23 +30,29 @@ function scoreFactFor(
 function renderFactMarkdown(
   fact: WikiFact,
   includeConfidence: boolean,
-  includeTags: boolean
+  includeTags: boolean,
+  includeEntityIds: boolean,
+  score: number | undefined,
 ): string {
   const confPart = includeConfidence ? ` (${fact.confidence})` : '';
-  const tagPart =
-    includeTags && fact.tags.length > 0 ? ` [${fact.tags.join(', ')}]` : '';
-  return `- **${fact.title}**${confPart}${tagPart}\n  ${fact.body.replace(/\n/g, '\n  ')}`;
+  const tagPart = includeTags && fact.tags.length > 0 ? ` [${fact.tags.join(', ')}]` : '';
+  const sourcePart = includeEntityIds ? ` {entity_id=${fact.entity_id}}` : '';
+  const scorePart = score !== undefined ? ` {score=${score.toFixed(4)}}` : '';
+  return `- **${fact.title}**${confPart}${tagPart}${sourcePart}${scorePart}\n  ${fact.body.replace(/\n/g, '\n  ')}`;
 }
 
 function renderFactPlain(
   fact: WikiFact,
   includeConfidence: boolean,
-  includeTags: boolean
+  includeTags: boolean,
+  includeEntityIds: boolean,
+  score: number | undefined,
 ): string {
   const confPart = includeConfidence ? ` (${fact.confidence})` : '';
-  const tagPart =
-    includeTags && fact.tags.length > 0 ? ` [${fact.tags.join(', ')}]` : '';
-  return `${fact.title}${confPart}${tagPart}: ${fact.body}`;
+  const tagPart = includeTags && fact.tags.length > 0 ? ` [${fact.tags.join(', ')}]` : '';
+  const sourcePart = includeEntityIds ? ` {entity_id=${fact.entity_id}}` : '';
+  const scorePart = score !== undefined ? ` {score=${score.toFixed(4)}}` : '';
+  return `${fact.title}${confPart}${tagPart}${sourcePart}${scorePart}: ${fact.body}`;
 }
 
 function renderTaskMarkdown(task: WikiTask): string {
@@ -78,6 +84,8 @@ export function formatContext(
     maxEvents: options?.maxEvents ?? 10,
     includeConfidence: options?.includeConfidence ?? true,
     includeTags: options?.includeTags ?? true,
+    includeEntityIds: options?.includeEntityIds ?? false,
+    includeFactScores: options?.includeFactScores ?? false,
     factWeights: {
       confidence: options?.factWeights?.confidence ?? 1.0,
       accessCount: options?.factWeights?.accessCount ?? 0.3,
@@ -92,9 +100,11 @@ export function formatContext(
   const weights = opts.factWeights as Required<NonNullable<FormatContextOptions['factWeights']>>;
 
   const now = Date.now();
-  const sortedFacts = [...bundle.facts]
-    .sort((a, b) => scoreFactFor(b, weights, now) - scoreFactFor(a, weights, now))
-    .slice(0, opts.maxFacts);
+  const sortedFacts = bundle.factScores
+    ? [...bundle.facts].slice(0, opts.maxFacts)
+    : [...bundle.facts]
+        .sort((a, b) => scoreFactFor(b, weights, now) - scoreFactFor(a, weights, now))
+        .slice(0, opts.maxFacts);
 
   const sortedTasks = [...bundle.tasks]
     .sort((a, b) => b.priority - a.priority || a.created_at - b.created_at)
@@ -118,7 +128,7 @@ export function formatContext(
       lines.push('');
       lines.push('### Known Facts');
       for (const fact of sortedFacts) {
-        lines.push(renderFactMarkdown(fact, opts.includeConfidence, opts.includeTags));
+        lines.push(renderFactMarkdown(fact, opts.includeConfidence, opts.includeTags, opts.includeEntityIds, opts.includeFactScores ? bundle.factScores?.[fact.id] : undefined));
       }
     }
 
@@ -141,7 +151,7 @@ export function formatContext(
     if (sortedFacts.length > 0) {
       lines.push('KNOWN FACTS:');
       for (const fact of sortedFacts) {
-        lines.push(renderFactPlain(fact, opts.includeConfidence, opts.includeTags));
+        lines.push(renderFactPlain(fact, opts.includeConfidence, opts.includeTags, opts.includeEntityIds, opts.includeFactScores ? bundle.factScores?.[fact.id] : undefined));
       }
     }
     if (sortedTasks.length > 0) {


### PR DESCRIPTION
## Summary


Implements Phase 4 of the multi-entity weighted retrieval spec [docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md](docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md).

- Add `librarianPrompt.ts` with `LibrarianOptions`, `DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT`, `hydrateLibrarianPrompt`, `validateLibrarianPromptTemplate`, and `mapLibrarianOptionsToReadOptions` — reusable prompt-contract utilities for downstream synthesis layers
- Extend `formatContext` with `includeEntityIds` and `includeFactScores` options; preserve weighted bundle order when `factScores` present
- Document multi-entity weighted reads and the librarian prompt override pattern in `README.md`

## Test Plan

- [ ] `pnpm --filter @equationalapplications/core-llm-wiki exec vitest run __tests__/librarianPrompt.test.ts __tests__/formatContext.test.ts` — 29 tests pass
- [ ] `pnpm --filter @equationalapplications/core-llm-wiki typecheck` — clean
- [ ] `pnpm --filter @equationalapplications/core-llm-wiki test` — 296/296 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)