### PR TITLE
feat(core): support multi-entity ranker retrieval

### DIFF
--- a/packages/core/__tests__/multiEntityVectorRanker.test.ts
+++ b/packages/core/__tests__/multiEntityVectorRanker.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WikiMemory } from '../src/WikiMemory';
+import { openTestDatabase } from './helpers/sqliteAdapter';
+import type { VectorRanker, WikiOptions } from '../src/types';
+
+function keywordEmbed(text: string): number[] {
+  if (text.includes('apple')) return [1, 0, 0];
+  return [0, 1, 0];
+}
+
+async function insertFact(
+  db: ReturnType<typeof openTestDatabase>,
+  id: string,
+  entityId: string,
+  title: string,
+  vec: number[] | null,
+) {
+  const blob = vec ? new Uint8Array(new Float32Array(vec).buffer) : null;
+  await db.runAsync(
+    `INSERT INTO llm_wiki_entries (id, entity_id, title, body, tags, confidence, source_type, created_at, updated_at, embedding_blob)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, entityId, title, 'body', '[]', 'certain', 'user_stated', 1000, 1000, blob],
+  );
+}
+
+function makeWiki(options: Partial<WikiOptions>) {
+  const db = openTestDatabase();
+  const wiki = new WikiMemory(db, {
+    llmProvider: { generateText: async () => '{}', embed: async text => keywordEmbed(text) },
+    ...options,
+  });
+  return { wiki, db };
+}
+
+describe('multi-entity vector ranker retrieval', () => {
+  it('calls vectorRanker once per requested entity and merges weighted scores globally', async () => {
+    const calls: Array<{ entityId: string; candidateIds?: readonly string[] }> = [];
+    const ranker: VectorRanker = {
+      rankBySimilarity: async (args) => {
+        calls.push({ entityId: args.entityId, candidateIds: args.candidateIds });
+        if (args.entityId === 'tier_wisdom') return [{ id: 'wisdom-1', semanticScore: 0.6 }];
+        if (args.entityId === 'tier_fact') return [{ id: 'fact-1', semanticScore: 0.9 }];
+        return [];
+      },
+    };
+    const { wiki, db } = makeWiki({ vectorRanker: ranker });
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', [1, 0, 0]);
+    await insertFact(db, 'fact-1', 'tier_fact', 'apple fact', [1, 0, 0]);
+
+    const result = await wiki.read(['tier_wisdom', 'tier_fact'], 'apple', {
+      maxResults: 1,
+      tierWeights: { tier_wisdom: 2, tier_fact: 1 },
+    });
+
+    expect(calls.map(call => call.entityId)).toEqual(['tier_wisdom', 'tier_fact']);
+    expect(result.facts.map(f => f.id)).toEqual(['wisdom-1']);
+    expect(result.factScores).toEqual({ 'wisdom-1': 1.2 });
+  });
+
+  it('passes per-entity prefilter ids to vectorRanker', async () => {
+    const ranker = {
+      rankBySimilarity: vi.fn(async (args) => args.candidateIds?.map(id => ({ id, semanticScore: 0.5 })) ?? []),
+    } satisfies VectorRanker;
+    const { wiki, db } = makeWiki({ vectorRanker: ranker });
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-apple', 'tier_wisdom', 'apple wisdom', [1, 0, 0]);
+    await insertFact(db, 'fact-apple', 'tier_fact', 'apple fact', [1, 0, 0]);
+    await insertFact(db, 'fact-car', 'tier_fact', 'car fact', [0, 1, 0]);
+    await wiki.setup(); // rebuild MiniSearch after direct DB inserts
+
+    await wiki.read(['tier_wisdom', 'tier_fact'], 'apple', { preFilterLimit: 10 });
+
+    expect(ranker.rankBySimilarity.mock.calls).toHaveLength(2);
+    expect(ranker.rankBySimilarity.mock.calls[0][0].candidateIds).toEqual(['wisdom-apple']);
+    expect(ranker.rankBySimilarity.mock.calls[1][0].candidateIds).toEqual(['fact-apple']);
+  });
+
+  it('ranker js-cosine fallback hydrates embeddings by selected ids without an entity_id guard', async () => {
+    const ranker: VectorRanker = {
+      rankBySimilarity: async () => { throw new Error('ranker unavailable'); },
+    };
+    const { wiki, db } = makeWiki({ vectorRanker: ranker, vectorRankerFallback: 'js-cosine' });
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', [1, 0, 0]);
+    await insertFact(db, 'fact-1', 'tier_fact', 'apple fact', [0.8, 0, 0]);
+
+    const result = await wiki.read(['tier_wisdom', 'tier_fact'], 'apple', { maxResults: 2 });
+
+    expect(result.facts.map(f => f.id)).toContain('wisdom-1');
+    expect(result.facts.map(f => f.id)).toContain('fact-1');
+    expect(result.facts).toHaveLength(2);
+  });
+
+  it('dimension mismatch in any requested entity causes one keyword fallback for the whole read', async () => {
+    const fallbackErrors: Error[] = [];
+    const { wiki, db } = makeWiki({ onRetrievalFallback: error => fallbackErrors.push(error) });
+    await wiki.setup();
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '3')`);
+    await insertFact(db, 'wisdom-1', 'tier_wisdom', 'apple wisdom', [1, 0, 0]);
+    await insertFact(db, 'fact-mismatch', 'tier_fact', 'apple fact', [1, 0]);
+    await wiki.setup(); // rebuild MiniSearch after direct DB inserts
+
+    const result = await wiki.read(['tier_wisdom', 'tier_fact'], 'apple');
+
+    expect(fallbackErrors).toHaveLength(1);
+    expect(fallbackErrors[0].message).toMatch(/do not match the current model dimension/i);
+    expect(result.facts.map(f => f.id)).toContain('wisdom-1');
+    expect(result.facts.map(f => f.id)).toContain('fact-mismatch');
+  });
+});

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1407,7 +1407,8 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                   // Oversample so tier weights can re-rank before the global slice
                   const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
                   const topResults = msResults.slice(0, keywordOversampledLimit);
-                  const candidateMap = new Map(candidateRows.map(row => [row.id, row]));
+                  const topResultIds = new Set(topResults.map(r => r.id));
+                  const candidateMap = new Map(candidateRows.filter(r => topResultIds.has(r.id)).map(row => [row.id, row]));
                   scored = topResults.map(result => {
                     const metadata = candidateMap.get(result.id);
                     const entityForScore = metadata?.entity_id

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1078,17 +1078,17 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             }
           }
 
-          // Check whether any non-deleted fact for any scored entity has a blob whose
-          // dimension differs from the query vector. Scoped to scoredEntityIds so a
-          // zero-weight entity's stale embeddings don't force keyword fallback.
-          const entityScope = this._entityInClause(scoredEntityIds);
+          // Check whether any non-deleted fact for any requested entity has a blob whose
+          // dimension differs from the query vector. Uses all entityIds (not just
+          // scoredEntityIds) so a caller requesting a namespace always gets fail-safe scoring.
+          const mismatchScope = this._entityInClause(entityIds);
           const mismatchedCount = await this.db.getFirstAsync<{ cnt: number }>(
             `SELECT COUNT(*) AS cnt FROM ${this.prefix}entries
-             WHERE ${entityScope.clause} AND deleted_at IS NULL
+             WHERE ${mismatchScope.clause} AND deleted_at IS NULL
                AND embedding_blob IS NOT NULL
                AND (CAST(length(embedding_blob) AS INTEGER) % 4 = 0)
                AND (CAST(length(embedding_blob) AS INTEGER) / 4) != ?`,
-            [...entityScope.params, queryVec.length]
+            [...mismatchScope.params, queryVec.length]
           );
           if (mismatchedCount && mismatchedCount.cnt > 0) {
             throw new Error(
@@ -1190,43 +1190,46 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
             let scored: Array<{ id: string; entity_id: string; score: number; updated_at?: number | null; access_count?: number | null }>;
 
             if (useRanker) {
-              // Use external ranker for semantic scoring.
-              // Pass candidateIds for multi-entity reads (entityCacheKey is a composite join string,
-              // not a real namespace) and pre-filtered reads (results already scoped to subset).
-              // For single-entity full-scan, omit so remote rankers avoid transmitting the full
-              // candidate list and can scope by entityId instead.
-              const candidateIds = entityIds.length > 1 || effectivePreFilterLimit !== undefined
-                ? candidateRows.map(r => r.id)
-                : undefined;
+              // Build per-entity candidate maps so each ranker call receives one entityId.
+              const candidateRowsByEntity = new Map<string, ReadCandidateRowMetadata[]>();
+              for (const row of candidateRows as ReadCandidateRowMetadata[]) {
+                const rows = candidateRowsByEntity.get(row.entity_id) ?? [];
+                rows.push(row);
+                candidateRowsByEntity.set(row.entity_id, rows);
+              }
 
               try {
-                // Oversample by max(2x, +50) to preserve recall after re-ranking;
-                // caller slices final output to maxResults.
-                const oversampledLimit = Math.max(maxResults * 2, maxResults + 50);
-                scored = await this._rankWithVectorRanker({
-                  entityId: entityCacheKey,
-                  queryVec,
-                  candidateIds,
-                  candidateRows: candidateRows as ReadCandidateRowMetadata[],
-                  weight,
-                  miniSearchScores,
-                  limit: oversampledLimit,
-                });
+                const rankerResultsByEntity = await Promise.all(
+                  scoredEntityIds.map(async scopedEntityId => {
+                    const rowsForEntity = candidateRowsByEntity.get(scopedEntityId) ?? [];
+                    const candidateIds = effectivePreFilterLimit !== undefined
+                      ? rowsForEntity.map(row => row.id)
+                      : undefined;
+                    const ranked = await this._rankWithVectorRanker({
+                      entityId: scopedEntityId,
+                      queryVec,
+                      candidateIds,
+                      candidateRows: rowsForEntity,
+                      weight,
+                      miniSearchScores,
+                      limit: Math.max(maxResults * 2, maxResults + 50),
+                    });
+                    return ranked.map(row => ({ ...row, entity_id: scopedEntityId }));
+                  }),
+                );
 
-                // Attach tie-break metadata from candidateRows (only for IDs returned by ranker)
-                if (scored.length > 0) {
-                  const scoredIds = new Set(scored.map(s => s.id));
-                  const metaMap = new Map<string, { updated_at: number | null; access_count: number | null }>();
-                  for (const r of candidateRows) {
-                    if (scoredIds.has(r.id)) {
-                      metaMap.set(r.id, { updated_at: r.updated_at, access_count: r.access_count });
-                    }
-                  }
-                  scored = scored.map(s => {
-                    const meta = metaMap.get(s.id);
-                    return { ...s, updated_at: meta?.updated_at ?? null, access_count: meta?.access_count ?? null };
-                  });
-                }
+                scored = rankerResultsByEntity.flat();
+
+                // Attach tie-break metadata by ID from the full candidateRows pool
+                const metadataById = new Map(candidateRows.map(row => [row.id, row]));
+                scored = scored.map(row => {
+                  const metadata = metadataById.get(row.id);
+                  return {
+                    ...row,
+                    updated_at: metadata?.updated_at ?? null,
+                    access_count: metadata?.access_count ?? null,
+                  };
+                });
 
                 // Backfill ranker-omitted rows per VectorRanker contract:
                 // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
@@ -1399,22 +1402,18 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
                   // Oversample so tier weights can re-rank before the global slice
                   const keywordOversampledLimit = Math.max(maxResults * 2, maxResults + 50);
                   const topResults = msResults.slice(0, keywordOversampledLimit);
-                  // Build metadata map only for returned IDs (not all candidates)
-                  const resultIds = new Set(topResults.map(r => r.id));
-                  const candidateMap = new Map<string, { entity_id: string; updated_at: number | null; access_count: number | null }>();
-                  for (const r of candidateRows) {
-                    if (resultIds.has(r.id)) {
-                      candidateMap.set(r.id, { entity_id: r.entity_id, updated_at: r.updated_at, access_count: r.access_count });
-                    }
-                  }
-                  scored = topResults.map(r => {
-                    const meta = candidateMap.get(r.id);
+                  const candidateMap = new Map(candidateRows.map(row => [row.id, row]));
+                  scored = topResults.map(result => {
+                    const metadata = candidateMap.get(result.id);
+                    const entityForScore = metadata?.entity_id
+                      ?? (result as unknown as { entity_id: string }).entity_id
+                      ?? '';
                     return {
-                      id: r.id,
-                      entity_id: meta?.entity_id ?? (r as unknown as { entity_id: string }).entity_id,
-                      score: r.score ?? 0,
-                      access_count: meta?.access_count ?? null,
-                      updated_at: meta?.updated_at ?? null,
+                      id: result.id,
+                      entity_id: entityForScore,
+                      score: result.score ?? 0,
+                      access_count: metadata?.access_count ?? null,
+                      updated_at: metadata?.updated_at ?? null,
                     };
                   });
                 } else {

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1200,7 +1200,7 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
               try {
                 const rankerResultsByEntity = await Promise.all(
-                  scoredEntityIds.map(async scopedEntityId => {
+                  scoredEntityIds.filter(id => (candidateRowsByEntity.get(id)?.length ?? 0) > 0).map(async scopedEntityId => {
                     const rowsForEntity = candidateRowsByEntity.get(scopedEntityId) ?? [];
                     const candidateIds = effectivePreFilterLimit !== undefined
                       ? rowsForEntity.map(row => row.id)
@@ -1220,8 +1220,14 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
                 scored = rankerResultsByEntity.flat();
 
-                // Attach tie-break metadata by ID from the full candidateRows pool
-                const metadataById = new Map(candidateRows.map(row => [row.id, row]));
+                // Build metadata map only for IDs returned by the ranker (not all candidates)
+                // to keep memory proportional to the oversampled result size on constrained runtimes.
+                const scoredIds = new Set(scored.map(s => s.id));
+                const metadataById = new Map(
+                  (candidateRows as ReadCandidateRowMetadata[])
+                    .filter(row => scoredIds.has(row.id))
+                    .map(row => [row.id, row])
+                );
                 scored = scored.map(row => {
                   const metadata = metadataById.get(row.id);
                   return {
@@ -1233,7 +1239,6 @@ UPDATE ${this.prefix}entries SET source_type = 'librarian_inferred' WHERE source
 
                 // Backfill ranker-omitted rows per VectorRanker contract:
                 // treat missing ids as "no embedding" (pure semantic: -2, hybrid: keyword-only)
-                const scoredIds = new Set(scored.map(s => s.id));
 
                 // Compute backfill budget up-front.
                 // Hybrid mode: allow up to maxResults keyword-only rows to compete.


### PR DESCRIPTION
## Summary

Implements Phase 3 of the multi-entity weighted retrieval spec [docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md](docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md).

- Call `rankBySimilarity()` once per entity via `Promise.all`, replacing single composite-key ranker call; merge weighted results globally
- Widen dimension-mismatch check to all requested `entityIds` (not just non-zero-weight ones) for fail-safe fallback
- Fix keyword fallback path: raw MiniSearch scores with correct `entity_id` attribution; global pass applies tier weights once

## Test Plan

- [ ] `pnpm --filter @equationalapplications/core-llm-wiki exec vitest run __tests__/multiEntityVectorRanker.test.ts` — 4 new tests pass
- [ ] `pnpm --filter @equationalapplications/core-llm-wiki test` — 293 tests pass
- [ ] `pnpm --filter @equationalapplications/core-llm-wiki typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)