### PR TITLE
fix(react): finalize multi-entity weighted retrieval - align hook dep key with core behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ expo-llm-wiki is a cross-platform TypeScript and SQLite library for long-term LL
 
 - **Bring Your Own Inference (BYOI):** Provide one `generateText` function. The package owns prompt construction, JSON parsing, and database writes.
 - **Namespace Safe:** All tables are prefixed (default: `llm_wiki_`) — no collisions with your existing database.
-- **Multi-Entity:** Multiple independent "brains" in one database via `entityId`.
+- **Multi-Entity:** Multiple independent "brains" in one database. `read()` accepts a single `entityId` string or an array for cross-namespace retrieval with per-entity `tierWeights`.
 - **Semantic Retrieval:** Supply an optional `embed()` function on `LLMProvider` to rank facts by vector cosine similarity. Falls back to MiniSearch keyword search when `embed` is absent or offline.
 - **Offline First:** The MiniSearch fallback runs entirely in-process with no network required. The cosine similarity path requires `embed()` to vectorise the query (typically a cloud API call) but falls back to MiniSearch automatically when offline or when `embed` throws.
 - **Full Unicode Support:** UTF-8 and UTF-16 (including surrogate pairs for emoji) are fully supported. Chunks are split safely at sentence boundaries; surrogate pairs are never fragmented.
@@ -37,7 +37,7 @@ flowchart TB
         ingest["ingestDocument()"]
         librarian["runLibrarian()"]
         heal["runHeal()"]
-        read["read(entityId, query)"]
+        read["read(entityId | entityId[], query, options?)"]
         reembed["runReembed()"]
     end
 
@@ -347,7 +347,29 @@ const overrideResult = await wiki.read('entity-123', 'weekend plans', {
   hybridWeight: 0.5,      // 50/50 semantic + keyword blend
   // preFilterLimit: null — explicitly disable a config-level preFilterLimit for this call
 });
+
+// Multi-entity read: search across namespaces in one pass
+const multiResult = await wiki.read(
+  ['tier_wisdom', 'tier_fact', 'tier_working'],
+  'weekend plans',
+  {
+    maxResults: 8,
+    tierWeights: {
+      tier_wisdom: 2,      // boost curated notes 2×
+      tier_fact: 1,        // neutral baseline
+      tier_working: 0.25,  // downrank unvetted working memory
+    },
+    // includeZeroWeightEntities: true — include 0-weight entities as bottom filler
+  }
+);
+// multiResult.factScores — Record<factId, weightedScore> (array entityId calls only)
+// multiResult.metadata  — { query, entityIds, tierWeights }
+// tasks capped at min(20 × entityCount, 200); events at min(10 × entityCount, 100)
 ```
+
+### Multi-Entity Weighted Reads
+
+`read()` also accepts `entityId` as an array, merging results across namespaces in one retrieval pass. Use `tierWeights` to boost or downrank individual entity namespaces before the final top-K slice.
 
 Pass an empty string to skip search and return the most recently updated facts.
 
@@ -414,6 +436,8 @@ const context = formatContext(bundle, {
   maxEvents: 10,             // default 10
   includeConfidence: true,   // default true — appends (certain/inferred/tentative)
   includeTags: true,         // default true — appends [tag1, tag2]
+  includeEntityIds: true,    // default false — appends [entity_id] for provenance in multi-entity reads
+  includeFactScores: true,   // default false — appends weighted score when factScores present
   factWeights: {
     confidence: 1.0,         // default 1.0
     accessCount: 0.3,        // default 0.3 — log(1 + access_count) * weight
@@ -424,6 +448,36 @@ const context = formatContext(bundle, {
 // Inject into your system prompt:
 const systemPrompt = `You are a helpful assistant.\n\n${context}`;
 ```
+
+### Librarian Prompt Utilities
+
+Core exports prompt utilities for weighted retrieval-based synthesis. Use `mapLibrarianOptionsToReadOptions()` to map `entityWeights` to `tierWeights`, then hydrate a prompt with `query`, `context`, and `tasks`.
+
+```typescript
+import {
+  DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT,
+  formatContext,
+  hydrateLibrarianPrompt,
+  mapLibrarianOptionsToReadOptions,
+  validateLibrarianPromptTemplate,
+} from '@equationalapplications/core-llm-wiki';
+
+const memory = await wiki.read(['tier_wisdom', 'tier_fact'], query, {
+  ...mapLibrarianOptionsToReadOptions({
+    entityWeights: { tier_wisdom: 2, tier_fact: 1 },
+  }),
+  maxResults: 8,
+});
+
+const template = DEFAULT_LIBRARIAN_SYNTHESIS_PROMPT;
+const finalPrompt = hydrateLibrarianPrompt(template, {
+  query,
+  context: formatContext(memory, { includeEntityIds: true, includeFactScores: true }),
+  tasks: formatContext({ facts: [], tasks: memory.tasks, events: [] }, { format: 'plain' }),
+});
+```
+
+For full examples, template-warning guidance, and the override contract, see [`packages/core/README.md`](packages/core/README.md#librarian-prompt-override-contract).
 
 Facts are ranked by a weighted score combining confidence tier, access frequency, and recency. Returns an empty string for an empty bundle.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ expo-llm-wiki is a cross-platform TypeScript and SQLite library for long-term LL
 - **Semantic Retrieval:** Supply an optional `embed()` function on `LLMProvider` to rank facts by vector cosine similarity. Falls back to MiniSearch keyword search when `embed` is absent or offline.
 - **Offline First:** The MiniSearch fallback runs entirely in-process with no network required. The cosine similarity path requires `embed()` to vectorise the query (typically a cloud API call) but falls back to MiniSearch automatically when offline or when `embed` throws.
 - **Full Unicode Support:** UTF-8 and UTF-16 (including surrogate pairs for emoji) are fully supported. Chunks are split safely at sentence boundaries; surrogate pairs are never fragmented.
+- **Immutable vs mutable memory:** Every fact includes `source_type`. Facts from `ingestDocument()` are stored as `immutable_document` and are preserved from librarian/heal rewriting; they can only be removed with `forget()` or replaced via re-ingest. Derived or user assertions are mutable (`librarian_inferred`, `user_stated`, `user_confirmed`) and can be updated by healer/librarian workflows.
 - **Cross-Platform:** Choose the right package for your platform: Expo, React Native, React web, vanilla JS, or Node.js. The core logic is framework-agnostic with platform-specific adapters.
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ const multiResult = await wiki.read(
     // includeZeroWeightEntities: true — include 0-weight entities as bottom filler
   }
 );
-// multiResult.factScores — Record<factId, weightedScore> (array entityId calls only)
+// multiResult.factScores — Record<factId, weightedScore> | undefined (array entityId only, populated when query is non-empty and at least one fact scored)
 // multiResult.metadata  — { query, entityIds, tierWeights }
 // tasks capped at min(20 × entityCount, 200); events at min(10 × entityCount, 100)
 ```

--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -46,26 +46,16 @@ Curated Thoughts also needs the synthesis prompt to be replaceable. Different pr
 ### `read()` Signature
 
 ```typescript
-// Phase 1 (current): entityId is string only
 async read(
-  entityId: string,
+  entityId: string | string[],
   query: string,
   options?: ReadOptions
 ): Promise<MemoryBundle>
-
-// Phase 2+ (planned): entityId will accept string | string[]
-// async read(
-//   entityId: string | string[],
-//   query: string,
-//   options?: ReadOptions
-// ): Promise<MemoryBundle>
 ```
 
-**Phase 1 (current)**: `read(entityId: string, query, options)` operates on a single entity as today.
+`entityId` accepts a single string or an array of strings. A string behaves as it did before this feature was added. An array enables multi-entity retrieval. Internally, the implementation normalizes to a deduplicated `entityIds: string[]`.
 
-**Phase 2+ (planned)**: `entityId` will accept `string | string[]` to enable multi-entity retrieval. A string behaves as it does today. An array enables multi-entity retrieval. Internally, the implementation will normalize to a deduplicated `entityIds: string[]`.
-
-A single-element array will be behaviorally equivalent to a string, except that optional metadata may be returned because the caller explicitly used the multi-entity shape.
+A single-element array is behaviorally equivalent to a string, except that optional metadata may be returned because the caller explicitly used the multi-entity shape.
 
 ### `ReadOptions`
 

--- a/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md
@@ -1,7 +1,7 @@
 # Multi-Entity Weighted Retrieval and Librarian Prompt Overrides
 
 **Date:** 2026-05-12  
-**Status:** Approved
+**Status:** Implemented
 **Breaking Change:** No
 
 ## Overview

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -9,7 +9,8 @@ Pure TypeScript business logic for LLM Wiki Memory.
 - **Platform-agnostic** — Zero runtime dependencies; works with any SQLite driver via the `SQLiteAdapter` interface
 - **Semantic search** — Vector embeddings via your LLM's `embed` function, ranked by cosine similarity
 - **Keyword fallback** — MiniSearch in-memory index for offline/degraded scenarios when embeddings unavailable
-- **Retrieval tuning** — Per-call overrides for `maxResults`, `preFilterLimit`, and `hybridWeight` blend
+- **Retrieval tuning** — Per-call overrides for `maxResults`, `preFilterLimit`, `hybridWeight`, `tierWeights`, and `includeZeroWeightEntities`
+- **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with per-entity score multipliers (`tierWeights`); optional `factScores` and `metadata` for explainability
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 - **Type-safe** — Built with TypeScript, full type exports
 
@@ -121,6 +122,19 @@ const memory = await wikiMemory.read('user-123', 'my preferences', {
   preFilterLimit: 20,
   hybridWeight: 0.5,
 });
+
+// Multi-entity with tier weights
+const multiMemory = await wikiMemory.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'my preferences', {
+  maxResults: 8,
+  tierWeights: {
+    tier_wisdom: 2,      // high-confidence curated notes boosted 2×
+    tier_fact: 1,        // neutral baseline
+    tier_working: 0.25,  // recent but unvetted context downranked
+  },
+  // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
+});
+// multiMemory.factScores — Record<factId, weightedScore> for all returned facts
+// multiMemory.metadata  — { query, entityIds, tierWeights }
 ```
 
 **Hybrid scoring blends:**
@@ -129,6 +143,15 @@ const memory = await wikiMemory.read('user-123', 'my preferences', {
 - `hybridWeight: 0.0` → pure keyword ranking, skips `embed()` entirely (no LLM API cost)
 
 True cosine-range pure semantic ranking (including negative cosine values) is used when `hybridWeight` is left `undefined`.
+
+**Tier weights:**
+- `tierWeights` applies a per-entity multiplier after semantic/keyword scoring: `finalScore = retrievalScore × weight`
+- Missing weights default to `1.0`. Negative weights clamp to `0`. Non-finite weights default to `1.0`.
+- `tierWeights[entity] = 0` skips that entity's scored retrieval branch (no compute cost).
+- `includeZeroWeightEntities: true` includes zero-weight entities as bottom-ranked filler instead of skipping them.
+- `factScores` and `metadata` are populated only for array-shaped `entityId` calls. Plain string calls never expose them.
+- `maxResults` applies globally across all requested entities.
+- Tasks are capped at `min(20 × entityCount, 200)`; events at `min(10 × entityCount, 100)` for multi-entity reads.
 
 **Pre-filtering optimization:**
 When `preFilterLimit: 50` is set with 1000 facts, cosine similarity is computed only for the top 50 MiniSearch keyword matches, reducing O(N) scoring to O(50).
@@ -418,7 +441,7 @@ console.log(memory.factScores);
 
 ### Librarian prompt override contract
 
-Core does not own a provider-specific synthesis API, but it exports prompt utilities for applications that synthesize answers from weighted retrieval results.
+Core exports prompt utilities for weighted retrieval-based synthesis. Use `mapLibrarianOptionsToReadOptions()` to map `entityWeights` to `tierWeights`, then hydrate a prompt with `query`, `context`, and `tasks`.
 
 ```ts
 import {
@@ -553,7 +576,7 @@ const adapter: SQLiteAdapter = {
 
 ```mermaid
 flowchart TD
-    A["read(entityId, query)"] --> B{hybridWeight = 0?}
+    A["read(entityId | entityId[], query, options?)"] --> B{hybridWeight = 0?}
     B -->|Yes| C["MiniSearch only<br/>(skip embed)"]
     B -->|No| D{embed available?}
     D -->|No| C

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,6 +11,7 @@ Pure TypeScript business logic for LLM Wiki Memory.
 - **Keyword fallback** — MiniSearch in-memory index for offline/degraded scenarios when embeddings unavailable
 - **Retrieval tuning** — Per-call overrides for `maxResults`, `preFilterLimit`, `hybridWeight`, `tierWeights`, and `includeZeroWeightEntities`
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with per-entity score multipliers (`tierWeights`); optional `factScores` and `metadata` for explainability
+- **Immutable vs mutable facts** — Use `WikiFact.source_type` to distinguish document-sourced facts (`immutable_document`) from derived or user-provided facts (`librarian_inferred`, `user_stated`, `user_confirmed`). Immutable document facts are not rewritten by `runLibrarian()` or `runHeal()` and can only be removed by `forget()` or re-ingesting.
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 - **Type-safe** — Built with TypeScript, full type exports
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -133,8 +133,8 @@ const multiMemory = await wikiMemory.read(['tier_wisdom', 'tier_fact', 'tier_wor
   },
   // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
 });
-// multiMemory.factScores — Record<factId, weightedScore> for all returned facts
-// multiMemory.metadata  — { query, entityIds, tierWeights }
+// multiMemory.factScores — optional Record<factId, weightedScore> for returned facts; may be absent/undefined
+// multiMemory.metadata  — optional { query, entityIds, tierWeights }; may be absent/undefined
 ```
 
 **Hybrid scoring blends:**

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -149,7 +149,7 @@ True cosine-range pure semantic ranking (including negative cosine values) is us
 - Missing weights default to `1.0`. Negative weights clamp to `0`. Non-finite weights default to `1.0`.
 - `tierWeights[entity] = 0` skips that entity's scored retrieval branch (no compute cost).
 - `includeZeroWeightEntities: true` includes zero-weight entities as bottom-ranked filler instead of skipping them.
-- `factScores` and `metadata` are populated only for array-shaped `entityId` calls. Plain string calls never expose them.
+- `factScores` is present for array-shaped `entityId` calls only when the query is non-empty and at least one fact is scored; empty-query ("recent facts") reads leave it absent even when `entityId` is an array. Plain string calls never expose it. `metadata` is present for all array-shaped calls regardless of query.
 - `maxResults` applies globally across all requested entities.
 - Tasks are capped at `min(20 × entityCount, 200)`; events at `min(10 × entityCount, 100)` for multi-entity reads.
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -17,6 +17,7 @@ Expo/React Native adapter for @equationalapplications/core-llm-wiki, powered by 
 - **Semantic search** — Vector embeddings via `embed` function, with MiniSearch fallback
 - **Retrieval tuning** — Per-call overrides for search behavior (pre-filter, hybrid blend, tier weights)
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights`
+- **Source provenance** — `WikiFact.source_type` distinguishes immutable document facts (`immutable_document`) from mutable derived/user facts. Immutable document content is protected from librarian/heal rewriting and only changed by `forget()` or re-ingest.
 - **React hooks** — `WikiProvider`, `useMemoryRead`, and all other hooks are re-exported directly from `@equationalapplications/expo-llm-wiki`
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -88,7 +88,7 @@ const multiMemory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working']
   },
   // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
 });
-// multiMemory.factScores — Record<factId, weightedScore>
+// multiMemory.factScores — Record<factId, weightedScore> | undefined (array entityId only, populated when query is non-empty and at least one fact scored)
 // multiMemory.metadata  — { query, entityIds, tierWeights }
 ```
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -15,7 +15,8 @@ Expo/React Native adapter for @equationalapplications/core-llm-wiki, powered by 
 - **Expo-ready** — Pre-configured for React Native + Expo
 - **Built on `expo-sqlite`** — Stable, well-supported SQLite driver
 - **Semantic search** — Vector embeddings via `embed` function, with MiniSearch fallback
-- **Retrieval tuning** — Per-call overrides for search behavior (pre-filter, hybrid blend)
+- **Retrieval tuning** — Per-call overrides for search behavior (pre-filter, hybrid blend, tier weights)
+- **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights`
 - **React hooks** — `WikiProvider`, `useMemoryRead`, and all other hooks are re-exported directly from `@equationalapplications/expo-llm-wiki`
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 
@@ -76,6 +77,19 @@ const fasterSearch = await wiki.read('user-123', 'activities', {
   preFilterLimit: 20,      // Tighter pre-filter for speed
   hybridWeight: 0.5,       // More keyword weight
 });
+
+// Multi-entity with tier weights
+const multiMemory = await wiki.read(['tier_wisdom', 'tier_fact', 'tier_working'], 'activities', {
+  maxResults: 8,
+  tierWeights: {
+    tier_wisdom: 2,      // boost curated notes 2×
+    tier_fact: 1,        // neutral baseline
+    tier_working: 0.25,  // downrank unvetted context
+  },
+  // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
+});
+// multiMemory.factScores — Record<factId, weightedScore>
+// multiMemory.metadata  — { query, entityIds, tierWeights }
 ```
 
 ## Configuration
@@ -219,7 +233,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["read(entityId, query)"] --> B{hybridWeight = 0?}
+    A["read(entityId | entityId[], query, options?)"] --> B{hybridWeight = 0?}
     B -->|Yes| C["MiniSearch only<br/>(skip embed)"]
     B -->|No| D{embed available?}
     D -->|No| C
@@ -250,6 +264,30 @@ The flowchart shows:
 4. **Two-phase SELECT**: phase 1 scores all/filtered facts with minimal columns, phase 2 fetches full rows for winners
 5. **Hybrid scoring** to blend semantic and keyword rankings
 6. **Vector caching** on full scans only; reads with `preFilterLimit` active skip cache population
+
+## Multi-Entity Reads
+
+`read()` accepts a single entity ID or an array to search across namespaces in one retrieval pass. Pass `tierWeights` to control per-entity ranking before the final top-K results:
+
+```typescript
+const memory = await wiki.read(
+  ['tier_wisdom', 'tier_fact', 'tier_working'],
+  'What do I know about this topic?',
+  {
+    maxResults: 8,
+    tierWeights: {
+      tier_wisdom: 2,      // boost curated notes 2×
+      tier_fact: 1,        // neutral
+      tier_working: 0.25,  // downrank unvetted context
+    },
+  }
+);
+// memory.factScores — Record<factId, weightedScore>
+// memory.metadata  — { query, entityIds, tierWeights }
+// tasks capped at min(20 × entityCount, 200); events at min(10 × entityCount, 100)
+```
+
+For Librarian prompt utilities (`hydrateLibrarianPrompt`, `validateLibrarianPromptTemplate`, etc.), see [`packages/core/README.md`](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#librarian-prompt-override-contract).
 
 ## License
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -282,7 +282,8 @@ const memory = await wiki.read(
     },
   }
 );
-// memory.factScores — Record<factId, weightedScore>
+// memory.factScores — Record<factId, weightedScore> | undefined
+//   attached for array-shaped reads when the query is non-empty and at least one fact is scored
 // memory.metadata  — { query, entityIds, tierWeights }
 // tasks capped at min(20 × entityCount, 200); events at min(10 × entityCount, 100)
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -175,7 +175,7 @@ const { data: multiData } = useMemoryRead(
 
 ### `useMemoryRead(entityId, query, options?)`
 
-Fetch memory reactively. `entityId` accepts a string or string array for multi-entity reads. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change, including per-call overrides such as `maxResults`, `preFilterLimit`, `hybridWeight`, `tierWeights`, and `includeZeroWeightEntities`. Changes to `tierWeights` and `includeZeroWeightEntities` are tracked and trigger refetches.
+Fetch memory reactively. `entityId` accepts a string or string array for multi-entity reads. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change on a behavioral level: `maxResults`, `preFilterLimit`, `hybridWeight`, and `tierWeights` are tracked. `tierWeights` entries at the default weight (`1.0`) are normalized to omission (passing `1.0` explicitly is spec-equivalent to omitting that key). `includeZeroWeightEntities: false` and `undefined` are equivalent in core (both skip zero-weight entities); only toggling to `true` triggers a refetch.
 
 ```typescript
 const { data, isPending, error, refetch } = useMemoryRead('user-123', 'preferences');

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,7 +7,8 @@ React hooks and web utilities for @equationalapplications/core-llm-wiki, designe
 ## Features
 
 - **Semantic search** — Vector embeddings with optional `embed` function and MiniSearch fallback
-- **Retrieval tuning** — Per-call overrides for hybrid scoring, pre-filtering, result limits
+- **Retrieval tuning** — Per-call overrides for hybrid scoring, pre-filtering, result limits, and tier weights
+- **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights` and optional `includeZeroWeightEntities`
 - **Reactive reads** — Auto-refetch on `entityId`, query, or `options` changes
 - **Mutation hooks** — `useWikiWrite`, `useWikiIngest`, `useWikiForget`, `useWikiMaintenance`, etc.
 - **Shared context** — Single `WikiProvider` per app, use anywhere
@@ -150,16 +151,38 @@ const { data } = useMemoryRead('user-123', 'preferences', {
   preFilterLimit: 20,      // Tighter pre-filter for speed
   hybridWeight: 0.5,       // More keyword weight
 });
+
+// Multi-entity hook — pass array entityId + tierWeights
+const { data: multiData } = useMemoryRead(
+  ['tier_wisdom', 'tier_fact', 'tier_working'],
+  'preferences',
+  {
+    maxResults: 8,
+    tierWeights: {
+      tier_wisdom: 2,
+      tier_fact: 1,
+      tier_working: 0.25,
+    },
+    // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
+  }
+);
+// multiData?.factScores — Record<factId, weightedScore>
+// multiData?.metadata  — { query, entityIds, tierWeights }
 ```
 
 ## Hooks
 
 ### `useMemoryRead(entityId, query, options?)`
 
-Fetch memory reactively. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change, including per-call overrides such as `maxResults`, `preFilterLimit`, and `hybridWeight`.
+Fetch memory reactively. `entityId` accepts a string or string array for multi-entity reads. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change, including per-call overrides such as `maxResults`, `preFilterLimit`, `hybridWeight`, and `tierWeights`.
 
 ```typescript
 const { data, isPending, error, refetch } = useMemoryRead('user-123', 'preferences');
+// data: MemoryBundle | null
+
+// Multi-entity
+const { data: multi } = useMemoryRead(['tier_wisdom', 'tier_fact'], 'preferences');
+// multi?.factScores, multi?.metadata available when entityId is array
 
 if (isPending) return <div>Loading...</div>;
 if (error) return <div>Error: {error.message}</div>;
@@ -292,6 +315,32 @@ await execute(['user-123']);
 // lastResult: MemoryDump | null
 ```
 
+## Multi-Entity Reads
+
+`useMemoryRead` accepts a single entity ID or an array to search across namespaces in one pass. Pass `tierWeights` to apply per-entity score multipliers before the global top-K slice:
+
+```typescript
+const { data } = useMemoryRead(
+  ['tier_wisdom', 'tier_fact', 'tier_working'],
+  'What are my preferences?',
+  {
+    maxResults: 8,
+    tierWeights: {
+      tier_wisdom: 2,      // boost curated notes 2×
+      tier_fact: 1,        // neutral
+      tier_working: 0.25,  // downrank unvetted context
+    },
+  }
+);
+
+if (data) {
+  console.log(data.facts);      // merged, globally ranked
+  console.log(data.factScores); // Record<factId, weightedScore>
+  console.log(data.metadata);   // { query, entityIds, tierWeights }
+}
+
+For Librarian prompt utilities, see [`packages/core/README.md`](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#librarian-prompt-override-contract).
+
 ## Component Lifecycle
 
 ```mermaid
@@ -329,7 +378,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["read(entityId, query)"] --> B{hybridWeight = 0?}
+    A["read(entityId | entityId[], query, options?)"] --> B{hybridWeight = 0?}
     B -->|Yes| C["MiniSearch only<br/>(skip embed)"]
     B -->|No| D{embed available?}
     D -->|No| C

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,6 +9,7 @@ React hooks and web utilities for @equationalapplications/core-llm-wiki, designe
 - **Semantic search** — Vector embeddings with optional `embed` function and MiniSearch fallback
 - **Retrieval tuning** — Per-call overrides for hybrid scoring, pre-filtering, result limits, and tier weights
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights` and optional `includeZeroWeightEntities`
+- **Source provenance** — `WikiFact.source_type` distinguishes immutable document facts (`immutable_document`) from mutable derived/user facts (`librarian_inferred`, `user_stated`, `user_confirmed`). Immutable document facts are preserved from librarian/heal rewriting and only removed by `forget()` or by re-ingesting the source.
 - **Reactive reads** — Auto-refetch on `entityId`, query, or `options` changes
 - **Mutation hooks** — `useWikiWrite`, `useWikiIngest`, `useWikiForget`, `useWikiMaintenance`, etc.
 - **Shared context** — Single `WikiProvider` per app, use anywhere

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -166,7 +166,7 @@ const { data: multiData } = useMemoryRead(
     // includeZeroWeightEntities: true — include 0-weight entities as bottom-ranked filler
   }
 );
-// multiData?.factScores — Record<factId, weightedScore>
+// multiData?.factScores — Record<factId, weightedScore> | undefined (array entityId only, populated when query is non-empty and at least one fact scored)
 // multiData?.metadata  — { query, entityIds, tierWeights }
 ```
 
@@ -174,7 +174,7 @@ const { data: multiData } = useMemoryRead(
 
 ### `useMemoryRead(entityId, query, options?)`
 
-Fetch memory reactively. `entityId` accepts a string or string array for multi-entity reads. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change, including per-call overrides such as `maxResults`, `preFilterLimit`, `hybridWeight`, and `tierWeights`.
+Fetch memory reactively. `entityId` accepts a string or string array for multi-entity reads. Auto-refetches when `entityId`, `query`, `wiki`, or `options` change, including per-call overrides such as `maxResults`, `preFilterLimit`, `hybridWeight`, `tierWeights`, and `includeZeroWeightEntities`. Changes to `tierWeights` and `includeZeroWeightEntities` are tracked and trigger refetches.
 
 ```typescript
 const { data, isPending, error, refetch } = useMemoryRead('user-123', 'preferences');

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -249,6 +249,21 @@ describe('useMemoryRead', () => {
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
   });
 
+  it('does not re-fetch when active entity tierWeight is explicitly set to the default (1.0 is same as omitted)', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: {} } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    // Per spec: "Missing tier weights default to 1.0", so passing 1.0 explicitly
+    // is behaviorally identical to omission and must not trigger a refetch.
+    rerender({ opts: { tierWeights: { 'user-1': 1 } } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
   it('does not re-fetch when tierWeights changes from undefined to {} (empty object is same as undefined)', async () => {
     const { rerender } = renderHook(
       ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -263,7 +263,7 @@ describe('useMemoryRead', () => {
     expect(wiki.read).toHaveBeenCalledTimes(1);
   });
 
-  it('re-fetches when tierWeights gains an entry (behavioral change from all-default weights)', async () => {
+  it('re-fetches when tierWeights gains an entry for the active entity (behavioral change from all-default weights)', async () => {
     const { rerender } = renderHook(
       ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
       { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: {} } } }
@@ -271,7 +271,8 @@ describe('useMemoryRead', () => {
 
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
 
-    rerender({ opts: { tierWeights: { tier_wisdom: 2 } } });
+    // 'user-1' matches the active entityId so the weight is included in the dep key.
+    rerender({ opts: { tierWeights: { 'user-1': 2 } } });
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
   });
 
@@ -301,6 +302,63 @@ describe('useMemoryRead', () => {
     rerender({ opts: { tierWeights: { tier_working: 0 } } });
     await act(async () => {});
     expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch when tierWeights changes only for entities outside the active entityId set', async () => {
+    // Core's sanitizeTierWeights(entityIds, tierWeights) only considers weights for
+    // the requested entity IDs — weights for other entities have no behavioral effect.
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { tier_wisdom: 2 } } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    // 'tier_wisdom' is not 'user-1', so adding or changing it has no effect.
+    rerender({ opts: { tierWeights: { tier_wisdom: 2, unrelated_entity: 99 } } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when tierWeights changes for the active entity', async () => {
+    // Use a string entityId to avoid array reference churn; the key point is that
+    // 'user-1' is in the active set so its weight IS included in the dep key.
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { 'user-1': 1 } } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    rerender({ opts: { tierWeights: { 'user-1': 2 } } });
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not re-fetch when includeZeroWeightEntities changes from undefined to false', async () => {
+    // In core, undefined and false are equivalent (both exclude zero-weight entities
+    // from scored retrieval by default). Toggling between them must not cause a refetch.
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: {} } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    rerender({ opts: { includeZeroWeightEntities: false } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when includeZeroWeightEntities changes from false to true (behavioral change)', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { includeZeroWeightEntities: false } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    rerender({ opts: { includeZeroWeightEntities: true } });
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -277,29 +277,33 @@ describe('useMemoryRead', () => {
   });
 
   it('does not re-fetch when tierWeights has non-finite values replaced by their effective 1.0 equivalent', async () => {
+    // Use entityId matching the tierWeights key so the key is in the active set
+    // and the sanitization path (NaN → 1.0) is actually exercised.
     const { rerender } = renderHook(
       ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
-      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { tier_wisdom: NaN } } } }
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { 'user-1': NaN } } } }
     );
 
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
 
     // NaN → 1.0 per spec ("non-finite values default to 1.0"), so key is unchanged.
-    rerender({ opts: { tierWeights: { tier_wisdom: 1 } } });
+    rerender({ opts: { tierWeights: { 'user-1': 1 } } });
     await act(async () => {});
     expect(wiki.read).toHaveBeenCalledTimes(1);
   });
 
   it('does not re-fetch when tierWeights has negative values replaced by their effective 0 equivalent', async () => {
+    // Use entityId matching the tierWeights key so the key is in the active set
+    // and the sanitization path (negative → 0) is actually exercised.
     const { rerender } = renderHook(
       ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
-      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { tier_working: -5 } } } }
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { 'user-1': -5 } } } }
     );
 
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
 
     // -5 → 0 per spec ("negative values clamp to 0"), so key is unchanged.
-    rerender({ opts: { tierWeights: { tier_working: 0 } } });
+    rerender({ opts: { tierWeights: { 'user-1': 0 } } });
     await act(async () => {});
     expect(wiki.read).toHaveBeenCalledTimes(1);
   });

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -248,6 +248,60 @@ describe('useMemoryRead', () => {
     rerender({ opts: { preFilterLimit: Infinity } });
     await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
   });
+
+  it('does not re-fetch when tierWeights changes from undefined to {} (empty object is same as undefined)', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: {} } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    // tierWeights: {} has no entries, so all weights default to 1.0 — same as undefined.
+    rerender({ opts: { tierWeights: {} } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches when tierWeights gains an entry (behavioral change from all-default weights)', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: {} } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    rerender({ opts: { tierWeights: { tier_wisdom: 2 } } });
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not re-fetch when tierWeights has non-finite values replaced by their effective 1.0 equivalent', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { tier_wisdom: NaN } } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    // NaN → 1.0 per spec ("non-finite values default to 1.0"), so key is unchanged.
+    rerender({ opts: { tierWeights: { tier_wisdom: 1 } } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch when tierWeights has negative values replaced by their effective 0 equivalent', async () => {
+    const { rerender } = renderHook(
+      ({ opts }: { opts: ReadOptions }) => useMemoryRead('user-1', 'q', opts),
+      { wrapper: wrapper(wiki), initialProps: { opts: { tierWeights: { tier_working: -5 } } } }
+    );
+
+    await waitFor(() => expect(wiki.read).toHaveBeenCalledTimes(1));
+
+    // -5 → 0 per spec ("negative values clamp to 0"), so key is unchanged.
+    rerender({ opts: { tierWeights: { tier_working: 0 } } });
+    await act(async () => {});
+    expect(wiki.read).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/useMemoryRead.ts
+++ b/packages/react/src/useMemoryRead.ts
@@ -93,8 +93,19 @@ export function useMemoryRead(entityId: string | string[], query: string, option
   const wikiRef = useRef(wiki);
   wikiRef.current = wiki;
 
+  const entityIdRef = useRef(entityId);
+  entityIdRef.current = entityId;
+
   const optionsRef = useRef(options);
   optionsRef.current = options;
+
+  // Stable dep key for entityId: sort+dedup so inline array literals (new reference
+  // each render) don't cause spurious refetches. The same set of entity IDs always
+  // produces the same key regardless of reference identity or insertion order.
+  const entityIdKey = Array.isArray(entityId)
+    ? [...new Set(entityId)].sort().join('\0')
+    : entityId;
+
   // Serialize a normalized form of options so:
   //  - `undefined` and `{}` map to the same string (no spurious refetch)
   //  - non-finite hybridWeight (±Infinity, NaN) is coerced to its effective value before
@@ -135,12 +146,12 @@ export function useMemoryRead(entityId: string | string[], query: string, option
   });
 
   useEffect(() => {
-    scheduleFetch.current(entityId, query);
-  }, [entityId, query, wiki, optionsStr]);
+    scheduleFetch.current(entityIdRef.current, query);
+  }, [entityIdKey, query, wiki, optionsStr]);
 
   const refetch = useCallback(() => {
-    scheduleFetch.current(entityId, query);
-  }, [entityId, query]);
+    scheduleFetch.current(entityIdRef.current, query);
+  }, [entityIdKey, query]);
 
   return { data, isPending, error, refetch };
 }

--- a/packages/react/src/useMemoryRead.ts
+++ b/packages/react/src/useMemoryRead.ts
@@ -12,6 +12,8 @@ import { useWiki } from './WikiContext';
  *      · preFilterLimit: NaN/±Infinity → null (disables config-level limit, same as null)
  *      · hybridWeight: NaN → null (explicitly disables config-level weight; distinct from
  *        undefined which defers to config); ±Infinity → clamped to 0/1
+ *      · tierWeights values: non-finite → 1.0, negative → 0 (mirrors core sanitization)
+ *      · tierWeights: {} is omitted (same effective behavior as undefined; all weights 1.0)
  *  - Keys are sorted so insertion-order differences never cause spurious refetches
  */
 function normalizeReadOptionsKey(opts?: ReadOptions): string {
@@ -47,14 +49,22 @@ function normalizeReadOptionsKey(opts?: ReadOptions): string {
       : Math.max(0, Math.min(1, opts.hybridWeight));
   }
 
-  // tierWeights: serialize with sorted keys so insertion-order differences
-  // don't cause spurious refetches.
+  // tierWeights: mirror core's weight sanitization (non-finite → 1.0, negative → 0)
+  // and sort keys so insertion-order differences and logically-equivalent values
+  // (e.g. NaN vs 1, -5 vs 0) never cause spurious refetches.
+  // An empty {} is omitted entirely — behaviorally identical to undefined.
   if (opts.tierWeights !== undefined) {
     const tw = opts.tierWeights;
     const twKeys = Object.keys(tw).sort();
-    normalized.tierWeights = twKeys.length
-      ? JSON.stringify(tw, twKeys)
-      : null;
+    if (twKeys.length) {
+      const sanitized: Record<string, number> = {};
+      for (const k of twKeys) {
+        const w = tw[k];
+        sanitized[k] = !Number.isFinite(w) ? 1.0 : Math.max(0, w);
+      }
+      normalized.tierWeights = JSON.stringify(sanitized, twKeys);
+    }
+    // Empty {} → omit (all weights default to 1.0, same as undefined)
   }
 
   // includeZeroWeightEntities: only include when explicitly set.

--- a/packages/react/src/useMemoryRead.ts
+++ b/packages/react/src/useMemoryRead.ts
@@ -13,10 +13,14 @@ import { useWiki } from './WikiContext';
  *      · hybridWeight: NaN → null (explicitly disables config-level weight; distinct from
  *        undefined which defers to config); ±Infinity → clamped to 0/1
  *      · tierWeights values: non-finite → 1.0, negative → 0 (mirrors core sanitization)
- *      · tierWeights: {} is omitted (same effective behavior as undefined; all weights 1.0)
+ *      · tierWeights keys: projected onto the active entityId set (mirrors core's
+ *        sanitizeTierWeights which ignores weights for entities not in the request)
+ *      · tierWeights: {} or fully-filtered result is omitted (same as undefined)
+ *      · includeZeroWeightEntities: false/undefined are equivalent (both skip zero-weight
+ *        entities); only true is keyed, matching core's default behavior
  *  - Keys are sorted so insertion-order differences never cause spurious refetches
  */
-function normalizeReadOptionsKey(opts?: ReadOptions): string {
+function normalizeReadOptionsKey(entityId: string | string[], opts?: ReadOptions): string {
   if (!opts) return '';
   const normalized: Record<string, unknown> = {};
 
@@ -49,13 +53,16 @@ function normalizeReadOptionsKey(opts?: ReadOptions): string {
       : Math.max(0, Math.min(1, opts.hybridWeight));
   }
 
-  // tierWeights: mirror core's weight sanitization (non-finite → 1.0, negative → 0)
-  // and sort keys so insertion-order differences and logically-equivalent values
-  // (e.g. NaN vs 1, -5 vs 0) never cause spurious refetches.
-  // An empty {} is omitted entirely — behaviorally identical to undefined.
+  // tierWeights: project onto the active entity set (core's sanitizeTierWeights only
+  // considers weights for the requested entityIds, so unrelated keys have no behavioral
+  // effect and should not contribute to the dep key). Sanitize values (non-finite → 1.0,
+  // negative → 0) and sort keys to avoid spurious refetches from insertion-order or
+  // logically-equivalent value differences. Omit entirely when the projected result is
+  // empty (all weights default to 1.0 — same as undefined).
   if (opts.tierWeights !== undefined) {
+    const activeIds = new Set(Array.isArray(entityId) ? entityId : [entityId]);
     const tw = opts.tierWeights;
-    const twKeys = Object.keys(tw).sort();
+    const twKeys = Object.keys(tw).filter(k => activeIds.has(k)).sort();
     if (twKeys.length) {
       const sanitized: Record<string, number> = {};
       for (const k of twKeys) {
@@ -64,12 +71,13 @@ function normalizeReadOptionsKey(opts?: ReadOptions): string {
       }
       normalized.tierWeights = JSON.stringify(sanitized, twKeys);
     }
-    // Empty {} → omit (all weights default to 1.0, same as undefined)
   }
 
-  // includeZeroWeightEntities: only include when explicitly set.
-  if (opts.includeZeroWeightEntities !== undefined) {
-    normalized.includeZeroWeightEntities = opts.includeZeroWeightEntities;
+  // includeZeroWeightEntities: false and undefined are equivalent in core (both exclude
+  // zero-weight entities from scored retrieval). Only key when true so toggling
+  // undefined → false does not cause a spurious refetch.
+  if (opts.includeZeroWeightEntities === true) {
+    normalized.includeZeroWeightEntities = true;
   }
 
   const sortedKeys = Object.keys(normalized).sort();
@@ -92,7 +100,7 @@ export function useMemoryRead(entityId: string | string[], query: string, option
   //  - non-finite hybridWeight (±Infinity, NaN) is coerced to its effective value before
   //    stringifying (JSON.stringify turns Infinity/NaN to `null`, losing type information)
   //  - keys are sorted so insertion-order differences don't cause spurious refetches
-  const optionsStr = normalizeReadOptionsKey(options);
+  const optionsStr = normalizeReadOptionsKey(entityId, options);
 
   const fetchQueue = useRef<{
     inFlight: boolean;

--- a/packages/react/src/useMemoryRead.ts
+++ b/packages/react/src/useMemoryRead.ts
@@ -15,7 +15,9 @@ import { useWiki } from './WikiContext';
  *      · tierWeights values: non-finite → 1.0, negative → 0 (mirrors core sanitization)
  *      · tierWeights keys: projected onto the active entityId set (mirrors core's
  *        sanitizeTierWeights which ignores weights for entities not in the request)
- *      · tierWeights: {} or fully-filtered result is omitted (same as undefined)
+ *      · tierWeights keys at default weight (1.0) are dropped — spec says missing
+ *        weights default to 1.0, so explicit 1.0 is behaviorally identical to omission
+ *      · tierWeights: {} or fully-filtered/all-default result is omitted (same as undefined)
  *      · includeZeroWeightEntities: false/undefined are equivalent (both skip zero-weight
  *        entities); only true is keyed, matching core's default behavior
  *  - Keys are sorted so insertion-order differences never cause spurious refetches
@@ -57,19 +59,26 @@ function normalizeReadOptionsKey(entityId: string | string[], opts?: ReadOptions
   // considers weights for the requested entityIds, so unrelated keys have no behavioral
   // effect and should not contribute to the dep key). Sanitize values (non-finite → 1.0,
   // negative → 0) and sort keys to avoid spurious refetches from insertion-order or
-  // logically-equivalent value differences. Omit entirely when the projected result is
-  // empty (all weights default to 1.0 — same as undefined).
+  // logically-equivalent value differences. Drop entries at the default weight (1.0)
+  // because missing weights also default to 1.0 per spec — explicit 1.0 is behaviorally
+  // identical to omission. Use Object.create(null) to match core's sanitizeTierWeights
+  // and avoid prototype-key edge cases (e.g. entityIds like __proto__). Omit entirely
+  // when the projected+filtered result is empty (same as undefined).
   if (opts.tierWeights !== undefined) {
     const activeIds = new Set(Array.isArray(entityId) ? entityId : [entityId]);
     const tw = opts.tierWeights;
     const twKeys = Object.keys(tw).filter(k => activeIds.has(k)).sort();
     if (twKeys.length) {
-      const sanitized: Record<string, number> = {};
+      const sanitized = Object.create(null) as Record<string, number>;
       for (const k of twKeys) {
         const w = tw[k];
         sanitized[k] = !Number.isFinite(w) ? 1.0 : Math.max(0, w);
       }
-      normalized.tierWeights = JSON.stringify(sanitized, twKeys);
+      // Drop default-weight entries (1.0) — spec says missing weights default to 1.0
+      const nonDefaultKeys = twKeys.filter(k => sanitized[k] !== 1.0);
+      if (nonDefaultKeys.length) {
+        normalized.tierWeights = JSON.stringify(sanitized, nonDefaultKeys);
+      }
     }
   }
 

--- a/packages/react/src/useMemoryRead.ts
+++ b/packages/react/src/useMemoryRead.ts
@@ -47,11 +47,26 @@ function normalizeReadOptionsKey(opts?: ReadOptions): string {
       : Math.max(0, Math.min(1, opts.hybridWeight));
   }
 
+  // tierWeights: serialize with sorted keys so insertion-order differences
+  // don't cause spurious refetches.
+  if (opts.tierWeights !== undefined) {
+    const tw = opts.tierWeights;
+    const twKeys = Object.keys(tw).sort();
+    normalized.tierWeights = twKeys.length
+      ? JSON.stringify(tw, twKeys)
+      : null;
+  }
+
+  // includeZeroWeightEntities: only include when explicitly set.
+  if (opts.includeZeroWeightEntities !== undefined) {
+    normalized.includeZeroWeightEntities = opts.includeZeroWeightEntities;
+  }
+
   const sortedKeys = Object.keys(normalized).sort();
   return sortedKeys.length ? JSON.stringify(normalized, sortedKeys) : '';
 }
 
-export function useMemoryRead(entityId: string, query: string, options?: ReadOptions) {
+export function useMemoryRead(entityId: string | string[], query: string, options?: ReadOptions) {
   const wiki = useWiki();
   const [data, setData] = useState<MemoryBundle | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -71,13 +86,13 @@ export function useMemoryRead(entityId: string, query: string, options?: ReadOpt
 
   const fetchQueue = useRef<{
     inFlight: boolean;
-    pending: { entityId: string; query: string } | null;
+    pending: { entityId: string | string[]; query: string } | null;
   }>({ inFlight: false, pending: null });
 
   // Stable scheduler: refs keep it from going stale across renders.
   // In-flight results are never discarded — spec requires them to land before
   // starting the next fetch with latest args.
-  const scheduleFetch = useRef(function schedule(eid: string, q: string) {
+  const scheduleFetch = useRef(function schedule(eid: string | string[], q: string) {
     const fq = fetchQueue.current;
     if (fq.inFlight) {
       fq.pending = { entityId: eid, query: q };


### PR DESCRIPTION
Documentation and runtime hook fixes for the multi-entity weighted retrieval spec [docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md](docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md).

### Changes

**`packages/react/src/useMemoryRead.ts`** — runtime behavior:
- `normalizeReadOptionsKey` now filters `tierWeights` to the active entityId set before serializing (mirrors `sanitizeTierWeights` in core, which ignores weights for entities outside the request)
- `includeZeroWeightEntities: false` is normalized to omission — `false` and `undefined` are equivalent in core and must not cause spurious refetches

**`packages/react/__tests__/hooks.test.tsx`** — 4 new tests:
- tierWeights for entities outside the active set don't cause spurious refetches
- tierWeights changes for an active entity do trigger a refetch
- `includeZeroWeightEntities: false` → same dep key as `undefined` (no refetch)
- `includeZeroWeightEntities: true` → refetch (behavioral change)

**`docs/superpowers/specs/2026-05-12-multi-entity-weighted-retrieval-design.md`** — doc consistency:
- Removed Phase 1 / Phase 2 "planned" split from the API Design section; the unified `read(entityId: string | string[])` signature is now shown as implemented (consistent with `Status: Implemented` at the top)