### PR TITLE
feat(core): extract pure utilities and JobManager (phase-3 PR1)

### DIFF
--- a/docs/superpowers/specs/2026-05-14-repository-phase-1.md
+++ b/docs/superpowers/specs/2026-05-14-repository-phase-1.md
@@ -1,7 +1,7 @@
 # Spec: Repository Infrastructure & Fact Migration - Phase 1
 
 **Date:** 2026-05-14
-**Status:** Approved
+**Status:** Implemented
 **Scope:** Establish the repository layer for `WikiFact` to centralize hydration and routine writes while preserving high-fidelity raw SQL paths for complex imports.
 
 ---

--- a/docs/superpowers/specs/2026-05-14-repository-phase-2-5-spec.md
+++ b/docs/superpowers/specs/2026-05-14-repository-phase-2-5-spec.md
@@ -1,7 +1,7 @@
 # Spec: Phase 2.5 — Decoupling Side Effects (SearchService)
 
 **Date:** May 15, 2026
-**Status:** Approved for Implementation
+**Status:** Implementated
 **Scope:** Extract in-memory indexing (`MiniSearch`) and embedding cache management (`vectorCache`) from `WikiMemory` into a dedicated `SearchService`. Execute via two parallel pull requests to separate core logic implementation from orchestration wiring.
 
 ---

--- a/docs/superpowers/specs/2026-05-14-repository-phase-2-5-spec.md
+++ b/docs/superpowers/specs/2026-05-14-repository-phase-2-5-spec.md
@@ -1,7 +1,7 @@
 # Spec: Phase 2.5 — Decoupling Side Effects (SearchService)
 
 **Date:** May 15, 2026
-**Status:** Implementated
+**Status:** Implemented
 **Scope:** Extract in-memory indexing (`MiniSearch`) and embedding cache management (`vectorCache`) from `WikiMemory` into a dedicated `SearchService`. Execute via two parallel pull requests to separate core logic implementation from orchestration wiring.
 
 ---

--- a/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
@@ -1,0 +1,146 @@
+# Spec: Phase 3 — Service Layer Extraction & Concurrency Decoupling
+
+**Date:** May 15, 2026
+**Status:** Draft
+**Scope:** Extract the remaining business logic—LLM orchestration, maintenance workflows, and concurrency locking—out of `WikiMemory` into dedicated domain services (`IngestionService`, `MaintenanceService`) and a `JobManager`.
+
+---
+
+## 1. Background & Motivation
+
+Phases 2 and 2.5 successfully extracted the data access layer (Repositories, Outbox) and in-memory indexing (`SearchService`). However, looking at the `staging` branch, `WikiMemory.ts` is still approximately 2,700 lines long.
+
+It currently violates the Single Responsibility Principle by acting as:
+
+1. **An LLM Orchestrator:** Formatting prompts, calling the LLM, and parsing JSON arrays for ingestion, healing, and librarian tasks.
+2. **A Mutex Lock Manager:** Manually checking and setting string keys in `activeMaintenanceJobs` and `activeIngestJobs` (triggering `WikiBusyError`) across almost every public method.
+3. **A Pub/Sub Broker:** Managing `statusSubscribers` and broadcasting state transitions.
+
+Phase 3 will strip `WikiMemory` down to a clean Facade/API layer by migrating these responsibilities into domain-specific classes.
+
+---
+
+## 2. Component 1: `JobManager` (Concurrency & Status)
+
+Currently, locking logic is heavily duplicated. Every operation manually constructs keys (e.g., `this._pruneKey(entityId)`), checks multiple sets, and throws a `WikiBusyError`.
+
+We will extract this into a `JobManager` to centralize mutex locking and status broadcasting.
+
+### Responsibilities
+
+* Maintain the `activeMaintenanceJobs` and `activeIngestJobs` sets.
+* Provide unified lock acquisition methods that throw `WikiBusyError` automatically if a conflict is detected.
+* Manage the `statusSubscribers` map and emit events when entity statuses (`ingesting`, `librarian`, `heal`) change.
+
+### Proposed Interface
+
+```typescript
+export class JobManager {
+  private activeMaintenanceJobs = new Set<string>();
+  private activeIngestJobs = new Set<string>();
+  private statusSubscribers = new Map<string, Set<SubscriberEntry>>();
+
+  constructor(private prefix: string) {}
+
+  /** * Attempts to acquire a lock for a specific operation.
+   * Throws WikiBusyError if a conflicting job is running.
+   */
+  acquireLock(operation: 'prune' | 'librarian' | 'heal' | 'ingest' | 'reembed' | 'import' | 'forget', entityId: string): void {
+    // ... logic ported from runPrune / ingestDocument etc.
+    // e.g., cross-checking reembed vs global import locks
+  }
+
+  releaseLock(operation: string, entityId: string): void {
+    // ... removes the key and notifies subscribers
+  }
+
+  getEntityStatus(entityId: string): EntityStatus { ... }
+  
+  subscribeEntityStatus(entityId: string, callback: (status: EntityStatus) => void): () => void { ... }
+}
+
+```
+
+---
+
+## 3. Component 2: `IngestionService`
+
+Document ingestion is an isolated workflow containing chunking math, bounded concurrency loops, and LLM text generation.
+
+### Responsibilities
+
+* Chunking documents (moving `chunkText` and `withConcurrency` utilities out of the core file).
+* Executing the `INGEST_SYSTEM_PROMPT` against the LLM provider.
+* Parsing and validating the extracted facts.
+* Coordinating with Repositories and `SearchService` to commit the results.
+
+### Proposed Interface
+
+```typescript
+export class IngestionService {
+  constructor(
+    private entryRepo: EntryRepository,
+    private searchService: SearchService,
+    private jobManager: JobManager,
+    private llmProvider: LLMProvider,
+    private config: WikiOptions['config']
+  ) {}
+
+  async ingestDocument(entityId: string, params: IngestParams): Promise<{ truncated: boolean; chunks: number }> {
+    this.jobManager.acquireLock('ingest', entityId);
+    try {
+      // ... chunking logic
+      // ... concurrent LLM calls
+      // ... DB transaction & searchService.sync()
+    } finally {
+      this.jobManager.releaseLock('ingest', entityId);
+    }
+  }
+}
+
+```
+
+---
+
+## 4. Component 3: `MaintenanceService`
+
+This service will absorb the "background" lifecycle methods of the Wiki. These operations usually require wide data scans, LLM reasoning, or external hook syncing.
+
+### Responsibilities
+
+* **The Librarian:** `runLibrarian`, `_doRunLibrarian` (deduplication, event summarization).
+* **Healing:** `runHeal`, `_doRunHeal` (orphaning, staleness downgrades, contradiction resolution).
+* **Data Lifecycle:** `runPrune`, `forget`.
+* **Vector Maintenance:** `runReembed`.
+
+Moving these out of `WikiMemory` drastically reduces the cognitive load of the core module and localizes the complex transaction-plus-LLM execution chains.
+
+---
+
+## 5. The Refactored `WikiMemory` (The Facade)
+
+Once Phase 3 is complete, `WikiMemory.ts` will transform from a monolithic god-class into a clean entry point.
+
+Its primary responsibilities will be:
+
+1. **Dependency Injection:** Instantiating the SQLite adapter, Repositories, `SearchService`, `JobManager`, `IngestionService`, and `MaintenanceService`.
+2. **Core Read/Write:** Handling `read()` (which coordinates the `vectorRanker` and `SearchService`) and `write()` (which logs events and triggers auto-librarian thresholds).
+3. **Delegation:** Forwarding calls like `wiki.ingestDocument(...)` to `this.ingestionService.ingestDocument(...)`.
+
+---
+
+## 6. Execution Strategy & PR Breakdown
+
+To minimize merge conflicts and ensure stability, execute this refactor in two sequential Pull Requests.
+
+### PR 1: Concurrency & Utilities (`JobManager`)
+
+1. Extract `chunkText`, `withConcurrency`, and parsing utilities (`parseJsonResponse`, `clip`, `validateFact`) into a `utils/` or `parsers/` directory.
+2. Create `JobManager.ts`. Move the sets, locking logic, and `subscribeEntityStatus` logic here.
+3. Update `WikiMemory` to delegate to `this.jobManager` instead of managing `activeMaintenanceJobs` internally.
+
+### PR 2: Domain Services (`IngestionService` & `MaintenanceService`)
+
+1. Create `IngestionService.ts`. Move `ingestDocument` and its associated types into this class.
+2. Create `MaintenanceService.ts`. Move `runPrune`, `runLibrarian`, `runHeal`, `runReembed`, and `forget` into this class.
+3. Update `WikiMemory.ts` to instantiate these services in the constructor and act as a simple pass-through facade for the public API.

--- a/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
@@ -42,12 +42,55 @@ export class JobManager {
 
   constructor(private prefix: string) {}
 
-  /** * Attempts to acquire a lock for a specific operation.
+  private _pruneKey(entityId: string) { return `${this.prefix}:${entityId}:prune`; }
+  private _reembedKey(entityId: string) { return `${this.prefix}:${entityId}:reembed`; }
+  private _importKey(entityId: string) { return `${this.prefix}:${entityId}:import`; }
+  private _globalReembedKey() { return `${this.prefix}:reembed`; }
+  private _globalImportKey() { return `${this.prefix}:import`; }
+
+  private _isIngestActiveFor(entityId: string): boolean {
+    const ingestPrefix = `${this.prefix}:${entityId}:`;
+    for (const k of this.activeIngestJobs) {
+      if (k.startsWith(ingestPrefix)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Attempts to acquire a lock for a specific operation.
    * Throws WikiBusyError if a conflicting job is running.
    */
-  acquireLock(operation: 'prune' | 'librarian' | 'heal' | 'ingest' | 'reembed' | 'import' | 'forget', entityId: string): void {
-    // ... logic ported from runPrune / ingestDocument etc.
-    // e.g., cross-checking reembed vs global import locks
+  acquireLock(
+    operation: 'prune' | 'librarian' | 'heal' | 'ingest' | 'reembed' | 'import' | 'forget',
+    entityId: string,
+    sourceRef?: string
+  ): void {
+    // 1. Global lock checks (e.g. global import or global reembed)
+    if (this.activeMaintenanceJobs.has(this._globalImportKey())) {
+      throw new WikiBusyError('import', '*');
+    }
+
+    // 2. Cross-entity prefix checks
+    let blockingOperation: string | null = null;
+    if (operation === 'prune') {
+      if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+      else if (this.activeMaintenanceJobs.has(this._importKey(entityId))) blockingOperation = 'import';
+      // ... other explicit conflicts
+    }
+
+    if (blockingOperation) {
+      throw new WikiBusyError(blockingOperation, entityId);
+    }
+
+    // 3. Acquire the requested lock
+    if (operation === 'ingest' && sourceRef) {
+      this.activeIngestJobs.add(`${this.prefix}:${entityId}:${sourceRef}`);
+    } else {
+      // Add the standard maintenance key for the operation
+    }
+
+    // 4. Notify subscribers of status transition
+    this._notifyStatusSubscribers(entityId);
   }
 
   releaseLock(operation: string, entityId: string): void {
@@ -60,6 +103,8 @@ export class JobManager {
 }
 
 ```
+
+By internalizing prefix generation and iteration, `WikiMemory` and the new domain services can simply call `this.jobManager.acquireLock('prune', entityId);` or `this.jobManager.acquireLock('ingest', entityId, sourceRef);` without needing to know how the lock keys are composed or how cross-entity conflicts are detected.
 
 ---
 
@@ -87,7 +132,7 @@ export class IngestionService {
   ) {}
 
   async ingestDocument(entityId: string, params: IngestParams): Promise<{ truncated: boolean; chunks: number }> {
-    this.jobManager.acquireLock('ingest', entityId);
+    this.jobManager.acquireLock('ingest', entityId, params.sourceRef);
     try {
       // ... chunking logic
       // ... concurrent LLM calls

--- a/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-3-spec copy.md
@@ -1,7 +1,7 @@
 # Spec: Phase 3 — Service Layer Extraction & Concurrency Decoupling
 
 **Date:** May 15, 2026
-**Status:** Draft
+**Status:** Approved
 **Scope:** Extract the remaining business logic—LLM orchestration, maintenance workflows, and concurrency locking—out of `WikiMemory` into dedicated domain services (`IngestionService`, `MaintenanceService`) and a `JobManager`.
 
 ---
@@ -180,12 +180,544 @@ To minimize merge conflicts and ensure stability, execute this refactor in two s
 
 ### PR 1: Concurrency & Utilities (`JobManager`)
 
-1. Extract `chunkText`, `withConcurrency`, and parsing utilities (`parseJsonResponse`, `clip`, `validateFact`) into a `utils/` or `parsers/` directory.
-2. Create `JobManager.ts`. Move the sets, locking logic, and `subscribeEntityStatus` logic here.
-3. Update `WikiMemory` to delegate to `this.jobManager` instead of managing `activeMaintenanceJobs` internally.
+This PR is all about foundational cleanup. By extracting the pure functions and the complex locking matrix first, we significantly reduce the noise in `WikiMemory.ts`, paving the way for a much cleaner extraction of domain services in PR 2.
+
+#### Step 1: Extract Pure Utilities
+
+Create `packages/core/src/utils/pure.ts` (or a similarly named utilities file) before building `JobManager`. Cut the pure utility functions out of `WikiMemory.ts` (lines 40-192) and place them in a dedicated utilities file.
+
+This includes:
+  * `parseJsonResponse`
+  * `safeSlice`
+  * `chunkText`
+  * `withConcurrency`
+  * `clip`
+  * `validateTags`, `validateFact`, `validateTask`
+  * `normalizeSourceRef`, `normalizeSourceHash`
+  * `titleTokens`, `jaccardScore`
+
+Update imports in `WikiMemory.ts` accordingly.
+
+* Action: Create `packages/core/src/utils/pure.ts` and move the pure helper functions there.
+* Action: Update the imports in `WikiMemory.ts` and ensure the `__testables` export at the bottom of the file still functions correctly (or update tests to import directly from the new utils file).
+
+#### Step 2: Implement `JobManager.ts`
+
+Create `packages/core/src/services/JobManager.ts` to encapsulate all lock state and subscriber notifications.
+
+* State to migrate from `WikiMemory`:
+  * `activeMaintenanceJobs` (Set)
+  * `activeIngestJobs` (Set)
+  * `statusSubscribers` (Map)
+
+* Internal helpers to migrate:
+  * Key generators: `_pruneKey`, `_reembedKey`, `_globalReembedKey`, `_importKey`, `_globalImportKey`, `_forgetKey`, `_librarianKey`, `_healKey`
+  * Status internals: `_copyEntityStatus`, `_notifyStatusSubscribers`, `_isIngestActiveFor`
+
+* Public API to implement:
+  * `acquireLock(operation: OperationType, entityId: string, sourceRef?: string): void`
+    * Logic: Move the massive `if/else if` blocks currently found at the top of `runPrune`, `runReembed`, `importDump`, etc., into this centralized method. Throw `WikiBusyError` on conflict.
+  * `releaseLock(operation: OperationType, entityId: string, sourceRef?: string): void`
+  * `getEntityStatus(entityId: string): EntityStatus`
+  * `subscribeEntityStatus(entityId: string, callback: (status: EntityStatus) => void): () => void`
+
+Provide the exact implementation below so PR 1 can be executed directly from this branch.
+
+```typescript
+import { EntityStatus, WikiBusyError } from '../types';
+
+export type OperationType = 
+  | 'prune' 
+  | 'librarian' 
+  | 'heal' 
+  | 'ingest' 
+  | 'reembed' 
+  | 'global_reembed' 
+  | 'import' 
+  | 'global_import' 
+  | 'forget';
+
+export class JobManager {
+  private activeMaintenanceJobs = new Set<string>();
+  private activeIngestJobs = new Set<string>();
+  private statusSubscribers = new Map<
+    string,
+    Set<{ callback: (s: EntityStatus) => void; last: EntityStatus }>
+  >();
+
+  constructor(private prefix: string) {}
+
+  // --- Internal Key Generators ---
+
+  private _pruneKey(entityId: string) { return `${this.prefix}:${entityId}:prune`; }
+  private _reembedKey(entityId: string) { return `${this.prefix}:${entityId}:reembed`; }
+  private _globalReembedKey() { return `${this.prefix}:reembed`; }
+  private _importKey(entityId: string) { return `${this.prefix}:${entityId}:import`; }
+  private _globalImportKey() { return `${this.prefix}:import`; }
+  private _forgetKey(entityId: string) { return `${this.prefix}:${entityId}:forget`; }
+  private _librarianKey(entityId: string) { return `${this.prefix}:${entityId}:librarian`; }
+  private _healKey(entityId: string) { return `${this.prefix}:${entityId}:heal`; }
+
+  // --- Internal State Checks ---
+
+  private _isReembedActive(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._reembedKey(entityId)) ||
+           this.activeMaintenanceJobs.has(this._globalReembedKey());
+  }
+
+  private _isImportActiveFor(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._importKey(entityId)) ||
+           this.activeMaintenanceJobs.has(this._globalImportKey());
+  }
+
+  private _isForgetActiveFor(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._forgetKey(entityId));
+  }
+
+  private _isAnyMaintenanceActiveWithSuffix(suffix: string): boolean {
+    const entityKeyPrefix = `${this.prefix}:`;
+    for (const k of this.activeMaintenanceJobs) {
+      if (k.startsWith(entityKeyPrefix) && k.endsWith(suffix)) return true;
+    }
+    return false;
+  }
+
+  private _isIngestActiveFor(entityId: string): boolean {
+    const entityKeyPrefix = `${this.prefix}:${entityId}:`;
+    for (const k of this.activeIngestJobs) {
+      if (k.startsWith(entityKeyPrefix)) return true;
+    }
+    return false;
+  }
+
+  // --- Public Lock API ---
+
+  acquireLock(operation: OperationType, entityId: string, sourceRef?: string): void {
+    let blockingOperation: string | null = null;
+
+    // 1. Universal Global Checks (applies to almost all targeted actions)
+    if (operation !== 'global_import' && this.activeMaintenanceJobs.has(this._globalImportKey())) {
+      throw new WikiBusyError('import', '*');
+    }
+
+    // 2. Specific Cross-Entity & Operation Rules
+    switch (operation) {
+      case 'prune':
+        if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'librarian':
+      case 'heal':
+        const opKey = operation === 'librarian' ? this._librarianKey(entityId) : this._healKey(entityId);
+        if (this.activeMaintenanceJobs.has(opKey)) blockingOperation = operation;
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'reembed':
+        if (this.activeMaintenanceJobs.has(this._reembedKey(entityId))) blockingOperation = 'reembed';
+        else if (this.activeMaintenanceJobs.has(this._globalReembedKey())) blockingOperation = 'reembed';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'global_reembed':
+        if (this.activeMaintenanceJobs.has(this._globalReembedKey())) blockingOperation = 'reembed';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':reembed')) blockingOperation = 'reembed';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':prune')) blockingOperation = 'prune';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':librarian')) blockingOperation = 'librarian';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':heal')) blockingOperation = 'heal';
+        else if (this.activeIngestJobs.size > 0) blockingOperation = 'ingest';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':import')) blockingOperation = 'import';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':forget')) blockingOperation = 'forget';
+        break;
+
+      case 'import':
+      case 'forget':
+        const selfKey = operation === 'import' ? this._importKey(entityId) : this._forgetKey(entityId);
+        if (this.activeMaintenanceJobs.has(selfKey)) blockingOperation = operation;
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'global_import':
+        if (this.activeMaintenanceJobs.has(this._globalImportKey())) blockingOperation = 'import';
+        break;
+
+      case 'ingest':
+        const ingestJobKey = `${this.prefix}:${entityId}:${sourceRef}`;
+        if (this.activeIngestJobs.has(ingestJobKey)) blockingOperation = 'ingest';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+    }
+
+    if (blockingOperation) {
+      throw new WikiBusyError(
+        blockingOperation, 
+        operation === 'global_reembed' || operation === 'global_import' ? '*' : entityId
+      );
+    }
+
+    // 3. Apply the Lock
+    if (operation === 'ingest') {
+      this.activeIngestJobs.add(`${this.prefix}:${entityId}:${sourceRef}`);
+    } else if (operation === 'global_reembed') {
+      this.activeMaintenanceJobs.add(this._globalReembedKey());
+    } else if (operation === 'global_import') {
+      this.activeMaintenanceJobs.add(this._globalImportKey());
+    } else {
+      const keyFnName = `_${operation}Key` as keyof this;
+      const keyFn = this[keyFnName] as (id: string) => string;
+      this.activeMaintenanceJobs.add(keyFn.call(this, entityId));
+    }
+
+    this._notifyStatusSubscribers(entityId);
+  }
+
+  releaseLock(operation: OperationType, entityId: string, sourceRef?: string): void {
+    if (operation === 'ingest') {
+      this.activeIngestJobs.delete(`${this.prefix}:${entityId}:${sourceRef}`);
+    } else if (operation === 'global_reembed') {
+      this.activeMaintenanceJobs.delete(this._globalReembedKey());
+    } else if (operation === 'global_import') {
+      this.activeMaintenanceJobs.delete(this._globalImportKey());
+    } else {
+      const keyFnName = `_${operation}Key` as keyof this;
+      const keyFn = this[keyFnName] as (id: string) => string;
+      this.activeMaintenanceJobs.delete(keyFn.call(this, entityId));
+    }
+
+    this._notifyStatusSubscribers(entityId);
+  }
+
+  // --- Status API ---
+
+  getEntityStatus(entityId: string): EntityStatus {
+    return {
+      ingesting: this._isIngestActiveFor(entityId),
+      librarian: this.activeMaintenanceJobs.has(this._librarianKey(entityId)),
+      heal: this.activeMaintenanceJobs.has(this._healKey(entityId)),
+    };
+  }
+
+  subscribeEntityStatus(entityId: string, callback: (status: EntityStatus) => void): () => void {
+    const initial = this.getEntityStatus(entityId);
+    let set = this.statusSubscribers.get(entityId);
+    if (!set) {
+      set = new Set();
+      this.statusSubscribers.set(entityId, set);
+    }
+    
+    const entry = { callback, last: this._copyEntityStatus(initial) };
+    set.add(entry);
+    
+    try {
+      callback(this._copyEntityStatus(initial));
+    } catch (err) {
+      console.error(`[JobManager] callback error for entityId="${entityId}" during initial emission`, err);
+    }
+    
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const s = this.statusSubscribers.get(entityId);
+      if (!s) return;
+      s.delete(entry);
+      if (s.size === 0) this.statusSubscribers.delete(entityId);
+    };
+  }
+
+  private _copyEntityStatus(s: EntityStatus): EntityStatus {
+    return { ingesting: s.ingesting, librarian: s.librarian, heal: s.heal };
+  }
+
+  private _notifyStatusSubscribers(entityId: string): void {
+    if (entityId === '*') return; // Globals don't trigger specific entity UI events directly here
+    
+    const set = this.statusSubscribers.get(entityId);
+    if (!set || set.size === 0) return;
+    
+    for (const entry of Array.from(set)) {
+      if (!set.has(entry)) continue;
+      const next = this.getEntityStatus(entityId);
+      
+      if (entry.last.ingesting === next.ingesting &&
+          entry.last.librarian === next.librarian &&
+          entry.last.heal === next.heal) {
+        continue;
+      }
+      
+      entry.last = this._copyEntityStatus(next);
+      try {
+        entry.callback(this._copyEntityStatus(next));
+      } catch (err) {
+        console.error(`[JobManager] callback error for entityId="${entityId}" during transition emission`, err);
+      }
+    }
+  }
+}
+```
+
+#### Step 3: Wire `WikiMemory` to `JobManager`
+
+With the manager built, gut the manual lock management from `WikiMemory`.
+
+* Constructor: instantiate `this.jobManager = new JobManager(this.prefix);`
+* Targeted find-and-replace (lock acquisition): audit `runPrune`, `runLibrarian`, `runHeal`, `runReembed`, `importDump`, `forget`, and `ingestDocument`; replace their sprawling conflict checks with a single call to `this.jobManager.acquireLock(...)`.
+* Ensure the `finally` blocks call `this.jobManager.releaseLock(...)`.
+* Targeted find-and-replace (status): delegate `getEntityStatus` and `subscribeEntityStatus` directly to `this.jobManager`.
+
+#### Step 4: Verification & Testing
+
+* Update any tests that mock or assert against `activeMaintenanceJobs` directly (if any) to interface with `JobManager` instead.
+* Verify that concurrent calls to `ingestDocument` and `runPrune` for the same entity still correctly throw a `WikiBusyError`.
 
 ### PR 2: Domain Services (`IngestionService` & `MaintenanceService`)
 
-1. Create `IngestionService.ts`. Move `ingestDocument` and its associated types into this class.
-2. Create `MaintenanceService.ts`. Move `runPrune`, `runLibrarian`, `runHeal`, `runReembed`, and `forget` into this class.
-3. Update `WikiMemory.ts` to instantiate these services in the constructor and act as a simple pass-through facade for the public API.
+Excellent. With the `JobManager` handling the complex concurrency matrix and the utilities out of the way, `WikiMemory.ts` is primed for the final extraction.
+
+Here is the exact execution plan and implementation guide for **PR 2: Domain Services (`IngestionService` & `MaintenanceService`)**.
+
+---
+
+## PR 2 Spec: The Domain Services Extraction
+
+**Goal:** Strip all LLM orchestration, background task logic, and database transaction loops out of `WikiMemory`, turning it into a clean, read/write Facade.
+
+### Step 1: Create `packages/core/src/services/IngestionService.ts`
+
+This service owns the `ingestDocument` pipeline. It relies entirely on the `JobManager` for lock acquisition.
+
+```typescript
+import { chunkText, withConcurrency, validateFact, parseJsonResponse } from '../utils/pure';
+import { INGEST_SYSTEM_PROMPT } from '../prompts';
+import { generateId } from '../utils/ids';
+import { normalizeSourceRef, normalizeSourceHash } from '../utils/pure';
+import type { WikiOptions, ExtractedFact, WikiFact } from '../types';
+import type { SQLiteAdapter } from '../types';
+import type { EntryRepository } from '../repositories/EntryRepository';
+import type { SearchService } from './SearchService';
+import type { JobManager } from './JobManager';
+
+export class IngestionService {
+  constructor(
+    private db: SQLiteAdapter,
+    private prefix: string,
+    private options: WikiOptions,
+    private entryRepo: EntryRepository,
+    private searchService: SearchService,
+    private jobManager: JobManager,
+    private embedFactFn: (fact: { id: string; entity_id: string; title: string; body: string; tags: string | string[] }) => Promise<boolean>,
+    private notifyPersistedFn: (entityId: string, factId: string, vector: Float32Array | null) => Promise<void>
+  ) {}
+
+  async ingestDocument(
+    entityId: string,
+    params: {
+      sourceRef: string;
+      sourceHash: string;
+      documentChunk: string;
+      maxChunkLength?: number;
+      chunkOverlap?: number;
+      chunkConcurrency?: number;
+    }
+  ): Promise<{ truncated: boolean; chunks: number }> {
+    const sourceRef = normalizeSourceRef(params.sourceRef);
+    if (!sourceRef) throw new Error('Invalid sourceRef');
+
+    const sourceHash = normalizeSourceHash(params.sourceHash);
+    if (!sourceHash) throw new Error('Invalid sourceHash (must be 64-char hex string)');
+
+    const maxChunkLength = params.maxChunkLength ?? this.options.config?.maxChunkLength ?? 12000;
+    const rawOverlap = params.chunkOverlap ?? this.options.config?.chunkOverlap ?? 400;
+    const chunkOverlap = Math.min(
+      Number.isFinite(rawOverlap) && rawOverlap >= 0 ? Math.floor(rawOverlap) : 400,
+      maxChunkLength - 1
+    );
+
+    const rawConcurrency = params.chunkConcurrency ?? this.options.config?.chunkConcurrency ?? 1;
+    const chunkConcurrency = Number.isFinite(rawConcurrency) && rawConcurrency >= 1 ? Math.floor(rawConcurrency) : 1;
+
+    if (typeof params.documentChunk !== 'string') {
+      throw new Error(`documentChunk must be a string, received ${typeof params.documentChunk}`);
+    }
+
+    // 1. Lock Acquisition via JobManager
+    this.jobManager.acquireLock('ingest', entityId, sourceRef);
+
+    try {
+      const { chunks, truncated } = chunkText(params.documentChunk, maxChunkLength, chunkOverlap);
+      if (chunks.length === 0) return { truncated: false, chunks: 0 };
+
+      // 2. LLM Processing
+      const chunkResults = await withConcurrency(
+        chunks.map((chunk) => async () => {
+          const userPrompt = `Document Chunk:\n${chunk}`;
+          const responseText = await this.options.llmProvider.generateText({
+            systemPrompt: INGEST_SYSTEM_PROMPT,
+            userPrompt,
+          });
+          const result = parseJsonResponse<{ facts: ExtractedFact[] }>(responseText);
+          return (Array.isArray(result.facts) ? result.facts : [])
+            .map(validateFact)
+            .filter((f): f is ExtractedFact => f !== null);
+        }),
+        chunkConcurrency
+      );
+
+      const seen = new Set<string>();
+      const allValidFacts: ExtractedFact[] = [];
+      for (const facts of chunkResults) {
+        for (const fact of facts) {
+          const normalized = fact.title.trim().toLowerCase().replace(/\s+/g, ' ');
+          if (!seen.has(normalized)) {
+            seen.add(normalized);
+            allValidFacts.push(fact);
+          }
+        }
+      }
+
+      const now = Date.now();
+      const insertedFacts: Array<{ id: string; entity_id: string; title: string; body: string; tags: string }> = [];
+      const deletedSourceFactIds: string[] = [];
+
+      // 3. Database Commit
+      await this.db.withTransactionAsync(async (tx) => {
+        deletedSourceFactIds.push(...(await this.entryRepo.findIdsBySource(entityId, sourceRef, null, tx, false)));
+        await this.entryRepo.softDeleteBySource(entityId, tx, sourceRef, null);
+
+        for (const fact of allValidFacts) {
+          const id = generateId('fact_');
+          const wikiFact: WikiFact = {
+            id, entity_id: entityId, title: fact.title, body: fact.body, tags: fact.tags, confidence: fact.confidence,
+            source_type: 'immutable_document', source_hash: sourceHash, source_ref: sourceRef,
+            created_at: now, updated_at: now, last_accessed_at: null, access_count: 0, deleted_at: null,
+          };
+          await this.entryRepo.upsert(wikiFact, tx);
+          insertedFacts.push({ id, entity_id: entityId, title: fact.title, body: fact.body, tags: JSON.stringify(fact.tags) });
+        }
+      });
+
+      // 4. Cache Sync & Side Effects
+      await this.searchService.sync(entityId);
+
+      const uniqueDeletedSourceFactIds = Array.from(new Set(deletedSourceFactIds));
+      for (const factId of uniqueDeletedSourceFactIds) {
+        try {
+          await this.notifyPersistedFn(entityId, factId, null);
+        } catch (hookErr) {
+          console.warn(`[WikiMemory] onEmbeddingPersisted hook failed during ingest for ${factId}:`, hookErr);
+        }
+      }
+
+      for (const fact of insertedFacts) {
+        await this.embedFactFn(fact);
+      }
+
+      this.searchService.evictCache(entityId);
+      return { truncated, chunks: chunks.length };
+
+    } finally {
+      // 5. Lock Release
+      this.jobManager.releaseLock('ingest', entityId, sourceRef);
+    }
+  }
+}
+```
+
+*(Note: We pass `embedFact` and `notifyPersisted` as callbacks in the constructor to avoid moving the highly specific vector-ranker hook logic out of `WikiMemory`'s direct control, keeping the service layers focused purely on the orchestration flow).* 
+
+---
+
+### Step 2: Create `packages/core/src/services/MaintenanceService.ts`
+
+This service will absorb `runLibrarian`, `_doRunLibrarian`, `runHeal`, `_doRunHeal`, `runPrune`, `runReembed`, and `forget`.
+
+Create the file and port those methods over. The structure is identical to `IngestionService`:
+
+1. The constructor takes the required Repositories, the `SearchService`, the `JobManager`, and the `embedFactFn` / hook callbacks.
+2. The massive lock-checking blocks at the top of each method are replaced with `this.jobManager.acquireLock('...', entityId);`.
+
+*Example of how clean `forget` becomes:*
+
+```typescript
+async forget(entityId: string, params: { entryId?: string; taskId?: string; sourceRef?: string; sourceHash?: string; clearAll?: boolean }): Promise<{ deleted: { entries: number; tasks: number } }> {
+  // Was 20 lines of checks, now just one:
+  this.jobManager.acquireLock('forget', entityId);
+  try {
+    // ... exact same database transaction logic ...
+  } finally {
+    this.jobManager.releaseLock('forget', entityId);
+  }
+}
+```
+
+---
+
+### Step 3: Wire up `WikiMemory.ts` (The Facade)
+
+Now, we gut the original implementation from `WikiMemory` and wire it up to our shiny new services.
+
+1. **Imports & Properties:** Import the new services and add them as private properties.
+2. **Constructor Initialization:**
+```typescript
+this.ingestionService = new IngestionService(
+  this.db, this.prefix, this.options, this.entryRepo, this.searchService, this.jobManager,
+  this.embedFact.bind(this), this._notifyEmbeddingPersisted.bind(this)
+);
+
+this.maintenanceService = new MaintenanceService(
+  this.db, this.prefix, this.options, this.entryRepo, this.taskRepo, this.eventRepo, this.metadataRepo, this.searchService, this.jobManager,
+  this.embedFact.bind(this), this._notifyEmbeddingPersisted.bind(this), this._notifyEmbeddingPersistedOrThrow.bind(this), this._reconcileEmbeddingDimension.bind(this)
+);
+```
+
+3. **Delegation:** Replace the entire bodies of the public methods with pass-throughs.
+```typescript
+async ingestDocument(entityId: string, params: any) {
+  return this.ingestionService.ingestDocument(entityId, params);
+}
+
+async runPrune(entityId: string, options?: any) {
+  return this.maintenanceService.runPrune(entityId, options);
+}
+
+async runLibrarian(entityId: string) {
+  return this.maintenanceService.runLibrarian(entityId);
+}
+
+async runHeal(entityId: string) {
+  return this.maintenanceService.runHeal(entityId);
+}
+
+async runReembed(entityId?: string, opts?: any) {
+  return this.maintenanceService.runReembed(entityId, opts);
+}
+
+async forget(entityId: string, params: any) {
+  return this.maintenanceService.forget(entityId, params);
+}
+```
+
+*(Note: Ensure you leave `read()`, `write()`, `importDump()`, and `exportDump()` in `WikiMemory.ts`, as they represent the core public data pathways and orchestrate the external hooks directly).*

--- a/docs/superpowers/specs/2026-05-15-repository-phase-3-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-3-spec.md
@@ -654,24 +654,496 @@ export class IngestionService {
 
 This service will absorb `runLibrarian`, `_doRunLibrarian`, `runHeal`, `_doRunHeal`, `runPrune`, `runReembed`, and `forget`.
 
-Create the file and port those methods over. The structure is identical to `IngestionService`:
+Before pasting the implementation below, make sure `HOOK_TIMEOUT_MARKER` is exported from `WikiMemory.ts` or moved to a shared constants/types file so `MaintenanceService` can correctly identify hook timeout errors during `runPrune` and `forget`.
 
-1. The constructor takes the required Repositories, the `SearchService`, the `JobManager`, and the `embedFactFn` / hook callbacks.
-2. The massive lock-checking blocks at the top of each method are replaced with `this.jobManager.acquireLock('...', entityId);`.
-
-*Example of how clean `forget` becomes:*
+Here is the complete, copy-pasteable implementation for `packages/core/src/services/MaintenanceService.ts`.
 
 ```typescript
-async forget(entityId: string, params: { entryId?: string; taskId?: string; sourceRef?: string; sourceHash?: string; clearAll?: boolean }): Promise<{ deleted: { entries: number; tasks: number } }> {
-  // Was 20 lines of checks, now just one:
-  this.jobManager.acquireLock('forget', entityId);
-  try {
-    // ... exact same database transaction logic ...
-  } finally {
-    this.jobManager.releaseLock('forget', entityId);
+import { parseJsonResponse, validateFact, validateTask, titleTokens, jaccardScore, normalizeSourceRef, normalizeSourceHash } from '../utils/pure';
+import { LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT } from '../prompts';
+import { generateId } from '../utils/ids';
+import { parseEmbedding } from '../utils/embedding';
+import { PrunePartialFailureError } from '../types';
+import type { WikiOptions, ExtractedFact, ExtractedTask, WikiFact, WikiTask } from '../types';
+import type { SQLiteAdapter } from '../types';
+import type { EntryRepository } from '../repositories/EntryRepository';
+import type { TaskRepository } from '../repositories/TaskRepository';
+import type { EventRepository } from '../repositories/EventRepository';
+import type { MetadataRepository } from '../repositories/MetadataRepository';
+import type { SearchService } from './SearchService';
+import type { JobManager } from './JobManager';
+
+// Constants used by the Librarian deduplication logic
+const FUZZY_THRESHOLD = 0.5;
+const MIN_TOKENS_TO_QUALIFY = 3;
+
+// Import this from wherever you ended up placing it (e.g., types, pure utils, or WikiMemory)
+import { HOOK_TIMEOUT_MARKER } from '../WikiMemory'; 
+
+export class MaintenanceService {
+  constructor(
+    private db: SQLiteAdapter,
+    private prefix: string,
+    private options: WikiOptions,
+    private entryRepo: EntryRepository,
+    private taskRepo: TaskRepository,
+    private eventRepo: EventRepository,
+    private metadataRepo: MetadataRepository,
+    private searchService: SearchService,
+    private jobManager: JobManager,
+    private embedFactFn: (fact: { id: string; entity_id: string; title: string; body: string; tags: string | string[] }) => Promise<boolean>,
+    private notifyPersistedFn: (entityId: string, factId: string, vector: Float32Array | null) => Promise<void>,
+    private notifyPersistedOrThrowFn: (entityId: string, factId: string, vector: Float32Array | null) => Promise<void>,
+    private reconcileEmbeddingDimensionFn: () => Promise<void>
+  ) {}
+
+  // --- Public Background & Lifecycle Methods ---
+
+  async runPrune(entityId: string, options?: { retainSoftDeletedFor?: number | null; retainEventsFor?: number | null; vacuum?: boolean; }): Promise<{ entries: number; tasks: number; events: number }> {
+    this.jobManager.acquireLock('prune', entityId);
+    
+    try {
+      const retainSoftDeletedFor = options?.retainSoftDeletedFor !== undefined ? options.retainSoftDeletedFor : (this.options.config?.pruneRetainSoftDeletedFor ?? 7);
+      const retainEventsFor = options?.retainEventsFor !== undefined ? options.retainEventsFor : (this.options.config?.pruneEventsAfter ?? 30);
+      const vacuum = options?.vacuum ?? false;
+
+      this._validatePruneDuration(retainSoftDeletedFor, 'retainSoftDeletedFor');
+      this._validatePruneDuration(retainEventsFor, 'retainEventsFor');
+
+      const now = Date.now();
+      let deletedEntries = 0;
+      let deletedTasks = 0;
+      let deletedEvents = 0;
+
+      if (retainSoftDeletedFor !== null) {
+        const cutoff = now - retainSoftDeletedFor * 86400000;
+        const entriesToDelete = await this.entryRepo.getPrunableMetadata(entityId, cutoff);
+
+        const succeeded: Array<{ entity_id: string; id: string }> = [];
+        let failure: { factId: string; cause: unknown } | null = null;
+
+        for (const row of entriesToDelete) {
+          try {
+            await this.notifyPersistedOrThrowFn(row.entity_id, row.id, null);
+            succeeded.push({ entity_id: row.entity_id, id: row.id });
+          } catch (err) {
+            failure = { factId: row.id, cause: err };
+            break;
+          }
+        }
+
+        const succeededIds = succeeded.map(r => r.id);
+
+        await this.db.withTransactionAsync(async (tx) => {
+          if (succeededIds.length > 0) {
+            deletedEntries = await this.entryRepo.bulkDeletePruned(entityId, cutoff, succeededIds, tx);
+          }
+          deletedTasks = await this.taskRepo.bulkDeletePruned(entityId, cutoff, tx);
+        });
+
+        if (failure) {
+          await this.searchService.sync(entityId);
+          const remaining = entriesToDelete.length - succeeded.length - 1;
+          const isTimeout = (failure.cause as any)?.[HOOK_TIMEOUT_MARKER] === true;
+
+          if (isTimeout) {
+            throw new PrunePartialFailureError(
+              succeeded.length, failure.factId, remaining, new Error('Deletion hook timed out'), deletedTasks, 0
+            );
+          }
+
+          const errMsg = (failure.cause as Error)?.message ?? '';
+          const isValidationError = errMsg.startsWith('Invalid deletionHookTimeoutMs');
+          const sanitizedCause = isValidationError ? failure.cause as Error : this._sanitizeRankerError(failure.cause);
+
+          throw new PrunePartialFailureError(
+            succeeded.length, failure.factId, remaining, sanitizedCause, deletedTasks, 0
+          );
+        }
+      }
+
+      if (retainEventsFor !== null) {
+        const cutoff = now - retainEventsFor * 86400000;
+        const eventResult = await this.eventRepo.prune(entityId, cutoff);
+        deletedEvents = eventResult.changes;
+      }
+
+      if (vacuum) {
+        await this.metadataRepo.vacuum();
+      }
+
+      await this.searchService.sync(entityId);
+      return { entries: deletedEntries, tasks: deletedTasks, events: deletedEvents };
+    } finally {
+      this.jobManager.releaseLock('prune', entityId);
+    }
+  }
+
+  async runLibrarian(entityId: string): Promise<void> {
+    this.jobManager.acquireLock('librarian', entityId);
+    try {
+      await this._doRunLibrarian(entityId);
+    } finally {
+      this.jobManager.releaseLock('librarian', entityId);
+    }
+  }
+
+  async runHeal(entityId: string): Promise<void> {
+    this.jobManager.acquireLock('heal', entityId);
+    try {
+      await this._doRunHeal(entityId);
+    } finally {
+      this.jobManager.releaseLock('heal', entityId);
+    }
+  }
+
+  async runReembed(entityId?: string, opts?: { force?: boolean; skipExisting?: boolean }): Promise<{ embedded: number; skipped: number; failed: number }> {
+    const op = entityId ? 'reembed' : 'global_reembed';
+    this.jobManager.acquireLock(op, entityId ?? '*');
+    
+    try {
+      const embedFn = this.options.llmProvider.embed;
+      if (!embedFn) return { embedded: 0, skipped: 0, failed: 0 };
+
+      const rows = await this.entryRepo.findAllForReembed(entityId);
+      this.searchService.evictCache(entityId);
+
+      const skipExisting = opts?.skipExisting ?? false;
+      let effectiveSkip = skipExisting;
+
+      if (skipExisting) {
+        const mismatchValue = await this.metadataRepo.getMeta('embedding_dimension_mismatch');
+        if (mismatchValue) {
+          if (entityId) {
+            const mismatchDim = parseInt(mismatchValue, 10);
+            const staleCount = await this.entryRepo.countStaleForEntity(entityId, mismatchDim);
+            if (staleCount > 0) effectiveSkip = false;
+          } else {
+            effectiveSkip = false;
+          }
+        }
+      }
+
+      let embedded = 0;
+      let skipped = 0;
+      let failed = 0;
+
+      try {
+        for (const row of rows) {
+          const existingBlob = (row as WikiFact & { embedding_blob?: Uint8Array | null }).embedding_blob;
+          const blobIsValid = !!existingBlob && existingBlob.byteLength > 0 && existingBlob.byteLength % 4 === 0;
+          
+          if (effectiveSkip && blobIsValid) {
+            const vec = parseEmbedding(existingBlob, null);
+            if (vec !== null && vec.every(v => Number.isFinite(v))) {
+              skipped++;
+              continue;
+            }
+          }
+
+          const success = await this.embedFactFn(row);
+          if (success) embedded++;
+          else failed++;
+        }
+
+        if (embedded > 0) {
+          await this.reconcileEmbeddingDimensionFn();
+        }
+      } finally {
+        this.searchService.evictCache(entityId);
+      }
+
+      return { embedded, skipped, failed };
+    } finally {
+      this.jobManager.releaseLock(op, entityId ?? '*');
+    }
+  }
+
+  async forget(entityId: string, params: { entryId?: string; taskId?: string; sourceRef?: string; sourceHash?: string; clearAll?: boolean }): Promise<{ deleted: { entries: number; tasks: number } }> {
+    this.jobManager.acquireLock('forget', entityId);
+    
+    try {
+      const now = Date.now();
+      let deletedEntries = 0;
+      let deletedTasks = 0;
+      const deletedEntryIds: string[] = [];
+
+      await this.db.withTransactionAsync(async (tx) => {
+        if (params.clearAll) {
+          deletedEntryIds.push(...await this.entryRepo.findIdsBySource(entityId, null, null, tx, true));
+          deletedEntries = await this.entryRepo.bulkSoftDeleteByEntityId(entityId, tx);
+          deletedTasks = await this.taskRepo.bulkSoftDeleteByEntityId(entityId, tx);
+          await this.metadataRepo.updateCheckpoint(entityId, { memory: 0, heal: 0 }, tx);
+        } else {
+          const hasIdSelectors = params.entryId !== undefined || params.taskId !== undefined;
+          const hasSourceSelectors = params.sourceRef !== undefined || params.sourceHash !== undefined;
+
+          if (hasIdSelectors && hasSourceSelectors) {
+            throw new Error('forget() params are mutually exclusive: use entryId/taskId together, or sourceRef/sourceHash together, but not both in the same call');
+          }
+
+          const sourceRef = params.sourceRef !== undefined ? normalizeSourceRef(params.sourceRef) : null;
+          if (params.sourceRef !== undefined && !sourceRef) throw new Error('Invalid sourceRef');
+
+          const sourceHash = params.sourceHash !== undefined ? normalizeSourceHash(params.sourceHash) : null;
+          if (params.sourceHash !== undefined && !sourceHash) throw new Error('Invalid sourceHash (must be 64-char hex string)');
+
+          if (params.entryId) {
+            const entryId = await this.entryRepo.findIdById(params.entryId, entityId, tx);
+            if (entryId) deletedEntryIds.push(entryId);
+          }
+
+          if (sourceRef || sourceHash) {
+            deletedEntryIds.push(...await this.entryRepo.findIdsBySource(entityId, sourceRef, sourceHash, tx, true));
+          }
+
+          const entryPromise = params.entryId ? this.entryRepo.softDelete(params.entryId, entityId, tx).then(r => r.changes > 0) : null;
+          const taskDeletedPromise = params.taskId ? this.taskRepo.softDeleteById(params.taskId, entityId, tx).then(r => r.changes > 0) : null;
+          const refPromise = (sourceRef || sourceHash) ? this.entryRepo.softDeleteBySource(entityId, tx, sourceRef, sourceHash) : null;
+
+          const [entryResult, taskResult, refResult] = await Promise.all([
+            entryPromise ?? Promise.resolve(false),
+            taskDeletedPromise ?? Promise.resolve(false),
+            refPromise ?? Promise.resolve(0),
+          ]);
+
+          if (entryResult) deletedEntries++;
+          if (taskResult) deletedTasks++;
+          deletedEntries += refResult;
+        }
+      });
+
+      await this.searchService.sync(entityId);
+
+      const uniqueDeletedIds = Array.from(new Set(deletedEntryIds));
+      for (const factId of uniqueDeletedIds) {
+        try {
+          await this.notifyPersistedOrThrowFn(entityId, factId, null);
+        } catch (hookErr) {
+          const isTimeout = (hookErr as any)?.[HOOK_TIMEOUT_MARKER] === true;
+          if (isTimeout) {
+            throw new Error(`forget(${entityId}/${factId}) failed: ${(hookErr as Error).message}`);
+          }
+          const errMsg = (hookErr as Error)?.message ?? '';
+          if (errMsg.startsWith('Invalid deletionHookTimeoutMs')) {
+            throw new Error(`forget(${entityId}/${factId}) failed: ${errMsg}`, { cause: hookErr });
+          }
+          throw new Error(`forget(${entityId}/${factId}) failed: ANN cleanup hook rejected`, { cause: this._sanitizeRankerError(hookErr) });
+        }
+      }
+
+      return { deleted: { entries: deletedEntries, tasks: deletedTasks } };
+    } finally {
+      this.jobManager.releaseLock('forget', entityId);
+    }
+  }
+
+  // --- Internal Implementations & Hooks ---
+
+  async _doRunLibrarian(entityId: string): Promise<void> {
+    const events = await this.eventRepo.getRecent(entityId, 50);
+    const currentFactsRows = await this.entryRepo.findRecentByEntityId(entityId, 100);
+    
+    const currentFacts = currentFactsRows.map(f => {
+      const { embedding: _embedding, embedding_blob: _blob, ...rest } = f as WikiFact & { embedding?: unknown; embedding_blob?: unknown };
+      return {
+        ...rest,
+        tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags,
+      };
+    });
+
+    const userPrompt = `Events:\n${JSON.stringify(events.reverse(), null, 2)}\n\nCurrent Facts:\n${JSON.stringify(currentFacts, null, 2)}`;
+
+    const responseText = await this.options.llmProvider.generateText({
+      systemPrompt: LIBRARIAN_SYSTEM_PROMPT,
+      userPrompt,
+    });
+
+    const result = parseJsonResponse<{ facts: ExtractedFact[], tasks: ExtractedTask[] }>(responseText);
+    const facts = Array.isArray(result.facts) ? result.facts : [];
+    const tasks = Array.isArray(result.tasks) ? result.tasks : [];
+
+    const validFacts = facts.map(validateFact).filter((f): f is ExtractedFact => f !== null);
+    const validTasks = tasks.map(validateTask).filter((t): t is ExtractedTask => t !== null);
+
+    const now = Date.now();
+    const insertedFacts: Array<{ id: string; entity_id: string; title: string; body: string; tags: string }> = [];
+
+    await this.db.withTransactionAsync(async (tx) => {
+      const factsForDedupe = await this.entryRepo.findRecentByEntityId(entityId, 100, tx);
+
+      for (const fact of validFacts) {
+        const newTokens = titleTokens(fact.title);
+        let skip = false;
+
+        if (newTokens.size >= MIN_TOKENS_TO_QUALIFY) {
+          for (const existing of factsForDedupe) {
+            if (existing.source_type !== 'librarian_inferred') continue;
+            const existingTokens = titleTokens(existing.title);
+            if (existingTokens.size >= MIN_TOKENS_TO_QUALIFY) {
+              if (jaccardScore(newTokens, existingTokens) >= FUZZY_THRESHOLD) {
+                skip = true;
+                break;
+              }
+            }
+          }
+        }
+
+        if (skip) continue;
+
+        const id = generateId('fact_');
+        const factObj: WikiFact = {
+          id, entity_id: entityId, title: fact.title, body: fact.body, tags: fact.tags, confidence: fact.confidence,
+          source_type: 'librarian_inferred', source_hash: null, source_ref: null,
+          created_at: now, updated_at: now, last_accessed_at: null, access_count: 0, deleted_at: null,
+        };
+
+        await this.entryRepo.upsert(factObj, tx);
+        insertedFacts.push({ id, entity_id: entityId, title: fact.title, body: fact.body, tags: JSON.stringify(fact.tags) });
+      }
+
+      for (const task of validTasks) {
+        const id = generateId('task_');
+        const taskObj: WikiTask = {
+          id, entity_id: entityId, description: task.description, status: 'pending', priority: task.priority,
+          created_at: now, updated_at: now, resolved_at: null, deleted_at: null
+        };
+        await this.taskRepo.upsert(taskObj, tx);
+      }
+    });
+
+    await this.searchService.sync(entityId);
+
+    for (const fact of insertedFacts) {
+      await this.embedFactFn(fact);
+    }
+
+    this.searchService.evictCache(entityId);
+  }
+
+  async _doRunHeal(entityId: string): Promise<void> {
+    const now = Date.now();
+    const orphanAfterDays = this.options.config?.orphanAfterDays !== undefined ? this.options.config?.orphanAfterDays : 30;
+    const staleInferredAfterDays = this.options.config?.staleInferredAfterDays !== undefined ? this.options.config?.staleInferredAfterDays : 60;
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+    if (orphanAfterDays !== null && (typeof orphanAfterDays !== 'number' || !Number.isFinite(orphanAfterDays) || orphanAfterDays < 0)) {
+      throw new Error('Invalid orphanAfterDays: must be a finite number >= 0 or null');
+    }
+    if (staleInferredAfterDays !== null && (typeof staleInferredAfterDays !== 'number' || !Number.isFinite(staleInferredAfterDays) || staleInferredAfterDays < 0)) {
+      throw new Error('Invalid staleInferredAfterDays: must be a finite number >= 0 or null');
+    }
+
+    await this.db.withTransactionAsync(async (tx) => {
+      if (orphanAfterDays !== null) {
+        const orphanThreshold = now - (orphanAfterDays * MS_PER_DAY);
+        await this.entryRepo.markOrphaned(entityId, orphanThreshold, tx);
+      }
+      if (staleInferredAfterDays !== null) {
+        const staleThreshold = now - (staleInferredAfterDays * MS_PER_DAY);
+        await this.entryRepo.downgradeStaleInferred(entityId, staleThreshold, tx);
+      }
+    });
+
+    const allFactsRows = await this.entryRepo.findAllByEntityId(entityId);
+    const allTasks = await this.taskRepo.findAllPending([entityId]);
+    const recentEvents = await this.eventRepo.getRecent(entityId, 20);
+
+    const healCandidates = allFactsRows.filter(f => f.source_type !== 'immutable_document');
+    const documentAnchors = allFactsRows
+      .filter(f => f.source_type === 'immutable_document')
+      .map(({ id, title, source_ref }) => ({ id, title, source_ref }));
+
+    const userPrompt = `Heal Candidates:\n${JSON.stringify(healCandidates.map(f => {
+      const { embedding: _embedding, embedding_blob: _blob, ...rest } = f as WikiFact & { embedding?: unknown; embedding_blob?: unknown };
+      return { ...rest, tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags };
+    }), null, 2)}
+    \nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}
+    \nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}
+    \nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}
+    \nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`;
+
+    const responseText = await this.options.llmProvider.generateText({
+      systemPrompt: HEAL_SYSTEM_PROMPT,
+      userPrompt,
+    });
+
+    const result = parseJsonResponse<{ downgraded: string[], deleted: string[], newFacts: ExtractedFact[] }>(responseText);
+
+    const mutableIds = new Set(healCandidates.map(f => f.id));
+    const downgraded = Array.isArray(result.downgraded) ? result.downgraded : [];
+    const deleted = Array.isArray(result.deleted) ? result.deleted : [];
+    const newFacts = Array.isArray(result.newFacts) ? result.newFacts : [];
+
+    const safeDowngraded = downgraded.filter(id => mutableIds.has(id));
+    const safeDeleted = deleted.filter(id => mutableIds.has(id));
+    const validNewFacts = newFacts.map(validateFact).filter((f): f is ExtractedFact => f !== null);
+
+    const insertedFacts: Array<{ id: string; entity_id: string; title: string; body: string; tags: string }> = [];
+    const uniqueDeletedFactIds = Array.from(new Set(safeDeleted));
+
+    await this.db.withTransactionAsync(async (tx) => {
+      await this.entryRepo.downgradeByIds(safeDowngraded, entityId, tx);
+      await this.entryRepo.softDeleteByIds(safeDeleted, entityId, tx);
+
+      for (const fact of validNewFacts) {
+        const id = generateId('fact_');
+        const factObj: WikiFact = {
+          id, entity_id: entityId, title: fact.title, body: fact.body, tags: fact.tags, confidence: fact.confidence,
+          source_type: 'librarian_inferred', source_hash: null, source_ref: null,
+          created_at: now, updated_at: now, last_accessed_at: null, access_count: 0, deleted_at: null,
+        };
+
+        await this.entryRepo.upsert(factObj, tx);
+        insertedFacts.push({ id, entity_id: entityId, title: fact.title, body: fact.body, tags: JSON.stringify(fact.tags) });
+      }
+    });
+
+    await this.searchService.sync(entityId);
+
+    for (const factId of uniqueDeletedFactIds) {
+      try {
+        await this.notifyPersistedFn(entityId, factId, null);
+      } catch (hookErr) {
+        console.warn(`[WikiMemory] onEmbeddingPersisted hook failed during heal for ${factId}:`, hookErr);
+      }
+    }
+
+    for (const fact of insertedFacts) {
+      await this.embedFactFn(fact);
+    }
+
+    this.searchService.evictCache(entityId);
+  }
+
+  // --- Utility Methods ---
+
+  private _validatePruneDuration(value: number | null | undefined, name: string): void {
+    if (value !== null && value !== undefined && (typeof value !== 'number' || !isFinite(value) || value < 0)) {
+      throw new Error(`Invalid ${name}: must be a non-negative finite number or null`);
+    }
+  }
+
+  private _sanitizeRankerError(err: unknown): Error {
+    if (this.options.sanitizeRankerErrors === false) {
+      return err instanceof Error ? err : new Error(String(err));
+    }
+    const typeName = err instanceof Error ? (err.constructor?.name ?? 'Error') : typeof err;
+    const innerCause = err instanceof Error && err.cause !== undefined
+      ? new Error(`Caused by: ${(err.cause as Error)?.constructor?.name ?? typeof err.cause}`)
+      : undefined;
+
+    const sanitized = new Error(
+      `VectorRanker ${typeName} (message scrubbed for security)`,
+      innerCause ? { cause: innerCause } : undefined,
+    );
+    sanitized.name = typeName;
+    return sanitized;
   }
 }
 ```
+
+The service should be written as an independent domain layer, with its own imports and lifecycle methods. Keep the wrapper callbacks in the constructor so `WikiMemory` retains ownership of hook-specific side effects.
 
 ---
 
@@ -692,6 +1164,10 @@ this.maintenanceService = new MaintenanceService(
   this.embedFact.bind(this), this._notifyEmbeddingPersisted.bind(this), this._notifyEmbeddingPersistedOrThrow.bind(this), this._reconcileEmbeddingDimension.bind(this)
 );
 ```
+
+> Minor implementation notes:
+> - Ensure every private `WikiMemory` callback passed into the services is bound to `this` (for example, `this.embedFact.bind(this)`). Otherwise the service may invoke it with the wrong receiver and break method access to `WikiMemory` internals.
+> - In `IngestionService` and `MaintenanceService`, keep the `db.withTransactionAsync(...)` work inside a `try { ... } finally { this.jobManager.releaseLock(...) }` block. That way any transaction failure still reaches `finally`, preventing lock leaks.
 
 3. **Delegation:** Replace the entire bodies of the public methods with pass-throughs.
 ```typescript

--- a/docs/superpowers/specs/2026-05-15-repository-phase-3-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-3-spec.md
@@ -1061,7 +1061,7 @@ export class MaintenanceService {
     \nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}
     \nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}
     \nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}
-    \nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`;
+    \nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`.;
 
     const responseText = await this.options.llmProvider.generateText({
       systemPrompt: HEAL_SYSTEM_PROMPT,

--- a/packages/core/__tests__/jobs.test.ts
+++ b/packages/core/__tests__/jobs.test.ts
@@ -47,7 +47,7 @@ describe('job mutex', () => {
 
   it('runLibrarian throws WikiBusyError when prune is running for same entity', async () => {
     const wiki = await freshWiki(slowProvider(0));
-    (wiki as any).activeMaintenanceJobs.add('jobs_:e1:prune');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('jobs_:e1:prune');
     const err = await wiki.runLibrarian('e1').catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('prune');
@@ -55,7 +55,7 @@ describe('job mutex', () => {
 
   it('runHeal throws WikiBusyError when prune is running for same entity', async () => {
     const wiki = await freshWiki(slowProvider(0));
-    (wiki as any).activeMaintenanceJobs.add('jobs_:e1:prune');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('jobs_:e1:prune');
     const err = await wiki.runHeal('e1').catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('prune');
@@ -63,7 +63,7 @@ describe('job mutex', () => {
 
   it('ingestDocument throws WikiBusyError when prune is running for same entity', async () => {
     const wiki = await freshWiki(slowProvider(0));
-    (wiki as any).activeMaintenanceJobs.add('jobs_:e1:prune');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('jobs_:e1:prune');
     const sourceHash = 'a'.repeat(64);
     const err = await wiki.ingestDocument('e1', { sourceRef: 'doc1', sourceHash, documentChunk: 'some content here' }).catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
@@ -72,7 +72,7 @@ describe('job mutex', () => {
 
   it('prune guard does not bleed to different entity', async () => {
     const wiki = await freshWiki(slowProvider(100));
-    (wiki as any).activeMaintenanceJobs.add('jobs_:e1:prune');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('jobs_:e1:prune');
     // e2 should not be affected by e1 prune lock
     const p = wiki.runLibrarian('e2');
     await expect(p).resolves.toBeUndefined();

--- a/packages/core/__tests__/prune.test.ts
+++ b/packages/core/__tests__/prune.test.ts
@@ -291,7 +291,7 @@ describe('WikiMemory.runPrune', () => {
   it('throws WikiBusyError when librarian is already running', async () => {
     const db = makeMockDb({});
     const wiki = new WikiMemory(db as any, stubOptions);
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:ent:librarian');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('llm_wiki_:ent:librarian');
     const err = await wiki.runPrune('ent').catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('librarian');
@@ -300,7 +300,7 @@ describe('WikiMemory.runPrune', () => {
   it('throws WikiBusyError when heal is already running', async () => {
     const db = makeMockDb({});
     const wiki = new WikiMemory(db as any, stubOptions);
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:ent:heal');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('llm_wiki_:ent:heal');
     const err = await wiki.runPrune('ent').catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('heal');
@@ -309,7 +309,7 @@ describe('WikiMemory.runPrune', () => {
   it('throws WikiBusyError when ingest is already running for same entity', async () => {
     const db = makeMockDb({});
     const wiki = new WikiMemory(db as any, stubOptions);
-    (wiki as any).activeIngestJobs.add('llm_wiki_:ent:doc.md');
+    (wiki as any).jobManager.activeIngestJobs.add('llm_wiki_:ent:doc.md');
     const err = await wiki.runPrune('ent').catch((e) => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('ingest');

--- a/packages/core/__tests__/runReembed.test.ts
+++ b/packages/core/__tests__/runReembed.test.ts
@@ -119,7 +119,7 @@ describe('runReembed()', () => {
     await wiki.setup();
     await insertFact(db, 'f1', 'user-1');
 
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:user-1:forget');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('llm_wiki_:user-1:forget');
 
     const err = await wiki.runReembed('user-1').catch(e => e);
     expect(err).toBeInstanceOf(WikiBusyError);
@@ -132,7 +132,7 @@ describe('runReembed()', () => {
     await wiki.setup();
     await insertFact(db, 'f1', 'user-1');
 
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:user-1:forget');
+    (wiki as any).jobManager.activeMaintenanceJobs.add('llm_wiki_:user-1:forget');
 
     const err = await wiki.runReembed().catch(e => e);
     expect(err).toBeInstanceOf(WikiBusyError);

--- a/packages/core/__tests__/subscribeEntityStatus.test.ts
+++ b/packages/core/__tests__/subscribeEntityStatus.test.ts
@@ -189,8 +189,8 @@ describe('subscribeEntityStatus — suppression and unsubscribe', () => {
     const calls: EntityStatus[] = [];
     const unsub = wiki.subscribeEntityStatus('e1', (s) => calls.push({ ...s }));
     // Fire the notifier with no actual mutation
-    (wiki as any)._notifyStatusSubscribers('e1');
-    (wiki as any)._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
     expect(calls.length).toBe(1); // only initial
     unsub();
   });
@@ -202,8 +202,8 @@ describe('subscribeEntityStatus — suppression and unsubscribe', () => {
       calls.push({ ...s });
       s.librarian = true;
     });
-    (wiki as any)._notifyStatusSubscribers('e1');
-    (wiki as any)._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
     expect(calls.length).toBe(1);
     unsub();
   });
@@ -213,15 +213,15 @@ describe('subscribeEntityStatus — suppression and unsubscribe', () => {
     const calls: EntityStatus[] = [];
     const unsub = wiki.subscribeEntityStatus('e1', (s) => calls.push({ ...s }));
 
-    const pruneKey = (wiki as any)._pruneKey('e1');
-    const reembedKey = (wiki as any)._reembedKey('e1');
-    const importKey = (wiki as any)._importKey('e1');
-    const forgetKey = (wiki as any)._forgetKey('e1');
+    const pruneKey = (wiki as any).jobManager._pruneKey('e1');
+    const reembedKey = (wiki as any).jobManager._reembedKey('e1');
+    const importKey = (wiki as any).jobManager._importKey('e1');
+    const forgetKey = (wiki as any).jobManager._forgetKey('e1');
     for (const k of [pruneKey, reembedKey, importKey, forgetKey]) {
-      (wiki as any).activeMaintenanceJobs.add(k);
-      (wiki as any)._notifyStatusSubscribers('e1'); // even if production code mistakenly called it
-      (wiki as any).activeMaintenanceJobs.delete(k);
-      (wiki as any)._notifyStatusSubscribers('e1');
+      (wiki as any).jobManager.activeMaintenanceJobs.add(k);
+      (wiki as any).jobManager._notifyStatusSubscribers('e1'); // even if production code mistakenly called it
+      (wiki as any).jobManager.activeMaintenanceJobs.delete(k);
+      (wiki as any).jobManager._notifyStatusSubscribers('e1');
     }
     expect(calls.length).toBe(1); // only initial
     unsub();
@@ -234,11 +234,11 @@ describe('subscribeEntityStatus — suppression and unsubscribe', () => {
     unsub();
     expect(() => unsub()).not.toThrow();
 
-    const key = (wiki as any)._librarianKey('e1');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
-    (wiki as any).activeMaintenanceJobs.delete(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    const key = (wiki as any).jobManager._librarianKey('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.delete(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
     expect(calls.length).toBe(1); // only the initial emission
   });
 });
@@ -253,15 +253,15 @@ describe('subscribeEntityStatus — multi-subscriber and re-entrancy', () => {
     expect(callsA.length).toBe(1);
     expect(callsB.length).toBe(1);
 
-    const key = (wiki as any)._librarianKey('e1');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    const key = (wiki as any).jobManager._librarianKey('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
     expect(callsA.at(-1)?.librarian).toBe(true);
     expect(callsB.at(-1)?.librarian).toBe(true);
 
     unsubA();
-    (wiki as any).activeMaintenanceJobs.delete(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.delete(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
     expect(callsA.length).toBe(2); // unchanged after unsub
     expect(callsB.at(-1)?.librarian).toBe(false);
     unsubB();
@@ -271,11 +271,11 @@ describe('subscribeEntityStatus — multi-subscriber and re-entrancy', () => {
     const wiki = await freshWiki(slowProvider(0));
     const calls: EntityStatus[] = [];
     const unsub = wiki.subscribeEntityStatus('b', (s) => calls.push({ ...s }));
-    const key = (wiki as any)._librarianKey('a');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('a');
-    (wiki as any).activeMaintenanceJobs.delete(key);
-    (wiki as any)._notifyStatusSubscribers('a');
+    const key = (wiki as any).jobManager._librarianKey('a');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('a');
+    (wiki as any).jobManager.activeMaintenanceJobs.delete(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('a');
     expect(calls.length).toBe(1); // only initial for 'b'
     unsub();
   });
@@ -288,9 +288,9 @@ describe('subscribeEntityStatus — multi-subscriber and re-entrancy', () => {
     const unsubBad = wiki.subscribeEntityStatus('e1', () => { throw new Error('boom'); });
     const unsubGood = wiki.subscribeEntityStatus('e1', (s) => otherCalls.push({ ...s }));
 
-    const key = (wiki as any)._librarianKey('e1');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    const key = (wiki as any).jobManager._librarianKey('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
 
     expect(otherCalls.at(-1)?.librarian).toBe(true);
     expect(errSpy).toHaveBeenCalled();
@@ -310,9 +310,9 @@ describe('subscribeEntityStatus — multi-subscriber and re-entrancy', () => {
     unsubB = wiki.subscribeEntityStatus('e1', (s) => callsB.push({ ...s }));
     expect(callsB.length).toBe(1); // initial only
 
-    const key = (wiki as any)._librarianKey('e1');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    const key = (wiki as any).jobManager._librarianKey('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
 
     // B was unsubscribed before the iterator reached it (snapshot still includes B,
     // but the implementation must skip removed entries — verify via no transition delivery).
@@ -334,9 +334,9 @@ describe('subscribeEntityStatus — multi-subscriber and re-entrancy', () => {
       }
     });
 
-    const key = (wiki as any)._librarianKey('e1');
-    (wiki as any).activeMaintenanceJobs.add(key);
-    (wiki as any)._notifyStatusSubscribers('e1');
+    const key = (wiki as any).jobManager._librarianKey('e1');
+    (wiki as any).jobManager.activeMaintenanceJobs.add(key);
+    (wiki as any).jobManager._notifyStatusSubscribers('e1');
 
     // Late subscriber received its synchronous initial emission and nothing else.
     expect(callsLate.length).toBe(1);

--- a/packages/core/__tests__/write.test.ts
+++ b/packages/core/__tests__/write.test.ts
@@ -47,7 +47,7 @@ describe('write() — librarian trigger suppression', () => {
     const { wiki } = makeWiki(1);
     await wiki.setup();
 
-    (wiki as any).activeMaintenanceJobs.add(`${PREFIX}:user-1:forget`);
+    (wiki as any).jobManager.activeMaintenanceJobs.add(`${PREFIX}:user-1:forget`);
     const librarianSpy = vi.spyOn(wiki as any, '_doRunLibrarian');
 
     await wiki.write('user-1', { event_type: 'observation', summary: 'no librarian' });
@@ -63,7 +63,7 @@ describe('write() — librarian trigger suppression', () => {
     const { wiki } = makeWiki(1);
     await wiki.setup();
 
-    (wiki as any).activeMaintenanceJobs.add(`${PREFIX}:user-1:prune`);
+    (wiki as any).jobManager.activeMaintenanceJobs.add(`${PREFIX}:user-1:prune`);
     const librarianSpy = vi.spyOn(wiki as any, '_doRunLibrarian');
 
     await wiki.write('user-1', { event_type: 'observation', summary: 'no librarian prune' });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1187,7 +1187,8 @@ export class WikiMemory {
           .finally(() => {
             this.jobManager.releaseLock('librarian', entityId);
           });
-      } catch {
+      } catch (e) {
+        if (!(e instanceof WikiBusyError)) throw e;
         // Conflict detected between pre-check and acquire — skip auto-trigger
       }
     }
@@ -1205,18 +1206,12 @@ export class WikiMemory {
     if (healCheckpoint > currentEventCount) healCheckpoint = 0;
     const shouldRunHeal = currentEventCount - healCheckpoint >= autoHealThreshold;
 
-    if (shouldRunHeal) {
+    if (shouldRunHeal && this.jobManager.tryAcquireAutoHealLock(entityId)) {
       try {
-        this.jobManager.acquireLock('heal', entityId);
-        try {
-          await this._doRunHeal(entityId);
-          await this.metadataRepo.updateCheckpoint(entityId, { heal: currentEventCount }, this.db);
-        } finally {
-          this.jobManager.releaseLock('heal', entityId);
-        }
-      } catch (e) {
-        if (!(e instanceof WikiBusyError)) throw e;
-        // Heal already running — skip auto-heal
+        await this._doRunHeal(entityId);
+        await this.metadataRepo.updateCheckpoint(entityId, { heal: currentEventCount }, this.db);
+      } finally {
+        this.jobManager.releaseLock('heal', entityId);
       }
     }
   }
@@ -2144,4 +2139,3 @@ export class WikiMemory {
 }
 
 export const __testables = { validateFact, validateTask, clip, chunkText };
-

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -10,265 +10,17 @@ import { MetadataRepository } from './repositories/MetadataRepository';
 import { LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT, INGEST_SYSTEM_PROMPT } from './prompts';
 import { parseEmbedding } from './utils/embedding';
 import { SearchService } from './services/SearchService';
+import { JobManager } from './services/JobManager';
 import { generateId } from './utils/ids';
 import { applyTierWeight, normalizeEntityIds, sanitizeTierWeights, shouldExposeReadMetadata } from './readOptions';
+import { parseJsonResponse, chunkText, withConcurrency, clip, validateFact, validateTask, normalizeSourceRef, normalizeSourceHash, titleTokens, jaccardScore } from './utils/pure';
 
 export { WikiBusyError, PrunePartialFailureError } from './types';
 
-/**
- * Private symbol to mark timeout errors thrown by WikiMemory (not from ranker).
- * Used to distinguish WikiMemory's own timeout errors from ranker errors that might contain "timed out" in message.
- */
-const HOOK_TIMEOUT_MARKER = Symbol('WikiMemoryHookTimeout');
+export const HOOK_TIMEOUT_MARKER = Symbol('WikiMemoryHookTimeout');
 
 type ReadCandidateRowMetadata = EntryRowMetadata;
 type ReadCandidateRowWithEmbeddings = EntryRowWithEmbeddings;
-
-function parseJsonResponse<T>(text: string): T {
-  const firstBrace = text.indexOf('{');
-  const firstBracket = text.indexOf('[');
-
-  let start: number;
-  let openChar: string;
-  let closeChar: string;
-
-  if (firstBrace !== -1 && (firstBracket === -1 || firstBrace < firstBracket)) {
-    start = firstBrace;
-    openChar = '{';
-    closeChar = '}';
-  } else if (firstBracket !== -1) {
-    start = firstBracket;
-    openChar = '[';
-    closeChar = ']';
-  } else {
-    throw new SyntaxError('No JSON object/array found in LLM response');
-  }
-
-  // Walk from `start`, tracking nesting depth and skipping strings/escapes,
-  // so we stop at the true matching close bracket rather than the last one.
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-  let end = -1;
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-    if (escape) { escape = false; continue; }
-    if (ch === '\\' && inString) { escape = true; continue; }
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
-    if (ch === openChar) { depth++; continue; }
-    if (ch === closeChar) {
-      depth--;
-      if (depth === 0) { end = i; break; }
-    }
-  }
-
-  if (end === -1) throw new SyntaxError('No JSON object/array found in LLM response');
-  return JSON.parse(text.slice(start, end + 1)) as T;
-}
-
-function safeSlice(value: string, start: number, end?: number): string {
-  const length = value.length;
-  let safeStart = start < 0 ? Math.max(length + start, 0) : Math.min(start, length);
-  let safeEnd = end === undefined
-    ? length
-    : end < 0
-      ? Math.max(length + end, 0)
-      : Math.min(end, length);
-
-  if (safeStart > safeEnd) {
-    [safeStart, safeEnd] = [safeEnd, safeStart];
-  }
-
-  if (
-    safeStart > 0 &&
-    safeStart < length &&
-    value.charCodeAt(safeStart) >= 0xDC00 &&
-    value.charCodeAt(safeStart) <= 0xDFFF &&
-    value.charCodeAt(safeStart - 1) >= 0xD800 &&
-    value.charCodeAt(safeStart - 1) <= 0xDBFF
-  ) {
-    safeStart--;
-  }
-
-  if (
-    safeEnd > 0 &&
-    safeEnd < length &&
-    value.charCodeAt(safeEnd - 1) >= 0xD800 &&
-    value.charCodeAt(safeEnd - 1) <= 0xDBFF &&
-    value.charCodeAt(safeEnd) >= 0xDC00 &&
-    value.charCodeAt(safeEnd) <= 0xDFFF
-  ) {
-    safeEnd--;
-  }
-
-  return value.slice(safeStart, safeEnd);
-}
-
-function chunkText(
-  input: string,
-  maxChunkLength: number,
-  overlap: number
-): { chunks: string[]; truncated: boolean } {
-  const text = input.trim();
-  if (text.length === 0) return { chunks: [], truncated: false };
-  if (!Number.isInteger(maxChunkLength) || maxChunkLength < 2) {
-    throw new Error('maxChunkLength must be an integer >= 2');
-  }
-  if (!Number.isInteger(overlap) || overlap < 0 || overlap >= maxChunkLength) {
-    throw new Error('overlap must be a non-negative integer < maxChunkLength');
-  }
-
-  const chunks: string[] = [];
-  let truncated = false;
-  let cursor = 0;
-  const halfMax = Math.floor(maxChunkLength / 2);
-
-  while (cursor < text.length) {
-    const remaining = text.length - cursor;
-    if (remaining <= maxChunkLength) {
-      chunks.push(safeSlice(text, cursor, text.length));
-      break;
-    }
-
-    const windowEnd = cursor + maxChunkLength;
-    const minSplit = cursor + halfMax;
-
-    // 1. paragraph break
-    let splitPoint = -1;
-    const paraIdx = text.lastIndexOf('\n\n', windowEnd);
-    if (paraIdx >= minSplit && paraIdx + 2 <= windowEnd) {
-      splitPoint = paraIdx + 2;
-    }
-
-    // 2. sentence terminator (single left-to-right pass, no lookahead regex)
-    if (splitPoint === -1) {
-      let lastTerm = -1;
-      for (let i = minSplit; i < windowEnd - 1; i++) {
-        const ch = text[i];
-        if ((ch === '.' || ch === '!' || ch === '?') && /\s/.test(text[i + 1])) {
-          lastTerm = i + 2; // include the terminator + whitespace
-        }
-      }
-      if (lastTerm !== -1 && lastTerm <= windowEnd) splitPoint = lastTerm;
-    }
-
-    // 3. whitespace
-    if (splitPoint === -1) {
-      for (let i = windowEnd - 1; i >= minSplit; i--) {
-        if (/\s/.test(text[i])) {
-          splitPoint = i + 1;
-          break;
-        }
-      }
-    }
-
-    // 4. hard cut
-    if (splitPoint === -1) {
-      truncated = true;
-      splitPoint = windowEnd;
-    }
-
-    chunks.push(safeSlice(text, cursor, splitPoint));
-    const next = Math.max(splitPoint - overlap, cursor + 1);
-    cursor = next;
-  }
-
-  return { chunks, truncated };
-}
-
-async function withConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
-  const results: T[] = new Array(tasks.length);
-  let index = 0;
-  let failed = false;
-  let firstError: unknown;
-  async function worker() {
-    while (index < tasks.length && !failed) {
-      const i = index++;
-      try {
-        results[i] = await tasks[i]();
-      } catch (e) {
-        if (!failed) { failed = true; firstError = e; }
-        return;
-      }
-    }
-  }
-  const workerCount = tasks.length === 0 ? 0 : Math.min(Math.max(limit, 1), tasks.length);
-  await Promise.allSettled(Array.from({ length: workerCount }, worker));
-  if (failed) throw firstError;
-  return results;
-}
-
-function clip(value: string, max: number): string {
-  if (typeof value !== 'string') return '';
-  const s = value.trim();
-  return s.length <= max ? s : safeSlice(s, 0, max).trimEnd();
-}
-
-function validateTags(tags: any[]): string[] {
-  if (!Array.isArray(tags)) return [];
-  return tags
-    .filter(t => typeof t === 'string')
-    .map(t => t.trim().toLowerCase())
-    .filter(t => t.length > 0 && t.length <= 40)
-    .slice(0, 6);
-}
-
-function validateFact(fact: any): ExtractedFact | null {
-  if (typeof fact?.title !== 'string' || typeof fact?.body !== 'string') return null;
-  const title = clip(fact.title, 80);
-  const body = clip(fact.body, 800);
-  if (!title || !body) return null;
-  
-  let confidence = fact.confidence;
-  if (confidence !== 'certain' && confidence !== 'tentative') confidence = 'inferred';
-  
-  return {
-    ...fact,
-    title,
-    body,
-    confidence,
-    tags: validateTags(fact.tags)
-  };
-}
-
-function validateTask(task: any): ExtractedTask | null {
-  if (typeof task?.description !== 'string') return null;
-  const description = clip(task.description, 200);
-  if (!description) return null;
-  
-  let priority = task.priority;
-  if (typeof priority !== 'number' || !isFinite(priority)) priority = 0;
-  
-  return {
-    ...task,
-    description,
-    priority
-  };
-}
-
-function normalizeSourceRef(value: string): string | null {
-  if (typeof value !== 'string') return null;
-  const cleaned = value.replace(/[^A-Za-z0-9._\- ]/g, '').trim().slice(0, 255);
-  return cleaned.length > 0 ? cleaned : null;
-}
-
-function normalizeSourceHash(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  return /^[0-9a-f]{64}$/i.test(value) ? value.toLowerCase() : null;
-}
-
-
-function titleTokens(title: string): Set<string> {
-  return new Set(title.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/).filter(t => t.length >= 3));
-}
-
-function jaccardScore(a: Set<string>, b: Set<string>): number {
-  if (a.size === 0 && b.size === 0) return 0;
-  const intersection = new Set([...a].filter(x => b.has(x)));
-  const union = new Set([...a, ...b]);
-  return intersection.size / union.size;
-}
 
 const FUZZY_THRESHOLD = 0.5;
 const MIN_TOKENS_TO_QUALIFY = 3;
@@ -283,12 +35,7 @@ export class WikiMemory {
   private eventRepo: EventRepository;
   private metadataRepo: MetadataRepository;
   private searchService: SearchService;
-  private activeMaintenanceJobs = new Set<string>();
-  private activeIngestJobs = new Set<string>();
-  private statusSubscribers = new Map<
-    string,
-    Set<{ callback: (s: EntityStatus) => void; last: EntityStatus }>
-  >();
+  private jobManager: JobManager;
   private async storeEmbeddingDimension(dim: number): Promise<void> {
     const existing = await this.metadataRepo.getMeta('embedding_dimension');
     if (existing) {
@@ -387,8 +134,6 @@ export class WikiMemory {
     }
   }
 
-  private _librarianKey(entityId: string) { return `${this.prefix}:${entityId}:librarian`; }
-  private _healKey(entityId: string) { return `${this.prefix}:${entityId}:heal`; }
   private _warnCrossEntityCollision(type: 'entry' | 'task', id: string, existingEntityId: string, targetEntityId: string): void {
     console.warn(`[WikiMemory] importDump: ${type} id "${id}" already belongs to entity "${existingEntityId}"; skipping for entity "${targetEntityId}"`);
   }
@@ -498,6 +243,7 @@ export class WikiMemory {
     this.eventRepo = new EventRepository(db, this.prefix);
     this.metadataRepo = new MetadataRepository(db, this.prefix);
     this.searchService = new SearchService(this.entryRepo);
+    this.jobManager = new JobManager(this.prefix);
   }
 
   async setup() {
@@ -591,67 +337,6 @@ export class WikiMemory {
     return normalizedStoredHash !== normalizedHash;
   }
 
-  private _pruneKey(entityId: string) { return `${this.prefix}:${entityId}:prune`; }
-  private _reembedKey(entityId: string) { return `${this.prefix}:${entityId}:reembed`; }
-  private _globalReembedKey() { return `${this.prefix}:reembed`; }
-  private _importKey(entityId: string) { return `${this.prefix}:${entityId}:import`; }
-  private _globalImportKey() { return `${this.prefix}:import`; }
-  private _forgetKey(entityId: string) { return `${this.prefix}:${entityId}:forget`; }
-  private _isReembedActive(entityId: string): boolean {
-    return this.activeMaintenanceJobs.has(this._reembedKey(entityId))
-      || this.activeMaintenanceJobs.has(this._globalReembedKey());
-  }
-  private _isImportActiveFor(entityId: string): boolean {
-    return this.activeMaintenanceJobs.has(this._importKey(entityId))
-      || this.activeMaintenanceJobs.has(this._globalImportKey());
-  }
-  private _isForgetActiveFor(entityId: string): boolean {
-    return this.activeMaintenanceJobs.has(this._forgetKey(entityId));
-  }
-  /** Returns true if any maintenance job has the given operation suffix (e.g. ':prune'). */
-  private _isAnyMaintenanceActiveWithSuffix(suffix: string): boolean {
-    const entityKeyPrefix = `${this.prefix}:`;
-    for (const k of this.activeMaintenanceJobs) {
-      if (k.startsWith(entityKeyPrefix) && k.endsWith(suffix)) return true;
-    }
-    return false;
-  }
-  /** Returns true if any ingest job is active for the given entity. */
-  private _isIngestActiveFor(entityId: string): boolean {
-    const entityKeyPrefix = `${this.prefix}:${entityId}:`;
-    for (const k of this.activeIngestJobs) {
-      if (k.startsWith(entityKeyPrefix)) return true;
-    }
-    return false;
-  }
-
-  private _copyEntityStatus(s: EntityStatus): EntityStatus {
-    return { ingesting: s.ingesting, librarian: s.librarian, heal: s.heal };
-  }
-
-  private _notifyStatusSubscribers(entityId: string): void {
-    const set = this.statusSubscribers.get(entityId);
-    if (!set || set.size === 0) return;
-    // Snapshot for safe iteration if a callback unsubscribes or subscribes.
-    // Re-read status each iteration so re-entrant mutations cannot leave stale
-    // snapshots for remaining subscribers.
-    for (const entry of Array.from(set)) {
-      if (!set.has(entry)) continue; // unsubscribed during this emission
-      const next = this.getEntityStatus(entityId);
-      if (
-        entry.last.ingesting === next.ingesting &&
-        entry.last.librarian === next.librarian &&
-        entry.last.heal === next.heal
-      ) continue;
-      entry.last = this._copyEntityStatus(next);
-      try {
-        entry.callback(this._copyEntityStatus(next));
-      } catch (err) {
-        console.error(`[WikiMemory.subscribeEntityStatus] callback error for entityId="${entityId}" during transition emission`, err);
-      }
-    }
-  }
-
   private _validatePruneDuration(value: number | null | undefined, name: string): void {
     if (value !== null && value !== undefined && (typeof value !== 'number' || !isFinite(value) || value < 0)) {
       throw new Error(`Invalid ${name}: must be a non-negative finite number or null`);
@@ -666,34 +351,7 @@ export class WikiMemory {
       vacuum?: boolean;
     }
   ): Promise<{ entries: number; tasks: number; events: number }> {
-    const pruneKey = this._pruneKey(entityId);
-    // Prune must not run concurrently with librarian, heal, ingest, import, or another
-    // prune for the same entity.
-    const ingestPrefix = `${this.prefix}:${entityId}:`;
-    let isIngestRunning = false;
-    for (const k of this.activeIngestJobs) {
-      if (k.startsWith(ingestPrefix)) { isIngestRunning = true; break; }
-    }
-    let blockingOperation: 'prune' | 'librarian' | 'heal' | 'ingest' | 'reembed' | 'import' | 'forget' | null = null;
-    if (this.activeMaintenanceJobs.has(pruneKey)) {
-      blockingOperation = 'prune';
-    } else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) {
-      blockingOperation = 'librarian';
-    } else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) {
-      blockingOperation = 'heal';
-    } else if (this._isReembedActive(entityId)) {
-      blockingOperation = 'reembed';
-    } else if (isIngestRunning) {
-      blockingOperation = 'ingest';
-    } else if (this._isImportActiveFor(entityId)) {
-      blockingOperation = 'import';
-    } else if (this._isForgetActiveFor(entityId)) {
-      blockingOperation = 'forget';
-    }
-    if (blockingOperation !== null) {
-      throw new WikiBusyError(blockingOperation, entityId);
-    }
-    this.activeMaintenanceJobs.add(pruneKey);
+    this.jobManager.acquireLock('prune', entityId);
     try {
       const retainSoftDeletedFor = options?.retainSoftDeletedFor !== undefined
         ? options.retainSoftDeletedFor
@@ -789,7 +447,7 @@ export class WikiMemory {
 
       return { entries: deletedEntries, tasks: deletedTasks, events: deletedEvents };
     } finally {
-      this.activeMaintenanceJobs.delete(pruneKey);
+      this.jobManager.releaseLock('prune', entityId);
     }
   }
 
@@ -1498,7 +1156,6 @@ export class WikiMemory {
     // Wrap in transaction to ensure Event + Checkpoint logic is atomic
     let shouldRunLibrarian = false;
     let librarianCount = 0;
-    let librarianJobKey: string | null = null;
 
     await this.db.withTransactionAsync(async (tx) => {
       await this.eventRepo.add(newEvent, tx);
@@ -1514,31 +1171,25 @@ export class WikiMemory {
       if (memoryCheckpoint > count) memoryCheckpoint = 0;
 
       if (count - memoryCheckpoint >= threshold) {
-        const jobKey = this._librarianKey(entityId);
-        if (
-          !this.activeMaintenanceJobs.has(jobKey) &&
-          !this.activeMaintenanceJobs.has(this._pruneKey(entityId)) &&
-          !this._isReembedActive(entityId) &&
-          !this._isImportActiveFor(entityId) &&
-          !this._isForgetActiveFor(entityId)
-        ) {
+        if (!this.jobManager.isBlocked('librarian', entityId)) {
           shouldRunLibrarian = true;
           librarianCount = count;
-          librarianJobKey = jobKey;
           await this.metadataRepo.updateCheckpoint(entityId, { memory: count }, tx);
         }
       }
     });
 
-    if (shouldRunLibrarian && librarianJobKey !== null) {
-      this.activeMaintenanceJobs.add(librarianJobKey);
-      this._notifyStatusSubscribers(entityId);
-      this.runLibrarianThenMaybeHeal(entityId, librarianCount)
-        .catch(console.error)
-        .finally(() => {
-          this.activeMaintenanceJobs.delete(librarianJobKey!);
-          this._notifyStatusSubscribers(entityId);
-        });
+    if (shouldRunLibrarian) {
+      try {
+        this.jobManager.acquireLock('librarian', entityId);
+        this.runLibrarianThenMaybeHeal(entityId, librarianCount)
+          .catch(console.error)
+          .finally(() => {
+            this.jobManager.releaseLock('librarian', entityId);
+          });
+      } catch {
+        // Conflict detected between pre-check and acquire — skip auto-trigger
+      }
     }
   }
 
@@ -1555,17 +1206,17 @@ export class WikiMemory {
     const shouldRunHeal = currentEventCount - healCheckpoint >= autoHealThreshold;
 
     if (shouldRunHeal) {
-      const healKey = this._healKey(entityId);
-      if (!this.activeMaintenanceJobs.has(healKey)) {
-        this.activeMaintenanceJobs.add(healKey);
-        this._notifyStatusSubscribers(entityId);
+      try {
+        this.jobManager.acquireLock('heal', entityId);
         try {
           await this._doRunHeal(entityId);
           await this.metadataRepo.updateCheckpoint(entityId, { heal: currentEventCount }, this.db);
         } finally {
-          this.activeMaintenanceJobs.delete(healKey);
-          this._notifyStatusSubscribers(entityId);
+          this.jobManager.releaseLock('heal', entityId);
         }
+      } catch (e) {
+        if (!(e instanceof WikiBusyError)) throw e;
+        // Heal already running — skip auto-heal
       }
     }
   }
@@ -1771,56 +1422,20 @@ export class WikiMemory {
   }
 
   async runLibrarian(entityId: string): Promise<void> {
-    const jobKey = this._librarianKey(entityId);
-    if (this.activeMaintenanceJobs.has(jobKey)) {
-      throw new WikiBusyError('librarian', entityId);
-    }
-    if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-      throw new WikiBusyError('prune', entityId);
-    }
-    if (this._isReembedActive(entityId)) {
-      throw new WikiBusyError('reembed', entityId);
-    }
-    if (this._isImportActiveFor(entityId)) {
-      throw new WikiBusyError('import', entityId);
-    }
-    if (this._isForgetActiveFor(entityId)) {
-      throw new WikiBusyError('forget', entityId);
-    }
-    this.activeMaintenanceJobs.add(jobKey);
-    this._notifyStatusSubscribers(entityId);
+    this.jobManager.acquireLock('librarian', entityId);
     try {
       await this._doRunLibrarian(entityId);
     } finally {
-      this.activeMaintenanceJobs.delete(jobKey);
-      this._notifyStatusSubscribers(entityId);
+      this.jobManager.releaseLock('librarian', entityId);
     }
   }
 
   async runHeal(entityId: string): Promise<void> {
-    const jobKey = this._healKey(entityId);
-    if (this.activeMaintenanceJobs.has(jobKey)) {
-      throw new WikiBusyError('heal', entityId);
-    }
-    if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-      throw new WikiBusyError('prune', entityId);
-    }
-    if (this._isReembedActive(entityId)) {
-      throw new WikiBusyError('reembed', entityId);
-    }
-    if (this._isImportActiveFor(entityId)) {
-      throw new WikiBusyError('import', entityId);
-    }
-    if (this._isForgetActiveFor(entityId)) {
-      throw new WikiBusyError('forget', entityId);
-    }
-    this.activeMaintenanceJobs.add(jobKey);
-    this._notifyStatusSubscribers(entityId);
+    this.jobManager.acquireLock('heal', entityId);
     try {
       await this._doRunHeal(entityId);
     } finally {
-      this.activeMaintenanceJobs.delete(jobKey);
-      this._notifyStatusSubscribers(entityId);
+      this.jobManager.releaseLock('heal', entityId);
     }
   }
 
@@ -1828,58 +1443,8 @@ export class WikiMemory {
     const embedFn = this.options.llmProvider.embed;
     if (!embedFn) return { embedded: 0, skipped: 0, failed: 0 };
 
-    const reembedKey = entityId ? this._reembedKey(entityId) : this._globalReembedKey();
-    if (this.activeMaintenanceJobs.has(reembedKey)) {
-      throw new WikiBusyError('reembed', entityId ?? '*');
-    }
-    if (entityId) {
-      // Cross-check: fail if global reembed is in-flight (it covers this entity too)
-      if (this.activeMaintenanceJobs.has(this._globalReembedKey())) {
-        throw new WikiBusyError('reembed', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-        throw new WikiBusyError('prune', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) {
-        throw new WikiBusyError('librarian', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._healKey(entityId))) {
-        throw new WikiBusyError('heal', entityId);
-      }
-      if (this._isIngestActiveFor(entityId)) {
-        throw new WikiBusyError('ingest', entityId);
-      }
-      if (this._isImportActiveFor(entityId)) {
-        throw new WikiBusyError('import', entityId);
-      }
-      if (this._isForgetActiveFor(entityId)) {
-        throw new WikiBusyError('forget', entityId);
-      }
-    } else {
-      // Cross-check: fail if any per-entity reembed is in-flight (global covers all entities)
-      if (this._isAnyMaintenanceActiveWithSuffix(':reembed')) {
-        throw new WikiBusyError('reembed', '*');
-      }
-      if (this._isAnyMaintenanceActiveWithSuffix(':prune')) {
-        throw new WikiBusyError('prune', '*');
-      }
-      if (this._isAnyMaintenanceActiveWithSuffix(':librarian')) {
-        throw new WikiBusyError('librarian', '*');
-      }
-      if (this._isAnyMaintenanceActiveWithSuffix(':heal')) {
-        throw new WikiBusyError('heal', '*');
-      }
-      if (this.activeIngestJobs.size > 0) {
-        throw new WikiBusyError('ingest', '*');
-      }
-      if (this._isAnyMaintenanceActiveWithSuffix(':import')) {
-        throw new WikiBusyError('import', '*');
-      }
-      if (this._isAnyMaintenanceActiveWithSuffix(':forget')) {
-        throw new WikiBusyError('forget', '*');
-      }
-    }
-    this.activeMaintenanceJobs.add(reembedKey);
+    const op = entityId ? 'reembed' : 'global_reembed';
+    this.jobManager.acquireLock(op, entityId ?? '*');
 
     try {
       const rows = await this.entryRepo.findAllForReembed(entityId);
@@ -1965,22 +1530,12 @@ export class WikiMemory {
 
       return { embedded, skipped, failed };
     } finally {
-      this.activeMaintenanceJobs.delete(reembedKey);
+      this.jobManager.releaseLock(op, entityId ?? '*');
     }
   }
 
   getEntityStatus(entityId: string): EntityStatus {
-    const ingestPrefix = `${this.prefix}:${entityId}:`;
-    let ingesting = false;
-    for (const k of this.activeIngestJobs) {
-      if (k.startsWith(ingestPrefix)) { ingesting = true; break; }
-    }
-
-    return {
-      ingesting,
-      librarian: this.activeMaintenanceJobs.has(this._librarianKey(entityId)),
-      heal: this.activeMaintenanceJobs.has(this._healKey(entityId)),
-    };
+    return this.jobManager.getEntityStatus(entityId);
   }
 
   /**
@@ -1997,30 +1552,7 @@ export class WikiMemory {
     entityId: string,
     callback: (status: EntityStatus) => void
   ): () => void {
-    const initial = this.getEntityStatus(entityId);
-    let set = this.statusSubscribers.get(entityId);
-    if (!set) {
-      set = new Set();
-      this.statusSubscribers.set(entityId, set);
-    }
-    const entry = { callback, last: this._copyEntityStatus(initial) };
-    set.add(entry);
-
-    try {
-      callback(this._copyEntityStatus(initial));
-    } catch (err) {
-      console.error(`[WikiMemory.subscribeEntityStatus] callback error for entityId="${entityId}" during initial emission`, err);
-    }
-
-    let active = true;
-    return () => {
-      if (!active) return;
-      active = false;
-      const s = this.statusSubscribers.get(entityId);
-      if (!s) return;
-      s.delete(entry);
-      if (s.size === 0) this.statusSubscribers.delete(entityId);
-    };
+    return this.jobManager.subscribeEntityStatus(entityId, callback);
   }
 
   public clearVectorCache(): void {
@@ -2084,46 +1616,9 @@ export class WikiMemory {
     const merge = opts?.merge ?? false;
     const entityIds = Object.keys(dump.entities);
 
-    // Pre-validate all locks before writing anything. This makes the operation
-    // atomic with respect to busy-error rejection: either every entity passes the
-    // lock check and we proceed, or we reject before mutating any entity.
-    // Per-entity checks first: surface the specific conflicting entity in the error.
-    for (const entityId of entityIds) {
-      if (this.activeMaintenanceJobs.has(this._importKey(entityId))) {
-        throw new WikiBusyError('import', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) {
-        throw new WikiBusyError('librarian', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._healKey(entityId))) {
-        throw new WikiBusyError('heal', entityId);
-      }
-      if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-        throw new WikiBusyError('prune', entityId);
-      }
-      if (this._isReembedActive(entityId)) {
-        throw new WikiBusyError('reembed', entityId);
-      }
-      if (this._isIngestActiveFor(entityId)) {
-        throw new WikiBusyError('ingest', entityId);
-      }
-      if (this._isForgetActiveFor(entityId)) {
-        throw new WikiBusyError('forget', entityId);
-      }
-    }
-    // Global import lock check after per-entity checks: serializes concurrent
-    // importDump() calls for *different* entities so they cannot race on the shared
-    // embedding_dimension / embedding_dimension_mismatch meta keys.
-    if (this.activeMaintenanceJobs.has(this._globalImportKey())) {
-      throw new WikiBusyError('import', '*');
-    }
-
-    // Acquire global + per-entity import locks before any await so the lock check and
-    // lock acquisition remain race-free across concurrent importDump() calls.
-    this.activeMaintenanceJobs.add(this._globalImportKey());
-    for (const entityId of entityIds) {
-      this.activeMaintenanceJobs.add(this._importKey(entityId));
-    }
+    // acquireImportLocks validates all per-entity conflicts, then the global lock,
+    // then acquires global + per-entity atomically (same semantics as before).
+    this.jobManager.acquireImportLocks(entityIds);
     try {
       // Fail before any writes so we never partially commit an import and then reject
       // with a migration error — same probe as setup().
@@ -2133,10 +1628,7 @@ export class WikiMemory {
         await this._doImportEntity(entityId, bundle, merge);
       }
     } finally {
-      this.activeMaintenanceJobs.delete(this._globalImportKey());
-      for (const entityId of entityIds) {
-        this.activeMaintenanceJobs.delete(this._importKey(entityId));
-      }
+      this.jobManager.releaseImportLocks(entityIds);
     }
   }
 
@@ -2440,27 +1932,7 @@ export class WikiMemory {
   }
 
   async forget(entityId: string, params: { entryId?: string; taskId?: string; sourceRef?: string; sourceHash?: string; clearAll?: boolean }): Promise<{ deleted: { entries: number; tasks: number } }> {
-    let blockingOperation: "librarian" | "heal" | "prune" | "reembed" | "ingest" | "forget" | "import" | null = null;
-    if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) {
-      blockingOperation = 'librarian';
-    } else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) {
-      blockingOperation = 'heal';
-    } else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-      blockingOperation = 'prune';
-    } else if (this._isReembedActive(entityId)) {
-      blockingOperation = 'reembed';
-    } else if (this._isIngestActiveFor(entityId)) {
-      blockingOperation = 'ingest';
-    } else if (this._isImportActiveFor(entityId)) {
-      blockingOperation = 'import';
-    } else if (this._isForgetActiveFor(entityId)) {
-      blockingOperation = 'forget';
-    }
-    if (blockingOperation !== null) {
-      throw new WikiBusyError(blockingOperation, entityId);
-    }
-    const forgetKey = this._forgetKey(entityId);
-    this.activeMaintenanceJobs.add(forgetKey);
+    this.jobManager.acquireLock('forget', entityId);
     try {
       const now = Date.now();
       let deletedEntries = 0;
@@ -2554,7 +2026,7 @@ export class WikiMemory {
 
       return { deleted: { entries: deletedEntries, tasks: deletedTasks } };
     } finally {
-      this.activeMaintenanceJobs.delete(forgetKey);
+      this.jobManager.releaseLock('forget', entityId);
     }
   }
 
@@ -2579,24 +2051,7 @@ export class WikiMemory {
       throw new Error(`documentChunk must be a string, received ${typeof params.documentChunk}`);
     }
 
-    const jobKey = `${this.prefix}:${entityId}:${sourceRef}`;
-    if (this.activeIngestJobs.has(jobKey)) {
-      throw new WikiBusyError('ingest', entityId);
-    }
-    if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) {
-      throw new WikiBusyError('prune', entityId);
-    }
-    if (this._isReembedActive(entityId)) {
-      throw new WikiBusyError('reembed', entityId);
-    }
-    if (this._isImportActiveFor(entityId)) {
-      throw new WikiBusyError('import', entityId);
-    }
-    if (this._isForgetActiveFor(entityId)) {
-      throw new WikiBusyError('forget', entityId);
-    }
-    this.activeIngestJobs.add(jobKey);
-    this._notifyStatusSubscribers(entityId);
+    this.jobManager.acquireLock('ingest', entityId, sourceRef);
 
     try {
       const { chunks, truncated } = chunkText(params.documentChunk, maxChunkLength, chunkOverlap);
@@ -2683,10 +2138,10 @@ export class WikiMemory {
 
       return { truncated, chunks: chunks.length };
     } finally {
-      this.activeIngestJobs.delete(jobKey);
-      this._notifyStatusSubscribers(entityId);
+      this.jobManager.releaseLock('ingest', entityId, sourceRef);
     }
   }
 }
 
 export const __testables = { validateFact, validateTask, clip, chunkText };
+

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -1,0 +1,304 @@
+import { EntityStatus, WikiBusyError } from '../types';
+
+export type OperationType =
+  | 'prune'
+  | 'librarian'
+  | 'heal'
+  | 'ingest'
+  | 'reembed'
+  | 'global_reembed'
+  | 'import'
+  | 'global_import'
+  | 'forget';
+
+export class JobManager {
+  private activeMaintenanceJobs = new Set<string>();
+  private activeIngestJobs = new Set<string>();
+  private statusSubscribers = new Map<
+    string,
+    Set<{ callback: (s: EntityStatus) => void; last: EntityStatus }>
+  >();
+
+  constructor(private prefix: string) {}
+
+  private _pruneKey(entityId: string) { return `${this.prefix}:${entityId}:prune`; }
+  private _reembedKey(entityId: string) { return `${this.prefix}:${entityId}:reembed`; }
+  private _globalReembedKey() { return `${this.prefix}:reembed`; }
+  private _importKey(entityId: string) { return `${this.prefix}:${entityId}:import`; }
+  private _globalImportKey() { return `${this.prefix}:import`; }
+  private _forgetKey(entityId: string) { return `${this.prefix}:${entityId}:forget`; }
+  private _librarianKey(entityId: string) { return `${this.prefix}:${entityId}:librarian`; }
+  private _healKey(entityId: string) { return `${this.prefix}:${entityId}:heal`; }
+
+  private _isReembedActive(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._reembedKey(entityId)) ||
+           this.activeMaintenanceJobs.has(this._globalReembedKey());
+  }
+
+  private _isImportActiveFor(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._importKey(entityId)) ||
+           this.activeMaintenanceJobs.has(this._globalImportKey());
+  }
+
+  private _isForgetActiveFor(entityId: string): boolean {
+    return this.activeMaintenanceJobs.has(this._forgetKey(entityId));
+  }
+
+  private _isAnyMaintenanceActiveWithSuffix(suffix: string): boolean {
+    const entityKeyPrefix = `${this.prefix}:`;
+    for (const k of this.activeMaintenanceJobs) {
+      if (k.startsWith(entityKeyPrefix) && k.endsWith(suffix)) return true;
+    }
+    return false;
+  }
+
+  private _isIngestActiveFor(entityId: string): boolean {
+    const entityKeyPrefix = `${this.prefix}:${entityId}:`;
+    for (const k of this.activeIngestJobs) {
+      if (k.startsWith(entityKeyPrefix)) return true;
+    }
+    return false;
+  }
+
+  acquireLock(operation: OperationType, entityId: string, sourceRef?: string): void {
+    let blockingOperation: string | null = null;
+
+    if (operation !== 'global_import' && this.activeMaintenanceJobs.has(this._globalImportKey())) {
+      throw new WikiBusyError('import', '*');
+    }
+
+    switch (operation) {
+      case 'prune':
+        if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'librarian':
+      case 'heal': {
+        const opKey = operation === 'librarian' ? this._librarianKey(entityId) : this._healKey(entityId);
+        if (this.activeMaintenanceJobs.has(opKey)) blockingOperation = operation;
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+      }
+
+      case 'reembed':
+        if (this.activeMaintenanceJobs.has(this._reembedKey(entityId))) blockingOperation = 'reembed';
+        else if (this.activeMaintenanceJobs.has(this._globalReembedKey())) blockingOperation = 'reembed';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+
+      case 'global_reembed':
+        if (this.activeMaintenanceJobs.has(this._globalReembedKey())) blockingOperation = 'reembed';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':reembed')) blockingOperation = 'reembed';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':prune')) blockingOperation = 'prune';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':librarian')) blockingOperation = 'librarian';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':heal')) blockingOperation = 'heal';
+        else if (this.activeIngestJobs.size > 0) blockingOperation = 'ingest';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':import')) blockingOperation = 'import';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':forget')) blockingOperation = 'forget';
+        break;
+
+      case 'import':
+      case 'forget': {
+        const selfKey = operation === 'import' ? this._importKey(entityId) : this._forgetKey(entityId);
+        if (this.activeMaintenanceJobs.has(selfKey)) blockingOperation = operation;
+        else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
+        else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+      }
+
+      case 'global_import':
+        if (this.activeMaintenanceJobs.has(this._globalImportKey())) blockingOperation = 'import';
+        break;
+
+      case 'ingest': {
+        const ingestJobKey = `${this.prefix}:${entityId}:${sourceRef}`;
+        if (this.activeIngestJobs.has(ingestJobKey)) blockingOperation = 'ingest';
+        else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
+        else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
+        else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
+        else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
+        break;
+      }
+    }
+
+    if (blockingOperation) {
+      throw new WikiBusyError(
+        blockingOperation,
+        operation === 'global_reembed' || operation === 'global_import' ? '*' : entityId
+      );
+    }
+
+    if (operation === 'ingest') {
+      this.activeIngestJobs.add(`${this.prefix}:${entityId}:${sourceRef}`);
+    } else if (operation === 'global_reembed') {
+      this.activeMaintenanceJobs.add(this._globalReembedKey());
+    } else if (operation === 'global_import') {
+      this.activeMaintenanceJobs.add(this._globalImportKey());
+    } else {
+      const keyFnName = `_${operation}Key` as keyof this;
+      const keyFn = this[keyFnName] as (id: string) => string;
+      this.activeMaintenanceJobs.add(keyFn.call(this, entityId));
+    }
+
+    this._notifyStatusSubscribers(entityId);
+  }
+
+  releaseLock(operation: OperationType, entityId: string, sourceRef?: string): void {
+    if (operation === 'ingest') {
+      this.activeIngestJobs.delete(`${this.prefix}:${entityId}:${sourceRef}`);
+    } else if (operation === 'global_reembed') {
+      this.activeMaintenanceJobs.delete(this._globalReembedKey());
+    } else if (operation === 'global_import') {
+      this.activeMaintenanceJobs.delete(this._globalImportKey());
+    } else {
+      const keyFnName = `_${operation}Key` as keyof this;
+      const keyFn = this[keyFnName] as (id: string) => string;
+      this.activeMaintenanceJobs.delete(keyFn.call(this, entityId));
+    }
+
+    this._notifyStatusSubscribers(entityId);
+  }
+
+  /**
+   * Returns true if acquireLock(operation, entityId) would throw WikiBusyError.
+   * Use for non-throwing conflict checks (e.g. auto-trigger gating in write()).
+   */
+  isBlocked(operation: OperationType, entityId: string): boolean {
+    if (operation !== 'global_import' && this.activeMaintenanceJobs.has(this._globalImportKey())) return true;
+
+    switch (operation) {
+      case 'librarian':
+      case 'heal': {
+        const opKey = operation === 'librarian' ? this._librarianKey(entityId) : this._healKey(entityId);
+        return this.activeMaintenanceJobs.has(opKey) ||
+               this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
+               this._isReembedActive(entityId) ||
+               this._isImportActiveFor(entityId) ||
+               this._isForgetActiveFor(entityId);
+      }
+      case 'prune':
+        return this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
+               this.activeMaintenanceJobs.has(this._librarianKey(entityId)) ||
+               this.activeMaintenanceJobs.has(this._healKey(entityId)) ||
+               this._isReembedActive(entityId) ||
+               this._isIngestActiveFor(entityId) ||
+               this._isImportActiveFor(entityId) ||
+               this._isForgetActiveFor(entityId);
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Validates then acquires global + per-entity import locks atomically.
+   * Validates all entities before acquiring any lock (same as current importDump semantics).
+   */
+  acquireImportLocks(entityIds: string[]): void {
+    for (const entityId of entityIds) {
+      if (this.activeMaintenanceJobs.has(this._importKey(entityId))) throw new WikiBusyError('import', entityId);
+      if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) throw new WikiBusyError('librarian', entityId);
+      if (this.activeMaintenanceJobs.has(this._healKey(entityId))) throw new WikiBusyError('heal', entityId);
+      if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) throw new WikiBusyError('prune', entityId);
+      if (this._isReembedActive(entityId)) throw new WikiBusyError('reembed', entityId);
+      if (this._isIngestActiveFor(entityId)) throw new WikiBusyError('ingest', entityId);
+      if (this._isForgetActiveFor(entityId)) throw new WikiBusyError('forget', entityId);
+    }
+    if (this.activeMaintenanceJobs.has(this._globalImportKey())) throw new WikiBusyError('import', '*');
+
+    this.activeMaintenanceJobs.add(this._globalImportKey());
+    for (const entityId of entityIds) {
+      this.activeMaintenanceJobs.add(this._importKey(entityId));
+    }
+  }
+
+  releaseImportLocks(entityIds: string[]): void {
+    this.activeMaintenanceJobs.delete(this._globalImportKey());
+    for (const entityId of entityIds) {
+      this.activeMaintenanceJobs.delete(this._importKey(entityId));
+    }
+  }
+
+  getEntityStatus(entityId: string): EntityStatus {
+    return {
+      ingesting: this._isIngestActiveFor(entityId),
+      librarian: this.activeMaintenanceJobs.has(this._librarianKey(entityId)),
+      heal: this.activeMaintenanceJobs.has(this._healKey(entityId)),
+    };
+  }
+
+  subscribeEntityStatus(entityId: string, callback: (status: EntityStatus) => void): () => void {
+    const initial = this.getEntityStatus(entityId);
+    let set = this.statusSubscribers.get(entityId);
+    if (!set) {
+      set = new Set();
+      this.statusSubscribers.set(entityId, set);
+    }
+
+    const entry = { callback, last: this._copyEntityStatus(initial) };
+    set.add(entry);
+
+    try {
+      callback(this._copyEntityStatus(initial));
+    } catch (err) {
+      console.error(`[JobManager] callback error for entityId="${entityId}" during initial emission`, err);
+    }
+
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const s = this.statusSubscribers.get(entityId);
+      if (!s) return;
+      s.delete(entry);
+      if (s.size === 0) this.statusSubscribers.delete(entityId);
+    };
+  }
+
+  private _copyEntityStatus(s: EntityStatus): EntityStatus {
+    return { ingesting: s.ingesting, librarian: s.librarian, heal: s.heal };
+  }
+
+  private _notifyStatusSubscribers(entityId: string): void {
+    if (entityId === '*') return;
+
+    const set = this.statusSubscribers.get(entityId);
+    if (!set || set.size === 0) return;
+
+    for (const entry of Array.from(set)) {
+      if (!set.has(entry)) continue;
+      const next = this.getEntityStatus(entityId);
+
+      if (entry.last.ingesting === next.ingesting &&
+          entry.last.librarian === next.librarian &&
+          entry.last.heal === next.heal) {
+        continue;
+      }
+
+      entry.last = this._copyEntityStatus(next);
+      try {
+        entry.callback(this._copyEntityStatus(next));
+      } catch (err) {
+        console.error(`[JobManager] callback error for entityId="${entityId}" during transition emission`, err);
+      }
+    }
+  }
+}

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -187,14 +187,17 @@ export class JobManager {
 
     switch (operation) {
       case 'librarian':
-      case 'heal': {
-        const opKey = operation === 'librarian' ? this._librarianKey(entityId) : this._healKey(entityId);
-        return this.activeMaintenanceJobs.has(opKey) ||
+        return this.activeMaintenanceJobs.has(this._librarianKey(entityId)) ||
                this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
                this._isReembedActive(entityId) ||
                this._isImportActiveFor(entityId) ||
                this._isForgetActiveFor(entityId);
-      }
+      case 'heal':
+        return this.activeMaintenanceJobs.has(this._healKey(entityId)) ||
+               this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
+               this._isReembedActive(entityId) ||
+               this._isImportActiveFor(entityId) ||
+               this._isForgetActiveFor(entityId);
       case 'prune':
         return this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
                this.activeMaintenanceJobs.has(this._librarianKey(entityId)) ||
@@ -206,6 +209,18 @@ export class JobManager {
       default:
         return false;
     }
+  }
+
+  /**
+   * Auto-heal historically only gated on the heal self-key. Keep that behavior
+   * for write() auto-trigger paths while preserving stricter checks in acquireLock().
+   */
+  tryAcquireAutoHealLock(entityId: string): boolean {
+    const healKey = this._healKey(entityId);
+    if (this.activeMaintenanceJobs.has(healKey)) return false;
+    this.activeMaintenanceJobs.add(healKey);
+    this._notifyStatusSubscribers(entityId);
+    return true;
   }
 
   /**

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -1,4 +1,4 @@
-import { EntityStatus, WikiBusyError } from '../types';
+import { EntityStatus, WikiBusyError, WikiBusyOperation } from '../types';
 
 export type OperationType =
   | 'prune'
@@ -61,7 +61,7 @@ export class JobManager {
   }
 
   acquireLock(operation: OperationType, entityId: string, sourceRef?: string): void {
-    let blockingOperation: string | null = null;
+    let blockingOperation: WikiBusyOperation | null = null;
 
     if (operation !== 'global_import' && this.activeMaintenanceJobs.has(this._globalImportKey())) {
       throw new WikiBusyError('import', '*');

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -1,0 +1,244 @@
+import type { ExtractedFact, ExtractedTask } from '../types';
+
+export function parseJsonResponse<T>(text: string): T {
+  const firstBrace = text.indexOf('{');
+  const firstBracket = text.indexOf('[');
+
+  let start: number;
+  let openChar: string;
+  let closeChar: string;
+
+  if (firstBrace !== -1 && (firstBracket === -1 || firstBrace < firstBracket)) {
+    start = firstBrace;
+    openChar = '{';
+    closeChar = '}';
+  } else if (firstBracket !== -1) {
+    start = firstBracket;
+    openChar = '[';
+    closeChar = ']';
+  } else {
+    throw new SyntaxError('No JSON object/array found in LLM response');
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let end = -1;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) { escape = false; continue; }
+    if (ch === '\\' && inString) { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === openChar) { depth++; continue; }
+    if (ch === closeChar) {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+
+  if (end === -1) throw new SyntaxError('No JSON object/array found in LLM response');
+  return JSON.parse(text.slice(start, end + 1)) as T;
+}
+
+export function safeSlice(value: string, start: number, end?: number): string {
+  const length = value.length;
+  let safeStart = start < 0 ? Math.max(length + start, 0) : Math.min(start, length);
+  let safeEnd = end === undefined
+    ? length
+    : end < 0
+      ? Math.max(length + end, 0)
+      : Math.min(end, length);
+
+  if (safeStart > safeEnd) {
+    [safeStart, safeEnd] = [safeEnd, safeStart];
+  }
+
+  if (
+    safeStart > 0 &&
+    safeStart < length &&
+    value.charCodeAt(safeStart) >= 0xDC00 &&
+    value.charCodeAt(safeStart) <= 0xDFFF &&
+    value.charCodeAt(safeStart - 1) >= 0xD800 &&
+    value.charCodeAt(safeStart - 1) <= 0xDBFF
+  ) {
+    safeStart--;
+  }
+
+  if (
+    safeEnd > 0 &&
+    safeEnd < length &&
+    value.charCodeAt(safeEnd - 1) >= 0xD800 &&
+    value.charCodeAt(safeEnd - 1) <= 0xDBFF &&
+    value.charCodeAt(safeEnd) >= 0xDC00 &&
+    value.charCodeAt(safeEnd) <= 0xDFFF
+  ) {
+    safeEnd--;
+  }
+
+  return value.slice(safeStart, safeEnd);
+}
+
+export function chunkText(
+  input: string,
+  maxChunkLength: number,
+  overlap: number
+): { chunks: string[]; truncated: boolean } {
+  const text = input.trim();
+  if (text.length === 0) return { chunks: [], truncated: false };
+  if (!Number.isInteger(maxChunkLength) || maxChunkLength < 2) {
+    throw new Error('maxChunkLength must be an integer >= 2');
+  }
+  if (!Number.isInteger(overlap) || overlap < 0 || overlap >= maxChunkLength) {
+    throw new Error('overlap must be a non-negative integer < maxChunkLength');
+  }
+
+  const chunks: string[] = [];
+  let truncated = false;
+  let cursor = 0;
+  const halfMax = Math.floor(maxChunkLength / 2);
+
+  while (cursor < text.length) {
+    const remaining = text.length - cursor;
+    if (remaining <= maxChunkLength) {
+      chunks.push(safeSlice(text, cursor, text.length));
+      break;
+    }
+
+    const windowEnd = cursor + maxChunkLength;
+    const minSplit = cursor + halfMax;
+
+    // 1. paragraph break
+    let splitPoint = -1;
+    const paraIdx = text.lastIndexOf('\n\n', windowEnd);
+    if (paraIdx >= minSplit && paraIdx + 2 <= windowEnd) {
+      splitPoint = paraIdx + 2;
+    }
+
+    // 2. sentence terminator (single left-to-right pass, no lookahead regex)
+    if (splitPoint === -1) {
+      let lastTerm = -1;
+      for (let i = minSplit; i < windowEnd - 1; i++) {
+        const ch = text[i];
+        if ((ch === '.' || ch === '!' || ch === '?') && /\s/.test(text[i + 1])) {
+          lastTerm = i + 2; // include the terminator + whitespace
+        }
+      }
+      if (lastTerm !== -1 && lastTerm <= windowEnd) splitPoint = lastTerm;
+    }
+
+    // 3. whitespace
+    if (splitPoint === -1) {
+      for (let i = windowEnd - 1; i >= minSplit; i--) {
+        if (/\s/.test(text[i])) {
+          splitPoint = i + 1;
+          break;
+        }
+      }
+    }
+
+    // 4. hard cut
+    if (splitPoint === -1) {
+      truncated = true;
+      splitPoint = windowEnd;
+    }
+
+    chunks.push(safeSlice(text, cursor, splitPoint));
+    const next = Math.max(splitPoint - overlap, cursor + 1);
+    cursor = next;
+  }
+
+  return { chunks, truncated };
+}
+
+export async function withConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let index = 0;
+  let failed = false;
+  let firstError: unknown;
+  async function worker() {
+    while (index < tasks.length && !failed) {
+      const i = index++;
+      try {
+        results[i] = await tasks[i]();
+      } catch (e) {
+        if (!failed) { failed = true; firstError = e; }
+        return;
+      }
+    }
+  }
+  const workerCount = tasks.length === 0 ? 0 : Math.min(Math.max(limit, 1), tasks.length);
+  await Promise.allSettled(Array.from({ length: workerCount }, worker));
+  if (failed) throw firstError;
+  return results;
+}
+
+export function clip(value: string, max: number): string {
+  if (typeof value !== 'string') return '';
+  const s = value.trim();
+  return s.length <= max ? s : safeSlice(s, 0, max).trimEnd();
+}
+
+export function validateTags(tags: any[]): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter(t => typeof t === 'string')
+    .map(t => t.trim().toLowerCase())
+    .filter(t => t.length > 0 && t.length <= 40)
+    .slice(0, 6);
+}
+
+export function validateFact(fact: any): ExtractedFact | null {
+  if (typeof fact?.title !== 'string' || typeof fact?.body !== 'string') return null;
+  const title = clip(fact.title, 80);
+  const body = clip(fact.body, 800);
+  if (!title || !body) return null;
+
+  let confidence = fact.confidence;
+  if (confidence !== 'certain' && confidence !== 'tentative') confidence = 'inferred';
+
+  return {
+    ...fact,
+    title,
+    body,
+    confidence,
+    tags: validateTags(fact.tags)
+  };
+}
+
+export function validateTask(task: any): ExtractedTask | null {
+  if (typeof task?.description !== 'string') return null;
+  const description = clip(task.description, 200);
+  if (!description) return null;
+
+  let priority = task.priority;
+  if (typeof priority !== 'number' || !isFinite(priority)) priority = 0;
+
+  return {
+    ...task,
+    description,
+    priority
+  };
+}
+
+export function normalizeSourceRef(value: string): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[^A-Za-z0-9._\- ]/g, '').trim().slice(0, 255);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+export function normalizeSourceHash(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return /^[0-9a-f]{64}$/i.test(value) ? value.toLowerCase() : null;
+}
+
+export function titleTokens(title: string): Set<string> {
+  return new Set(title.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/).filter(t => t.length >= 3));
+}
+
+export function jaccardScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  const intersection = new Set([...a].filter(x => b.has(x)));
+  const union = new Set([...a, ...b]);
+  return intersection.size / union.size;
+}


### PR DESCRIPTION
## Summary

- Moves pure helper functions (`parseJsonResponse`, `chunkText`, `withConcurrency`, `clip`, `validateFact`, `validateTask`, `normalizeSourceRef`, `normalizeSourceHash`, `titleTokens`, `jaccardScore`, `safeSlice`, `validateTags`) out of `WikiMemory.ts` into `packages/core/src/utils/pure.ts`
- Introduces `JobManager` (`packages/core/src/services/JobManager.ts`) to centralize all mutex locking (`activeMaintenanceJobs`, `activeIngestJobs`) and status subscriber broadcasting
- Wires `WikiMemory` to delegate all lock acquisition/release and status operations through `jobManager`; removes ~60 lines of sprawling conflict-check boilerplate from each public method
- Exports `HOOK_TIMEOUT_MARKER` from `WikiMemory.ts` so PR2's `MaintenanceService` can import it
- Updates all test helpers that accessed internal lock state directly to go through `jobManager`

**Note:** This is phase-3 PR1. Merge after rebasing `phase-3-pr2` on top.

## Test plan

- [ ] All 406 existing tests pass (`npm run test` in `packages/core`)
- [ ] `jobs.test.ts` — concurrent lock semantics preserved (WikiBusyError still thrown on conflicts)
- [ ] `subscribeEntityStatus.test.ts` — subscriber notifications still fire on librarian/heal/ingest transitions
- [ ] `write.test.ts` — auto-librarian trigger suppression still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)