### PR TITLE
feat(core): Phase 4 — Prompt & Context Management Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ const wiki = createWiki(db, {
 
     // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
     // ingestSystemPrompt applies only to explicit ingestDocument() calls.
+    // ⚠ Overrides replace the entire default prompt, including the JSON output contract.
+    // Your prompt must instruct the LLM to return the required JSON shape — see packages/core/README.md#prompt-management--overrides.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
@@ -405,7 +407,8 @@ const result = await wiki.ingestDocument('entity-123', {
   maxChunkLength: 12000,              // optional, character count
   chunkOverlap: 400,                  // optional, overlap in characters
   chunkConcurrency: 1,                // optional, parallel LLM calls per ingest (default: 1)
-  // Optional: runtime override for this call only (does not affect write() auto-runs)
+  // Optional: runtime override for this call only (does not affect write() auto-runs).
+  // Must include the JSON output contract — overrides replace the entire default prompt.
   promptOverride: `Extract strict technical requirements: {{documentChunk}}`,
 });
 // result: { truncated: boolean; chunks: number }
@@ -419,7 +422,8 @@ const result = await wiki.ingestDocument('entity-123', {
 // Consolidate recent events into durable facts (auto-triggered by write, or call manually)
 await wiki.runLibrarian('entity-123');
 
-// Run a manual synthesis with a one-off runtime override (does not affect write() auto-runs)
+// Run a manual synthesis with a one-off runtime override (does not affect write() auto-runs).
+// Must include the JSON output contract — overrides replace the entire default prompt.
 await wiki.runLibrarian('entity-123', {
   promptOverride: `One-off extraction task:\n{{events}}`,
 });

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ const wiki = createWiki(db, {
     staleInferredAfterDays: 60,        // optional, default: 60 (days before runHeal downgrades inferred facts; null to disable)
     preFilterLimit: 50,                // optional, default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // optional, default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
+
+    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    prompts: {
+      ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
+      librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
+      healSystemPrompt: `Fix the memory graph based on these candidates: {{healCandidates}}`,
+    },
   },
 });
 
@@ -401,6 +408,8 @@ const result = await wiki.ingestDocument('entity-123', {
   maxChunkLength: 12000,              // optional, character count
   chunkOverlap: 400,                  // optional, overlap in characters
   chunkConcurrency: 1,                // optional, parallel LLM calls per ingest (default: 1)
+  // Optional: runtime override for this call only (does not affect write() auto-runs)
+  promptOverride: `Extract strict technical requirements: {{documentChunk}}`,
 });
 // result: { truncated: boolean; chunks: number }
 // truncated: true if at least one hard-split was required (no sentence boundary)
@@ -412,6 +421,11 @@ const result = await wiki.ingestDocument('entity-123', {
 ```typescript
 // Consolidate recent events into durable facts (auto-triggered by write, or call manually)
 await wiki.runLibrarian('entity-123');
+
+// Run a manual synthesis with a one-off runtime override (does not affect write() auto-runs)
+await wiki.runLibrarian('entity-123', {
+  promptOverride: `One-off extraction task:\n{{events}}`,
+});
 
 // Resolve contradictions, downgrade stale claims, remove obsolete facts
 await wiki.runHeal('entity-123');
@@ -478,7 +492,7 @@ const finalPrompt = hydrateLibrarianPrompt(template, {
 });
 ```
 
-For full examples, template-warning guidance, and the override contract, see [`packages/core/README.md`](packages/core/README.md#librarian-prompt-override-contract).
+Advanced Prompting: For full details on `{{mustache}}` prompt templating, hydration utilities, and the strict distinction between global auto-runs and runtime overrides, see [Prompt Management & Overrides](packages/core/README.md#prompt-management--overrides) in `packages/core/README.md`.
 
 Facts are ranked by a weighted score combining confidence tier, access frequency, and recency. Returns an empty string for an empty bundle.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=expo)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![bundlephobia](https://img.shields.io/bundlephobia/minzip/%40equationalapplications%2Fexpo-llm-wiki?label=gzip)](https://bundlephobia.com/package/@equationalapplications/expo-llm-wiki)<br>
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![bundlephobia](https://img.shields.io/bundlephobia/minzip/%40equationalapplications%2Freact-llm-wiki?label=gzip)](https://bundlephobia.com/package/@equationalapplications/react-llm-wiki)<br>
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=core)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![bundlephobia](https://img.shields.io/bundlephobia/minzip/%40equationalapplications%2Fcore-llm-wiki?label=gzip)](https://bundlephobia.com/package/@equationalapplications/core-llm-wiki)
-
 ## Persistent, episodic memory for AI Agents.
 
 expo-llm-wiki is a cross-platform TypeScript and SQLite library for long-term LLM memory. It bridges the gap between raw conversation logs and a structured knowledge base, supporting background fact extraction, semantic embedding search, and memory pruning.
@@ -94,11 +90,11 @@ flowchart TB
 
 `expo-llm-wiki` is organized as a monorepo with three packages, each optimized for different platforms:
 
-| Package | Platform | SQLite Adapter | Size | Dependencies |
-|---------|----------|---|---|---|
-| **`@equationalapplications/core-llm-wiki`** | Node.js, any platform | User-provided (e.g., `better-sqlite3`) | Smallest | `minisearch` |
-| **`@equationalapplications/expo-llm-wiki`** | Expo, React Native | `expo-sqlite` (built-in) | Minimal | `expo-sqlite` (peer) |
-| **`@equationalapplications/react-llm-wiki`** | Web (React) | User-provided (e.g., `sql.js`) | Small | `react` (peer) |
+| Package | Platform | SQLite Adapter | Size (Minzipped) |
+|---------|----------|---|---|
+| **`@equationalapplications/core-llm-wiki`** | Node.js, any platform | User-provided (e.g., `better-sqlite3`) | ~23 kB |
+| **`@equationalapplications/expo-llm-wiki`** | Expo, React Native | `expo-sqlite` (built-in) | ~24 kB |
+| **`@equationalapplications/react-llm-wiki`** | Web (React) | User-provided (e.g., `sql.js`) | ~25 kB |
 
 **Choose your package:**
 - **Expo/React Native app?** → `@equationalapplications/expo-llm-wiki`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ const wiki = createWiki(db, {
     preFilterLimit: 50,                // optional, default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // optional, default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
 
-    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
+    // ingestSystemPrompt applies only to explicit ingestDocument() calls.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -1,6 +1,8 @@
 ## Phase 4: Prompt & Context Management Extraction.
 
-### Current implementation state
+> **Note:** This spec was written pre-implementation and describes the state of the codebase _before_ Phase 4 was applied. The "Current implementation state" section below is historical context. All items listed as missing have been implemented in this branch.
+
+### Current implementation state (pre-implementation snapshot)
 
 The current code base does not yet implement this Phase 4 design. Core services still rely on static prompt constants and manual prompt construction, so the planned prompt abstraction layer is currently absent.
 

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -497,17 +497,11 @@ CRITICAL CONSTRAINTS:
 
 With PR 1 acting as the anchor, these agents will safely gut the formatting logic out of your core services in parallel.
 
-Once they complete PRs 2 and 3, would you like me to draft the final implementation for PR 4 (the `WikiMemory` facade wiring) so you can close out the Phase 4 refactor entirely?
+---
 
---- 
+## Post-Phase 4 Roadmap
 
-That is a phenomenal wrap-up to the core refactoring. Implementing the `__testAccess` pattern with strict typing (`WikiMemoryTestAccess`) gives you the exact best of both worlds: a pristine, dummy-proof public API for consumers, and a fully transparent playground for your test suites. Seeing 406 tests pass on an architecture change this massive is a testament to how well you laid out the test coverage beforehand.
-
-You are exactly right about the roadmap. Phase 1 through 3.5 were all about **building the engine**: getting the schemas right, abstracting the SQLite layer, handling dual-writes, and finally decoupling the God Object into cohesive domain services.
-
-The core engine is now built, tuned, and tested. For **Phase 4**, we move from building the engine to _installing it in the car_. Since this is the `expo-llm-wiki` repository, the natural progression is to move up the stack towards developer experience (DX) and integration.
-
-Here are the most logical tracks for Phase 4. Which of these aligns best with your immediate goals for the project?
+With the core engine built and tested (Phases 1–4), the natural next tracks are developer experience (DX) and integration.
 
 ### Track A: The React / Expo Integration Layer (Hooks & Context)
 

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -418,7 +418,7 @@ Once PRs 2 and 3 are merged, the final step is to connect the new pipes to the p
 
 By isolating `WikiMemory.ts` to the very last step, your agents can run PRs 2 and 3 concurrently without locking up your repository.
 
-Do you want me to write the exact system prompts you can copy-paste into Cursor/GitHub Copilot for Agents 2 and 3 to ensure they execute their specific PRs flawlessly?
+The following section provides exact system prompts for Agents 2 and 3 that can be copied into Cursor, GitHub Copilot Workspace, or a similar AI agent workflow.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -416,23 +416,21 @@ Once PRs 2 and 3 are merged, the final step is to connect the new pipes to the p
 
 ---
 
-By isolating `WikiMemory.ts` to the very last step, your agents can run PRs 2 and 3 concurrently without locking up your repository.
+By isolating `WikiMemory.ts` to the very last step, PRs 2 and 3 can be implemented concurrently with minimal overlap, and the public API can then be updated once the underlying services have stabilized.
 
-The following section provides exact system prompts for Agents 2 and 3 that can be copied into Cursor, GitHub Copilot Workspace, or a similar AI agent workflow.
+### Implementation sequencing note
 
----
+The intended rollout order for this phase was:
 
-Here are the exact system prompts you can feed into Cursor, GitHub Copilot Workspace, or your AI agent of choice.
+1. Introduce the shared prompt abstraction and supporting types.
+2. Refactor ingestion and maintenance flows to consume that abstraction.
+3. Wire `WikiMemory.ts` to instantiate and pass the shared prompt service, then expose the new optional runtime override arguments on the public API.
 
-These prompts are designed to be **highly restrictive**—they give the agent exactly the context it needs while explicitly forbidding it from touching unrelated logic like database transactions or concurrency locks.
+This ordering reduces churn in the facade layer and keeps the integration step focused on wiring already-defined service contracts rather than redesigning them in parallel.
 
----
+### Historical coordination note
 
-### Prompt for Agent 2 (PR 2: Ingestion Overhaul)
-
-**Copy and paste this into the agent working on `IngestionService`:**
-
-Plaintext
+Earlier drafts of this spec included tool-specific assistant prompts used during implementation planning. Those operational instructions are omitted here because this document is intended to remain a durable repository reference describing the design, sequencing constraints, and expected code changes.
 
 ```
 You are executing PR 2 of our Prompt Management Refactor. 

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -432,65 +432,7 @@ This ordering reduces churn in the facade layer and keeps the integration step f
 
 Earlier drafts of this spec included tool-specific assistant prompts used during implementation planning. Those operational instructions are omitted here because this document is intended to remain a durable repository reference describing the design, sequencing constraints, and expected code changes.
 
-```
-You are executing PR 2 of our Prompt Management Refactor. 
-Your scope is strictly limited to `packages/core/src/services/IngestionService.ts` and its corresponding test file.
-
-Assume `PromptService` already exists and is exported from `../services/PromptService` (or equivalent types file). It has the following method:
-`buildIngestPrompt(documentChunk: string, runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
-
-Execute the following changes:
-1. Update the `IngestionService` constructor to accept `private promptService: PromptService`.
-2. Update the `ingestDocument` method signature so the `params` object accepts an optional `promptOverride?: string`.
-3. Inside `ingestDocument`, locate the LLM generation step inside the `chunks.map` loop.
-4. Remove the manual construction of `userPrompt` (`const userPrompt = 'Document Chunk:\n' + chunk;`) and the direct usage of `INGEST_SYSTEM_PROMPT`.
-5. Call `const { systemPrompt, userPrompt } = this.promptService.buildIngestPrompt(chunk, params.promptOverride);`
-6. Pass those returned values into `this.options.llmProvider.generateText({ systemPrompt, userPrompt })`.
-7. Remove the import for `INGEST_SYSTEM_PROMPT` at the top of the file if it is no longer used.
-
-CRITICAL CONSTRAINTS:
-- Do NOT alter any `JobManager` lock acquisition or release logic.
-- Do NOT alter the chunking math or concurrency loops.
-- Do NOT alter any database transaction, upsert, or `searchService.sync()` logic.
-- Only output the exact modifications requested.
-```
-
----
-
-### Prompt for Agent 3 (PR 3: Maintenance Overhaul)
-
-**Copy and paste this into the agent working on `MaintenanceService`:**
-
-Plaintext
-
-```
-You are executing PR 3 of our Prompt Management Refactor. 
-Your scope is strictly limited to `packages/core/src/services/MaintenanceService.ts` and its corresponding test file.
-
-Assume `PromptService` already exists and is exported from `../services/PromptService`. It has the following methods:
-- `buildLibrarianPrompt(events: any[], currentFacts: any[], runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
-- `buildHealPrompt(healCandidates: any[], documentAnchors: any[], allTasks: any[], recentEvents: any[], runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
-
-Execute the following changes:
-1. Update the `MaintenanceService` constructor to accept `private promptService: PromptService`.
-2. Update the public `runLibrarian(entityId: string, options?: { promptOverride?: string })` and `runHeal(entityId: string, options?: { promptOverride?: string })` methods to accept the new options object, and pass the override down to `doRunLibrarian` and `doRunHeal`.
-3. Update `doRunLibrarian(entityId: string, promptOverride?: string)`:
-   - Remove the manual `userPrompt` stringification (`Events:\n${JSON.stringify(...)}`).
-   - Call `const { systemPrompt, userPrompt } = this.promptService.buildLibrarianPrompt(events, currentFacts, promptOverride);`.
-   - Pass these into `this.options.llmProvider.generateText`.
-4. Update `doRunHeal(entityId: string, promptOverride?: string)`:
-   - Remove the massive manual `userPrompt` stringification block.
-   - Call `const { systemPrompt, userPrompt } = this.promptService.buildHealPrompt(healCandidates, documentAnchors, allTasks, recentEvents, promptOverride);`.
-   - Pass these into `this.options.llmProvider.generateText`.
-5. Remove the imports for `LIBRARIAN_SYSTEM_PROMPT` and `HEAL_SYSTEM_PROMPT` if they are no longer used.
-
-CRITICAL CONSTRAINTS:
-- Do NOT alter any `JobManager` lock acquisition or release logic.
-- Do NOT alter the database threshold logic (orphan/stale checks).
-- Do NOT alter the database upsert, downgrade, or transaction logic.
-- Only output the exact modifications requested.
-```
-
+> Note: This durable spec intentionally excludes tool-specific agent prompts. It documents the expected design and sequencing, not operational prompt instructions.
 ---
 
 With PR 1 acting as the anchor, these agents will safely gut the formatting logic out of your core services in parallel.

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -1,0 +1,88 @@
+# Phase 4 Technical Specification: DX, Integrations, & Prompt Management
+
+## 1. Executive Summary
+
+With the core `WikiMemory` engine successfully decoupled into cohesive domain services (Ingestion, Maintenance, Retrieval, etc.) and backed by robust test coverage, Phase 4 focuses on **Developer Experience (DX) and App Integration**. This phase bridges the gap between the isolated domain logic and the consumer applications building on top of it, introducing dynamic prompt management, React/Expo bindings, and background task orchestration.
+
+## 2. Core Architecture Update: Prompt & Context Management
+
+Hardcoded system prompts limit the engine to a generic assistant persona. To support domain-specific apps (like *Curated Thoughts*), we will extract all LLM instruction logic into a dedicated `PromptService`.
+
+### 2.1 Configuration Interfaces
+
+Introduce standardized configuration objects allowing developers to define global defaults and runtime overrides.
+
+```typescript
+export interface PromptOverrides {
+  ingestSystemPrompt?: string;
+  librarianSystemPrompt?: string;
+  healSystemPrompt?: string;
+}
+
+export interface WikiConfig {
+  tablePrefix?: string;
+  prompts?: PromptOverrides; 
+  // ... existing configs
+}
+
+```
+
+### 2.2 The `PromptService`
+
+A new service responsible for handling string serialization, `{{mustache}}` variable hydration, and prompt resolution.
+
+* **Decoupling:** Removes all `JSON.stringify` and formatting logic from `IngestionService` and `MaintenanceService`.
+* **Hydration:** Replaces variables like `{{events}}` or `{{documentChunk}}` if the developer provides a custom template.
+* **Fallback:** If no variables are detected in an override template, gracefully falls back to appending the raw JSON as the `userPrompt`.
+
+### 2.3 Rollout Strategy (Zero-Conflict Parallelism)
+
+To prevent Git merge conflicts and allow multiple AI agents to execute the refactor concurrently, the rollout will follow a 3-step, 4-PR sequence:
+
+1. **PR 1 (Foundation):** Define `PromptOverrides`, build `PromptService`, and write isolated mustache hydration tests.
+2. **PR 2 & 3 (Parallel Domain Overhaul):** * Agent A strips formatting logic from `IngestionService`, injecting `PromptService.buildIngestPrompt()`.
+* Agent B strips formatting from `MaintenanceService`, injecting `buildLibrarianPrompt()` and `buildHealPrompt()`.
+
+
+3. **PR 4 (Facade Wiring):** Update the `WikiMemory` constructor to initialize `PromptService` and pass it down. Expose optional `promptOverride` arguments on public methods (`ingestDocument`, `runLibrarian`, `runHeal`).
+
+---
+
+## 3. Expo & React Integration Layer (Hooks & Context)
+
+Currently, `WikiMemory` is a pure Vanilla JS/TypeScript class. To make it ergonomic for React Native / Expo, we will build a reactivity layer.
+
+* **`<WikiProvider />`:** A context provider that initializes the SQLite database and holds the `WikiMemory` singleton safely.
+* **Data Hooks:** `useWikiRead()` and `useWikiWrite()` for standard read/write operations.
+* **Status Hooks:** A `useEntityStatus(entityId)` hook natively wrapping the `subscribeEntityStatus` method. This allows the UI to reactively display spinners/indicators when the Librarian or Ingestion queues are churning.
+
+---
+
+## 4. Background Task Orchestration
+
+Heavy LLM operations (pruning, healing, synthesizing) currently run on the active JS thread.
+
+* **Expo TaskManager Integration:** Wire the `MaintenanceService` (`runLibrarian`, `runHeal`) into Expo's `TaskManager` or `BackgroundFetch` APIs.
+* **Objective:** Enable the LLM to process Outbox queues and re-embed data while the app is backgrounded or the device is charging, ensuring zero frame drops on the main UI thread during active user interaction.
+
+---
+
+## 5. Observability & DevTools
+
+Vector databases and LLM summaries are notoriously opaque during development.
+
+* **Memory Explorer UI / CLI:** Build a drop-in `<WikiDevTools />` component.
+* **Features:** Allow developers to visually inspect an entity's timeline, monitor vector dimension mismatches, view the Outbox queue, and manually trigger operations like `runReembed()` or `runPrune()`.
+* **Telemetry:** Implement a lightweight `jobId` or `traceId` context passed through the `JobManager` to provide highly descriptive error stacks if a background job fails.
+
+---
+
+## 6. API Polish & NPM Publishing
+
+Finalizing the monorepo for public consumption.
+
+* **Exports:** Lock down public exports in `index.ts` (ensuring internal repos like `OutboxRepository` aren't accidentally exposed).
+* **Documentation:** Finalize READMEs with clear examples of global vs. runtime prompt overrides.
+* **Release:** Set up the monorepo build pipeline and cut `v1.0.0-rc.1`.
+
+---

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -1,88 +1,684 @@
-# Phase 4 Technical Specification: DX, Integrations, & Prompt Management
+## Phase 4: Prompt & Context Management Extraction.
 
-## 1. Executive Summary
+### Current implementation state
 
-With the core `WikiMemory` engine successfully decoupled into cohesive domain services (Ingestion, Maintenance, Retrieval, etc.) and backed by robust test coverage, Phase 4 focuses on **Developer Experience (DX) and App Integration**. This phase bridges the gap between the isolated domain logic and the consumer applications building on top of it, introducing dynamic prompt management, React/Expo bindings, and background task orchestration.
+The current code base does not yet implement this Phase 4 design. Core services still rely on static prompt constants and manual prompt construction, so the planned prompt abstraction layer is currently absent.
 
-## 2. Core Architecture Update: Prompt & Context Management
+Key mismatches:
 
-Hardcoded system prompts limit the engine to a generic assistant persona. To support domain-specific apps (like *Curated Thoughts*), we will extract all LLM instruction logic into a dedicated `PromptService`.
+- `packages/core/src/services/PromptService.ts` does not exist.
+- `PromptOverrides` is not defined in `packages/core/src/types.ts`.
+- `WikiConfig` does not include `prompts?: PromptOverrides`.
+- `packages/core/src/services/IngestionService.ts` imports `INGEST_SYSTEM_PROMPT` and builds `userPrompt` manually in `ingestDocument()`.
+- `ingestDocument()` does not accept a `promptOverride` parameter.
+- `packages/core/src/services/MaintenanceService.ts` imports `LIBRARIAN_SYSTEM_PROMPT` and `HEAL_SYSTEM_PROMPT`.
+- `doRunLibrarian()` and `doRunHeal()` still serialize raw JSON into `userPrompt` strings.
+- `runLibrarian()` and `runHeal()` do not accept runtime override options.
+- `packages/core/src/WikiMemory.ts` does not instantiate or pass a `PromptService`.
+- `WikiMemory` public APIs `runLibrarian()`, `runHeal()`, and `ingestDocument()` do not accept `promptOverride`.
+- `WikiMemoryTestAccess` does not expose a `promptService`.
 
-### 2.1 Configuration Interfaces
+Additional note:
 
-Introduce standardized configuration objects allowing developers to define global defaults and runtime overrides.
+`WriteService` already calls `maintenanceService.doRunLibrarian()` and `maintenanceService.doRunHeal()` internally. A proper `PromptService` must therefore be passed into `MaintenanceService` so global prompt overrides are available for internal auto-runs as well as manual calls.
 
-```typescript
+### 1. Define the Configuration Interfaces
+
+First, we need to define a standard configuration object for these prompts. We should allow developers to set **global overrides** (when instantiating `WikiMemory`) and **runtime overrides** (per method call).
+
+TypeScript
+
+```
 export interface PromptOverrides {
   ingestSystemPrompt?: string;
   librarianSystemPrompt?: string;
   healSystemPrompt?: string;
 }
 
+// Update WikiOptions to accept global default overrides
 export interface WikiConfig {
-  tablePrefix?: string;
+  // ... existing config (tablePrefix, maxResults, etc.)
   prompts?: PromptOverrides; 
-  // ... existing configs
 }
-
 ```
 
-### 2.2 The `PromptService`
+### 2. Create the `PromptService`
 
-A new service responsible for handling string serialization, `{{mustache}}` variable hydration, and prompt resolution.
+Instead of letting `IngestionService` and `MaintenanceService` directly import from `../prompts`, we will extract a `PromptService`. This service's job is to resolve the correct prompt (Runtime Override → Global Config → Base Default) and handle any hydration/variable injection.
 
-* **Decoupling:** Removes all `JSON.stringify` and formatting logic from `IngestionService` and `MaintenanceService`.
-* **Hydration:** Replaces variables like `{{events}}` or `{{documentChunk}}` if the developer provides a custom template.
-* **Fallback:** If no variables are detected in an override template, gracefully falls back to appending the raw JSON as the `userPrompt`.
+TypeScript
 
-### 2.3 Rollout Strategy (Zero-Conflict Parallelism)
+```
+import { 
+  INGEST_SYSTEM_PROMPT, 
+  LIBRARIAN_SYSTEM_PROMPT, 
+  HEAL_SYSTEM_PROMPT 
+} from '../prompts';
+import type { PromptOverrides } from '../types';
 
-To prevent Git merge conflicts and allow multiple AI agents to execute the refactor concurrently, the rollout will follow a 3-step, 4-PR sequence:
+export class PromptService {
+  constructor(private globalOverrides?: PromptOverrides) {}
 
-1. **PR 1 (Foundation):** Define `PromptOverrides`, build `PromptService`, and write isolated mustache hydration tests.
-2. **PR 2 & 3 (Parallel Domain Overhaul):** * Agent A strips formatting logic from `IngestionService`, injecting `PromptService.buildIngestPrompt()`.
-* Agent B strips formatting from `MaintenanceService`, injecting `buildLibrarianPrompt()` and `buildHealPrompt()`.
+  getIngestPrompt(runtimeOverride?: string): string {
+    return runtimeOverride ?? this.globalOverrides?.ingestSystemPrompt ?? INGEST_SYSTEM_PROMPT;
+  }
 
+  getLibrarianPrompt(runtimeOverride?: string): string {
+    return runtimeOverride ?? this.globalOverrides?.librarianSystemPrompt ?? LIBRARIAN_SYSTEM_PROMPT;
+  }
 
-3. **PR 4 (Facade Wiring):** Update the `WikiMemory` constructor to initialize `PromptService` and pass it down. Expose optional `promptOverride` arguments on public methods (`ingestDocument`, `runLibrarian`, `runHeal`).
+  getHealPrompt(runtimeOverride?: string): string {
+    return runtimeOverride ?? this.globalOverrides?.healSystemPrompt ?? HEAL_SYSTEM_PROMPT;
+  }
+}
+```
+
+### 3. Wire Up the Domain Services
+
+Now we update `IngestionService` and `MaintenanceService` to accept the `PromptService` in their constructors and use it to fetch the prompts dynamically.
+
+**Example: Updating `IngestionService.ts`**
+
+TypeScript
+
+```
+// Add `promptOverride` to the runtime params
+async ingestDocument(
+  entityId: string,
+  params: {
+    sourceRef: string;
+    sourceHash: string;
+    documentChunk: string;
+    promptOverride?: string; // <-- New optional runtime param
+    // ...
+  }
+) {
+  // ... lock acquisition ...
+  
+  // Resolve the prompt exactly when we need it
+  const systemPrompt = this.promptService.getIngestPrompt(params.promptOverride);
+
+  const chunkResults = await withConcurrency(
+    chunks.map((chunk) => async () => {
+      const userPrompt = `Document Chunk:\n${chunk}`;
+      return this.options.llmProvider.generateText({
+        systemPrompt, // <-- Injecting the dynamic prompt
+        userPrompt,
+      });
+      // ...
+```
+
+**Example: Updating `MaintenanceService.ts`**
+
+TypeScript
+
+```
+async doRunLibrarian(entityId: string, promptOverride?: string): Promise<void> {
+  // ... fetch events and facts ...
+
+  const systemPrompt = this.promptService.getLibrarianPrompt(promptOverride);
+  
+  const responseText = await this.options.llmProvider.generateText({
+    systemPrompt, // <-- Injecting the dynamic prompt
+    userPrompt: `Events:\n${JSON.stringify(events)}\n\nCurrent Facts:\n${JSON.stringify(currentFacts)}`,
+  });
+  // ...
+```
+
+### 4. Update the `WikiMemory` Facade
+
+Finally, update the public methods on `WikiMemory` to accept these optional overrides and pass them down.
+
+TypeScript
+
+```
+export class WikiMemory {
+  private promptService: PromptService;
+
+  constructor(db: SQLiteAdapter, options: WikiOptions) {
+    // ...
+    this.promptService = new PromptService(options.config?.prompts);
+    // Pass this.promptService down to IngestionService and MaintenanceService
+  }
+
+  async ingestDocument(entityId: string, params: IngestParams & { promptOverride?: string }) {
+    return this.ingestionService.ingestDocument(entityId, params);
+  }
+
+  async runLibrarian(entityId: string, options?: { promptOverride?: string }) {
+    return this.maintenanceService.runLibrarian(entityId, options?.promptOverride);
+  }
+  
+  async runHeal(entityId: string, options?: { promptOverride?: string }) {
+    return this.maintenanceService.runHeal(entityId, options?.promptOverride);
+  }
+}
+```
+
+> Note: `runLibrarian` and `runHeal` currently return `Promise<void>` and accept only `entityId`. This refactor explicitly changes the public API to accept an optional `options?: { promptOverride?: string }` object, so tests and public method signatures must be updated to match.
 
 ---
 
-## 3. Expo & React Integration Layer (Hooks & Context)
+By isolating this into a `PromptService`, you also create a perfect testing boundary for prompt generation and leave the door open for future features, like dynamically calculating token limits before sending the prompt off.
 
-Currently, `WikiMemory` is a pure Vanilla JS/TypeScript class. To make it ergonomic for React Native / Expo, we will build a reactivity layer.
+To ensure this aligns with your vision for apps like Curated Thoughts: do you want these prompts to remain static strings that the LLM reads alongside a JSON payload, or should the `PromptService` also take over the responsibility of injecting variables directly into the prompt templates (like `{{context}}` or `{{tasks}}`) before sending them to the LLM?
 
-* **`<WikiProvider />`:** A context provider that initializes the SQLite database and holds the `WikiMemory` singleton safely.
-* **Data Hooks:** `useWikiRead()` and `useWikiWrite()` for standard read/write operations.
-* **Status Hooks:** A `useEntityStatus(entityId)` hook natively wrapping the `subscribeEntityStatus` method. This allows the UI to reactively display spinners/indicators when the Librarian or Ingestion queues are churning.
+This is the perfect approach for an SDK. By moving the JSON serialization and template hydration into the `PromptService`, your domain services (`IngestionService`, `MaintenanceService`) become completely ignorant of _how_ the LLM is instructed. They just hand over the raw data arrays, and the `PromptService` handles the formatting.
 
----
+Since you already export `hydrateLibrarianPrompt` on the read-side (as seen in your [README.md](https://github.com/equationalapplications/expo-llm-wiki/blob/staging/packages/core/README.md)), utilizing the same `{{variable}}` syntax for background tasks creates a beautifully consistent developer experience.
 
-## 4. Background Task Orchestration
-
-Heavy LLM operations (pruning, healing, synthesizing) currently run on the active JS thread.
-
-* **Expo TaskManager Integration:** Wire the `MaintenanceService` (`runLibrarian`, `runHeal`) into Expo's `TaskManager` or `BackgroundFetch` APIs.
-* **Objective:** Enable the LLM to process Outbox queues and re-embed data while the app is backgrounded or the device is charging, ensuring zero frame drops on the main UI thread during active user interaction.
+Here is the exact implementation plan to build this out.
 
 ---
 
-## 5. Observability & DevTools
+## 1. The `PromptService` Implementation
 
-Vector databases and LLM summaries are notoriously opaque during development.
+We will build a service that takes raw objects/arrays, safely serializes them, and injects them into `{{mustache}}` style tags. If a developer provides a custom template, they can place `{{events}}` or `{{documentChunk}}` exactly where they want it.
 
-* **Memory Explorer UI / CLI:** Build a drop-in `<WikiDevTools />` component.
-* **Features:** Allow developers to visually inspect an entity's timeline, monitor vector dimension mismatches, view the Outbox queue, and manually trigger operations like `runReembed()` or `runPrune()`.
-* **Telemetry:** Implement a lightweight `jobId` or `traceId` context passed through the `JobManager` to provide highly descriptive error stacks if a background job fails.
+Create `packages/core/src/services/PromptService.ts`:
+
+TypeScript
+
+```
+import { 
+  INGEST_SYSTEM_PROMPT, 
+  LIBRARIAN_SYSTEM_PROMPT, 
+  HEAL_SYSTEM_PROMPT 
+} from '../prompts';
+import type { PromptOverrides, WikiFact, WikiTask, ExtractedFact } from '../types';
+
+export class PromptService {
+  constructor(private globalOverrides?: PromptOverrides) {}
+
+  /**
+   * Replaces {{key}} in the template with the stringified value from the variables object.
+   */
+  private hydrate(template: string, variables: Record<string, unknown>): string {
+    return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key) => {
+      const value = variables[key];
+      if (value === undefined) return match; // Leave un-hydrated if missing
+      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    });
+  }
+
+  buildIngestPrompt(documentChunk: string, runtimeOverride?: string): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.ingestSystemPrompt ?? INGEST_SYSTEM_PROMPT;
+    
+    // If the template contains {{documentChunk}}, inject it directly into the system prompt.
+    // Otherwise, fall back to the standard User Prompt separation.
+    if (template.includes('{{documentChunk}}')) {
+      return { 
+        systemPrompt: this.hydrate(template, { documentChunk }), 
+        userPrompt: 'Please extract the facts.' 
+      };
+    }
+
+    return {
+      systemPrompt: template,
+      userPrompt: `Document Chunk:\n${documentChunk}`
+    };
+  }
+
+  buildLibrarianPrompt(events: unknown[], currentFacts: unknown[], runtimeOverride?: string): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.librarianSystemPrompt ?? LIBRARIAN_SYSTEM_PROMPT;
+    
+    if (template.includes('{{events}}') || template.includes('{{currentFacts}}')) {
+      return {
+        systemPrompt: this.hydrate(template, { events, currentFacts }),
+        userPrompt: 'Please synthesize the context.'
+      };
+    }
+
+    return {
+      systemPrompt: template,
+      userPrompt: `Events:\n${JSON.stringify(events, null, 2)}\n\nCurrent Facts:\n${JSON.stringify(currentFacts, null, 2)}`
+    };
+  }
+
+  buildHealPrompt(
+    healCandidates: unknown[], 
+    documentAnchors: unknown[], 
+    allTasks: unknown[], 
+    recentEvents: unknown[], 
+    runtimeOverride?: string
+  ): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.healSystemPrompt ?? HEAL_SYSTEM_PROMPT;
+    
+    if (template.includes('{{healCandidates}}') || template.includes('{{documentAnchors}}')) {
+      return {
+        systemPrompt: this.hydrate(template, { healCandidates, documentAnchors, allTasks, recentEvents }),
+        userPrompt: 'Please heal the memory graph.'
+      };
+    }
+
+    return {
+      systemPrompt: template,
+      userPrompt: `Heal Candidates:\n${JSON.stringify(healCandidates, null, 2)}
+\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}
+\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}
+\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}`
+    };
+  }
+}
+```
+
+**Why this design?** It is backward compatible. If a developer just passes a plain string override without `{{}}` variables, the `PromptService` gracefully falls back to appending the raw JSON as the `userPrompt`, preserving the default behavior.
 
 ---
 
-## 6. API Polish & NPM Publishing
+## 2. Stripping Formatting from Domain Services
 
-Finalizing the monorepo for public consumption.
+Now look at how clean your background tasks become. The Domain Services no longer care about `JSON.stringify` or formatting instructions.
 
-* **Exports:** Lock down public exports in `index.ts` (ensuring internal repos like `OutboxRepository` aren't accidentally exposed).
-* **Documentation:** Finalize READMEs with clear examples of global vs. runtime prompt overrides.
-* **Release:** Set up the monorepo build pipeline and cut `v1.0.0-rc.1`.
+**In `IngestionService.ts`:**
+
+TypeScript
+
+```
+// Inside the chunk loop
+const { systemPrompt, userPrompt } = this.promptService.buildIngestPrompt(chunk, params.promptOverride);
+
+const responseText = await this.options.llmProvider.generateText({
+  systemPrompt,
+  userPrompt,
+});
+```
+
+**In `MaintenanceService.ts` (Librarian):**
+
+TypeScript
+
+```
+async doRunLibrarian(entityId: string, promptOverride?: string): Promise<void> {
+  const events = await this.eventRepo.getRecent(entityId, 50);
+  const currentFactsRows = await this.entryRepo.findRecentByEntityId(entityId, 100);
+  
+  // Strip out embeddings before sending to LLM
+  const currentFacts = currentFactsRows.map(f => { /* ... */ });
+
+  // Let PromptService handle all hydration and JSON formatting
+  const { systemPrompt, userPrompt } = this.promptService.buildLibrarianPrompt(
+    events, 
+    currentFacts, 
+    promptOverride
+  );
+
+  const responseText = await this.options.llmProvider.generateText({
+    systemPrompt,
+    userPrompt,
+  });
+  
+  // ... rest of librarian logic
+}
+```
 
 ---
+
+## 3. The Developer Experience (App Level)
+
+With this merged, a developer building _Curated Thoughts_ can inject highly specific domain templates at runtime:
+
+TypeScript
+
+```
+const customLibrarianPrompt = `
+You are an expert curator for Equational Applications LLC.
+Your job is to read the user's raw thoughts and format them into 'Curated Insights'.
+Never invent information.
+
+Recent Thoughts (Events):
+{{events}}
+
+Existing Insights:
+{{currentFacts}}
+
+Respond ONLY with a JSON object containing the new insights.
+`;
+
+// Runtime Override!
+await wiki.runLibrarian('user-123', { 
+  promptOverride: customLibrarianPrompt 
+});
+```
+
+### 3.1 Global vs Runtime Overrides
+
+When we document this feature, make the distinction explicit:
+
+- `options.config.prompts` is the only source of prompts that will persist for background auto-runs triggered by `WikiMemory.write()` or `WriteService` internals.
+- `promptOverride` is a one-off runtime override that applies only to the manual `runLibrarian`, `runHeal`, or `ingestDocument` call in which it is provided.
+
+That means if your app relies on automatic maintenance from `WriteService`, custom prompt templates must be configured globally during `WikiMemory` instantiation. Runtime overrides are powerful for ad hoc, manual executions, but they do not flow through the internal auto-run path.
+
+For developer guidance, this Phase 4 spec must also require:
+- JSDoc on `WikiMemory.runLibrarian()`, `WikiMemory.runHeal()`, and `WikiMemory.ingestDocument()` warning that `options.promptOverride` applies only to that manual call and does not affect `WriteService`-triggered internal auto-runs.
+- README examples that explicitly separate:
+  - global prompt config for auto-runs via `options.config.prompts`
+  - one-off prompt overrides for manual maintenance calls via `promptOverride`
+
+This makes the developer experience dummy-proof: global prompts control auto-run behavior, and runtime prompts control manual, one-off operations.
+
+This effectively turns `@equationalapplications/core-llm-wiki` from a rigid assistant memory layer into a highly malleable data-extraction engine.
+
+---
+
+To successfully unleash multiple AI agents on this refactor, the biggest threat is **Git merge conflicts**. If two agents try to update the `WikiMemory.ts` constructor at the same time, you will spend more time resolving conflicts than you saved by parallelizing them.
+
+To achieve maximum parallelism with zero file overlaps, you should break Phase 4 into **4 PRs executed across 3 sequential steps**.
+
+Here is the exact blueprint to hand off to your agents:
+
+### Step 1: The Contract (Agent 1)
+
+Before the other agents can do their work, they need the shared types and the new service to import. This must be merged (or at least branch-shared) first.
+
+- **PR 1: Foundation (`PromptService` & Types)**
+    
+    - **Files Touched:** `types.ts`, `prompts.ts`, `services/PromptService.ts`, `PromptService.test.ts`
+        
+    - **Agent Task:** Define the `PromptOverrides` interface in `types.ts`. Build the `PromptService` class with the `hydrate()` utility and the `buildIngestPrompt`, `buildLibrarianPrompt`, and `buildHealPrompt` methods. Write isolated unit tests verifying the mustache `{{variable}}` replacements work correctly.
+        
+
+---
+
+### Step 2: Parallel Domain Updates (Agents 2 & 3)
+
+Once PR 1 is available, you can spin up two agents simultaneously. Because they are working in completely different files, they will not step on each other's toes.
+
+- **PR 2: Ingestion Overhaul (Agent 2)**
+    
+    - **Files Touched:** `services/IngestionService.ts`, `IngestionService.test.ts`
+        
+    - **Agent Task:** Update the constructor to accept `PromptService`. Modify the `ingestDocument` signature to accept `promptOverride`. Gut the manual string formatting inside the chunk loop and replace it with a call to `this.promptService.buildIngestPrompt()`.
+        
+- **PR 3: Maintenance Overhaul (Agent 3)**
+    
+    - **Files Touched:** `services/MaintenanceService.ts`, `MaintenanceService.test.ts`
+        
+    - **Agent Task:** Update the constructor to accept `PromptService`. Modify `doRunLibrarian` and `doRunHeal` to accept `promptOverride`. Strip out all `JSON.stringify` logic for the LLM inputs and delegate entirely to `this.promptService.buildLibrarianPrompt()` and `this.promptService.buildHealPrompt()`.
+        
+
+---
+
+### Step 3: The Facade Wiring (Agent 4 or Human)
+
+Once PRs 2 and 3 are merged, the final step is to connect the new pipes to the public API.
+
+- **PR 4: `WikiMemory` Integration**
+    
+    - **Files Touched:** `WikiMemory.ts`, `README.md`
+        
+    - **Agent Task:** Instantiate `PromptService` in the `WikiMemory` constructor using `options.config?.prompts`. Pass it down into the instantiation of `IngestionService` and `MaintenanceService`. Update the public methods (`ingestDocument`, `runLibrarian`, `runHeal`) to accept the new optional `promptOverride` argument and pass it through to the services.
+    - **Documentation Task:** Add explicit JSDoc warnings to `WikiMemory.ts` that runtime `promptOverride` values apply only to manual calls, and ensure `README.md` clearly separates global prompt config (for auto-runs) from runtime overrides (for manual executions).
+        
+
+---
+
+By isolating `WikiMemory.ts` to the very last step, your agents can run PRs 2 and 3 concurrently without locking up your repository.
+
+Do you want me to write the exact system prompts you can copy-paste into Cursor/GitHub Copilot for Agents 2 and 3 to ensure they execute their specific PRs flawlessly?
+
+---
+
+Here are the exact system prompts you can feed into Cursor, GitHub Copilot Workspace, or your AI agent of choice.
+
+These prompts are designed to be **highly restrictive**—they give the agent exactly the context it needs while explicitly forbidding it from touching unrelated logic like database transactions or concurrency locks.
+
+---
+
+### Prompt for Agent 2 (PR 2: Ingestion Overhaul)
+
+**Copy and paste this into the agent working on `IngestionService`:**
+
+Plaintext
+
+```
+You are executing PR 2 of our Prompt Management Refactor. 
+Your scope is strictly limited to `packages/core/src/services/IngestionService.ts` and its corresponding test file.
+
+Assume `PromptService` already exists and is exported from `../services/PromptService` (or equivalent types file). It has the following method:
+`buildIngestPrompt(documentChunk: string, runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
+
+Execute the following changes:
+1. Update the `IngestionService` constructor to accept `private promptService: PromptService`.
+2. Update the `ingestDocument` method signature so the `params` object accepts an optional `promptOverride?: string`.
+3. Inside `ingestDocument`, locate the LLM generation step inside the `chunks.map` loop.
+4. Remove the manual construction of `userPrompt` (`const userPrompt = 'Document Chunk:\n' + chunk;`) and the direct usage of `INGEST_SYSTEM_PROMPT`.
+5. Call `const { systemPrompt, userPrompt } = this.promptService.buildIngestPrompt(chunk, params.promptOverride);`
+6. Pass those returned values into `this.options.llmProvider.generateText({ systemPrompt, userPrompt })`.
+7. Remove the import for `INGEST_SYSTEM_PROMPT` at the top of the file if it is no longer used.
+
+CRITICAL CONSTRAINTS:
+- Do NOT alter any `JobManager` lock acquisition or release logic.
+- Do NOT alter the chunking math or concurrency loops.
+- Do NOT alter any database transaction, upsert, or `searchService.sync()` logic.
+- Only output the exact modifications requested.
+```
+
+---
+
+### Prompt for Agent 3 (PR 3: Maintenance Overhaul)
+
+**Copy and paste this into the agent working on `MaintenanceService`:**
+
+Plaintext
+
+```
+You are executing PR 3 of our Prompt Management Refactor. 
+Your scope is strictly limited to `packages/core/src/services/MaintenanceService.ts` and its corresponding test file.
+
+Assume `PromptService` already exists and is exported from `../services/PromptService`. It has the following methods:
+- `buildLibrarianPrompt(events: any[], currentFacts: any[], runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
+- `buildHealPrompt(healCandidates: any[], documentAnchors: any[], allTasks: any[], recentEvents: any[], runtimeOverride?: string): { systemPrompt: string; userPrompt: string }`
+
+Execute the following changes:
+1. Update the `MaintenanceService` constructor to accept `private promptService: PromptService`.
+2. Update the public `runLibrarian(entityId: string, options?: { promptOverride?: string })` and `runHeal(entityId: string, options?: { promptOverride?: string })` methods to accept the new options object, and pass the override down to `doRunLibrarian` and `doRunHeal`.
+3. Update `doRunLibrarian(entityId: string, promptOverride?: string)`:
+   - Remove the manual `userPrompt` stringification (`Events:\n${JSON.stringify(...)}`).
+   - Call `const { systemPrompt, userPrompt } = this.promptService.buildLibrarianPrompt(events, currentFacts, promptOverride);`.
+   - Pass these into `this.options.llmProvider.generateText`.
+4. Update `doRunHeal(entityId: string, promptOverride?: string)`:
+   - Remove the massive manual `userPrompt` stringification block.
+   - Call `const { systemPrompt, userPrompt } = this.promptService.buildHealPrompt(healCandidates, documentAnchors, allTasks, recentEvents, promptOverride);`.
+   - Pass these into `this.options.llmProvider.generateText`.
+5. Remove the imports for `LIBRARIAN_SYSTEM_PROMPT` and `HEAL_SYSTEM_PROMPT` if they are no longer used.
+
+CRITICAL CONSTRAINTS:
+- Do NOT alter any `JobManager` lock acquisition or release logic.
+- Do NOT alter the database threshold logic (orphan/stale checks).
+- Do NOT alter the database upsert, downgrade, or transaction logic.
+- Only output the exact modifications requested.
+```
+
+---
+
+With PR 1 acting as the anchor, these agents will safely gut the formatting logic out of your core services in parallel.
+
+Once they complete PRs 2 and 3, would you like me to draft the final implementation for PR 4 (the `WikiMemory` facade wiring) so you can close out the Phase 4 refactor entirely?
+
+--- 
+
+That is a phenomenal wrap-up to the core refactoring. Implementing the `__testAccess` pattern with strict typing (`WikiMemoryTestAccess`) gives you the exact best of both worlds: a pristine, dummy-proof public API for consumers, and a fully transparent playground for your test suites. Seeing 406 tests pass on an architecture change this massive is a testament to how well you laid out the test coverage beforehand.
+
+You are exactly right about the roadmap. Phase 1 through 3.5 were all about **building the engine**: getting the schemas right, abstracting the SQLite layer, handling dual-writes, and finally decoupling the God Object into cohesive domain services.
+
+The core engine is now built, tuned, and tested. For **Phase 4**, we move from building the engine to _installing it in the car_. Since this is the `expo-llm-wiki` repository, the natural progression is to move up the stack towards developer experience (DX) and integration.
+
+Here are the most logical tracks for Phase 4. Which of these aligns best with your immediate goals for the project?
+
+### Track A: The React / Expo Integration Layer (Hooks & Context)
+
+Right now, `WikiMemory` is a pure Vanilla JS/TypeScript class. To make it ergonomic for an Expo app, you need a reactivity layer.
+
+- **Context Provider:** A `<WikiProvider>` that initializes the DB and holds the `WikiMemory` singleton.
+    
+- **Data Hooks:** `useWikiRead()`, `useWikiWrite()`.
+    
+- **Status Hooks:** A `useEntityStatus(entityId)` hook that natively wraps your `subscribeEntityStatus` method so the UI can show spinners when the Librarian or Ingestion services are actively churning in the background.
+    
+
+### Track B: Background Task Orchestration (Expo TaskManager)
+
+The `Librarian` and `Heal` jobs run in the background, but right now they run in the JS thread while the app is active.
+
+- **Integration:** Wiring the `MaintenanceService` into Expo's `TaskManager` or `BackgroundFetch` APIs.
+    
+- **Goal:** Allowing the LLM to prune, heal, and synthesize memories while the app is backgrounded or when the device is plugged in, so it doesn't block the UI thread during active use.
+    
+
+### Track C: DevTools & Observability (The "Memory Explorer")
+
+Because vector databases and LLM summaries are essentially "black boxes" to the user, debugging them during app development is notoriously difficult.
+
+- **Implementation:** Building a drop-in `<WikiDevTools />` component or a CLI script.
+    
+- **Goal:** Allowing a developer to visually inspect an entity's timeline, see the vector dimension mismatches, trigger a manual `runReembed()`, or view the Outbox queue.
+    
+
+### Track D: API Polish & NPM Publishing
+
+If the goal is to get this in the hands of other developers ASAP.
+
+- Writing the READMEs, setting up the monorepo build pipeline (if not fully done), locking down the public exports in `index.ts`, and cutting a `v1.0.0-rc.1`.
+    
+
+---
+
+### 1. Update Imports
+
+At the top of `packages/core/src/WikiMemory.ts`, import the new `PromptService`.
+
+TypeScript
+
+```
+// ... existing imports
+import { RetrievalService } from './services/RetrievalService';
+import { WriteService } from './services/WriteService';
+import { PromptService } from './services/PromptService'; // <-- NEW
+```
+
+### 2. Update the `WikiMemoryTestAccess` Interface
+
+To maintain your pristine testing environment, expose the new service.
+
+TypeScript
+
+```
+export interface WikiMemoryTestAccess {
+  embeddingService: EmbeddingService;
+  importExportService: ImportExportService;
+  ingestionService: IngestionService;
+  maintenanceService: MaintenanceService;
+  retrievalService: RetrievalService;
+  writeService: WriteService;
+  promptService: PromptService; // <-- NEW
+  entryRepo: EntryRepository;
+  metadataRepo: MetadataRepository;
+}
+```
+
+### 3. Update the `WikiMemory` Class Properties & Constructor
+
+Add the `promptService` to the class properties, initialize it using `options.config?.prompts`, and pass it into the `IngestionService` and `MaintenanceService`.
+
+TypeScript
+
+```
+export class WikiMemory {
+  // ... existing properties
+  private importExportService: ImportExportService;
+  private retrievalService: RetrievalService;
+  private writeService: WriteService;
+  private promptService: PromptService; // <-- NEW
+
+  constructor(db: SQLiteAdapter, options: WikiOptions) {
+    this.db = db;
+    this.options = options;
+    this.prefix = options.config?.tablePrefix || 'llm_wiki_';
+
+    // 1. Initialize PromptService with global overrides
+    this.promptService = new PromptService(options.config?.prompts); // <-- NEW
+
+    // ... existing repo initializations
+
+    // 2. Pass promptService to IngestionService
+    this.ingestionService = new IngestionService(
+      this.db,
+      this.prefix,
+      this.options,
+      this.entryRepo,
+      this.searchService,
+      this.jobManager,
+      this.embeddingService,
+      this.promptService // <-- NEW
+    );
+
+    // 3. Pass promptService to MaintenanceService
+    this.maintenanceService = new MaintenanceService(
+      this.db,
+      this.prefix,
+      this.options,
+      this.entryRepo,
+      this.taskRepo,
+      this.eventRepo,
+      this.metadataRepo,
+      this.searchService,
+      this.jobManager,
+      this.embeddingService,
+      this.promptService // <-- NEW
+    );
+
+    // ... existing service initializations
+  }
+  
+  get __testAccess(): WikiMemoryTestAccess {
+    // ... existing warning logic
+    return {
+      embeddingService: this.embeddingService,
+      importExportService: this.importExportService,
+      ingestionService: this.ingestionService,
+      maintenanceService: this.maintenanceService,
+      retrievalService: this.retrievalService,
+      writeService: this.writeService,
+      promptService: this.promptService, // <-- NEW
+      entryRepo: this.entryRepo,
+      metadataRepo: this.metadataRepo,
+    };
+  }
+  // ...
+```
+
+### 4. Update the Public Methods
+
+Finally, update the specific methods at the bottom of the file to accept the optional overrides and pass them through.
+
+TypeScript
+
+```
+  // Update runLibrarian to accept options
+  async runLibrarian(entityId: string, options?: { promptOverride?: string }): Promise<void> {
+    return this.maintenanceService.runLibrarian(entityId, options);
+  }
+
+  // Update runHeal to accept options
+  async runHeal(entityId: string, options?: { promptOverride?: string }): Promise<void> {
+    return this.maintenanceService.runHeal(entityId, options);
+  }
+
+  // Update ingestDocument params to accept promptOverride
+  async ingestDocument(
+    entityId: string,
+    params: {
+      sourceRef: string;
+      sourceHash: string;
+      documentChunk: string;
+      maxChunkLength?: number;
+      chunkOverlap?: number;
+      chunkConcurrency?: number;
+      promptOverride?: string; // <-- NEW
+    }
+  ): Promise<{ truncated: boolean; chunks: number }> {
+    return this.ingestionService.ingestDocument(entityId, params);
+  }
+```

--- a/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
+++ b/docs/superpowers/specs/2026-05-15-repository-phase-4-spec.md
@@ -161,15 +161,15 @@ export class WikiMemory {
 
 ---
 
-By isolating this into a `PromptService`, you also create a perfect testing boundary for prompt generation and leave the door open for future features, like dynamically calculating token limits before sending the prompt off.
+By isolating this into a `PromptService`, the design creates a clear testing boundary for prompt generation and leaves room for future enhancements such as dynamically calculating token limits before sending prompts.
 
-To ensure this aligns with your vision for apps like Curated Thoughts: do you want these prompts to remain static strings that the LLM reads alongside a JSON payload, or should the `PromptService` also take over the responsibility of injecting variables directly into the prompt templates (like `{{context}}` or `{{tasks}}`) before sending them to the LLM?
+For consistency with existing prompt hydration patterns, `PromptService` should own both responsibilities: injecting variables into prompt templates (for example `{{context}}` and `{{tasks}}`) and serializing structured payloads into the final prompt text sent to the LLM.
 
-This is the perfect approach for an SDK. By moving the JSON serialization and template hydration into the `PromptService`, your domain services (`IngestionService`, `MaintenanceService`) become completely ignorant of _how_ the LLM is instructed. They just hand over the raw data arrays, and the `PromptService` handles the formatting.
+This keeps domain services such as `IngestionService` and `MaintenanceService` independent of prompt-formatting details. They should provide raw domain data, while `PromptService` is responsible for template hydration, JSON serialization, and final prompt assembly.
 
-Since you already export `hydrateLibrarianPrompt` on the read-side (as seen in your [README.md](https://github.com/equationalapplications/expo-llm-wiki/blob/staging/packages/core/README.md)), utilizing the same `{{variable}}` syntax for background tasks creates a beautifully consistent developer experience.
+This approach also aligns background-task prompt construction with the existing `hydrateLibrarianPrompt` read-side pattern, preserving a consistent `{{variable}}` template convention across the SDK.
 
-Here is the exact implementation plan to build this out.
+The implementation plan below reflects this design.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:root": "tsup src/index.ts src/react/index.ts --format cjs,esm --dts --external react --external expo-sqlite --external @equationalapplications/core-llm-wiki --external @equationalapplications/expo-llm-wiki --external @equationalapplications/react-llm-wiki --out-dir dist --watch",
     "dev": "node -e \"const { spawn } = require('node:child_process'); const procs = [spawn('pnpm', ['run', 'dev:root'], { stdio: 'inherit', shell: true }), spawn('pnpm', ['run', 'dev:workspace'], { stdio: 'inherit', shell: true })]; let done = false; const stop = (signal) => { for (const p of procs) { if (!p.killed) p.kill(signal); } }; const finish = (code) => { if (done) return; done = true; stop('SIGTERM'); process.exit(code ?? 0); }; process.on('SIGINT', () => finish(130)); process.on('SIGTERM', () => finish(143)); for (const p of procs) p.on('exit', (code) => finish(code));\"",
     "integration-test": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run __tests__ --exclude \"**/financebench.test.ts\" --exclude \"**/scifact.test.ts\"",
-    "benchmark": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run __tests__/scifact.test.ts"
+    "benchmark": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run __tests__/scifact.test.ts __tests__/financebench.test.ts"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "build:core": "pnpm --filter @equationalapplications/core-llm-wiki build",
     "build:expo": "pnpm --filter @equationalapplications/expo-llm-wiki build",
     "build:react": "pnpm --filter @equationalapplications/react-llm-wiki build",
-    "test": "pnpm -r test",
+    "test": "pnpm -r --filter '!@equationalapplications/integration-llm-wiki' test",
     "typecheck": "pnpm -r typecheck",
     "dev:workspace": "pnpm -r --parallel dev",
     "dev:root": "tsup src/index.ts src/react/index.ts --format cjs,esm --dts --external react --external expo-sqlite --external @equationalapplications/core-llm-wiki --external @equationalapplications/expo-llm-wiki --external @equationalapplications/react-llm-wiki --out-dir dist --watch",
     "dev": "node -e \"const { spawn } = require('node:child_process'); const procs = [spawn('pnpm', ['run', 'dev:root'], { stdio: 'inherit', shell: true }), spawn('pnpm', ['run', 'dev:workspace'], { stdio: 'inherit', shell: true })]; let done = false; const stop = (signal) => { for (const p of procs) { if (!p.killed) p.kill(signal); } }; const finish = (code) => { if (done) return; done = true; stop('SIGTERM'); process.exit(code ?? 0); }; process.on('SIGINT', () => finish(130)); process.on('SIGTERM', () => finish(143)); for (const p of procs) p.on('exit', (code) => finish(code));\"",
-    "integration-test": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run",
+    "integration-test": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run __tests__ --exclude \"**/financebench.test.ts\" --exclude \"**/scifact.test.ts\"",
     "benchmark": "pnpm --filter @equationalapplications/integration-llm-wiki exec vitest run __tests__/scifact.test.ts"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -92,9 +92,72 @@ const wikiMemory = new WikiMemory(db, {
     staleInferredAfterDays: 60,        // default: 60 (days before runHeal downgrades inferred facts; null to disable)
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
+
+    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    prompts: {
+      ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
+      librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}`,
+      healSystemPrompt: `Fix the memory graph based on these candidates: {{healCandidates}}`,
+    },
   },
 });
 ```
+
+## Prompt Management & Overrides
+
+Core maintenance tasks (`ingestDocument`, `runLibrarian`, `runHeal`) use system prompts to instruct the LLM. You can customize these prompts using `{{mustache}}` style variables to inject context dynamically.
+
+### Global Overrides (Auto-Runs)
+
+If your application relies on `write()` to automatically maintain the memory graph in the background (via `autoLibrarianThreshold` and `autoHealThreshold`), configure custom prompts globally at instantiation. This ensures the internal `WriteService` uses your domain-specific instructions when it triggers an auto-run.
+
+```typescript
+const wikiMemory = new WikiMemory(db, {
+  llmProvider,
+  config: {
+    prompts: {
+      librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}`,
+    },
+  },
+});
+
+// WriteService uses the global prompt whenever autoLibrarianThreshold is hit
+await wikiMemory.write('user-123', { event_type: 'observation', summary: '...' });
+```
+
+Available `{{variables}}` per prompt type:
+
+| Prompt | Variables |
+|--------|-----------|
+| `ingestSystemPrompt` | `{{documentChunk}}` |
+| `librarianSystemPrompt` | `{{events}}`, `{{currentFacts}}` |
+| `healSystemPrompt` | `{{healCandidates}}`, `{{documentAnchors}}`, `{{allTasks}}`, `{{recentEvents}}` |
+
+When a template contains `{{variable}}` tags, the matching data is hydrated directly into `systemPrompt` and a short fixed string is used as `userPrompt`. When a template has no `{{}}` tags, the raw data is appended as `userPrompt` — backward compatible with plain-string overrides.
+
+### Runtime Overrides (Manual Execution)
+
+Pass `promptOverride` per-call for one-off instructions. **Runtime overrides apply only to that single call — they do not persist for future auto-runs triggered by `write()`.**
+
+```typescript
+// Override the base default AND global config for this single execution
+await wikiMemory.runLibrarian('user-123', {
+  promptOverride: `One-off extraction task:\n{{events}}`,
+});
+
+await wikiMemory.runHeal('user-123', {
+  promptOverride: `Domain-specific healing: {{healCandidates}}`,
+});
+
+await wikiMemory.ingestDocument('user-123', {
+  sourceRef: 'doc-1',
+  sourceHash: 'abc...',
+  documentChunk: content,
+  promptOverride: `Strict technical extraction: {{documentChunk}}`,
+});
+```
+
+> **Important:** If your app relies on `write()` auto-runs and needs custom prompts for those runs, use `config.prompts` at construction time. Runtime `promptOverride` values are never forwarded to `WriteService`-triggered internal runs.
 
 ## Retrieval Tuning
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -95,6 +95,8 @@ const wikiMemory = new WikiMemory(db, {
 
     // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
     // ingestSystemPrompt applies only to explicit ingestDocument() calls.
+    // ⚠ Overrides replace the entire default prompt, including the JSON output contract.
+    // See "JSON Output Contracts" in the Prompt Management & Overrides section below.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}`,
@@ -108,6 +110,14 @@ const wikiMemory = new WikiMemory(db, {
 
 Core maintenance tasks (`ingestDocument`, `runLibrarian`, `runHeal`) use system prompts to instruct the LLM. You can customize these prompts using `{{mustache}}` style variables to inject context dynamically.
 
+> **JSON Output Contracts:** Prompt overrides replace the *entire* default system prompt, including the JSON response schema the parser depends on. Your override **must** instruct the LLM to return raw JSON — no markdown. Required shapes:
+>
+> | Operation | Required JSON shape |
+> |-----------|-------------------|
+> | `ingestDocument` | `{ "facts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain\|inferred\|tentative" }] }` |
+> | `runLibrarian` | `{ "facts": [...], "tasks": [{ "description": "string", "priority": 0-10 }] }` |
+> | `runHeal` | `{ "downgraded": ["factId"], "deleted": ["factId"], "newFacts": [...] }` |
+
 ### Global Overrides (Auto-Runs)
 
 If your application relies on `write()` to automatically maintain the memory graph in the background (via `autoLibrarianThreshold` and `autoHealThreshold`), configure custom prompts globally at instantiation. This ensures the internal `WriteService` uses your domain-specific instructions when it triggers an auto-run.
@@ -117,7 +127,8 @@ const wikiMemory = new WikiMemory(db, {
   llmProvider,
   config: {
     prompts: {
-      librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}`,
+      // Override must include the JSON output contract — it replaces the entire default prompt.
+      librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}\n\nReturn ONLY a valid JSON object: { "facts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain|inferred|tentative" }], "tasks": [{ "description": "string", "priority": 0 }] }. No markdown.`,
     },
   },
 });
@@ -141,20 +152,21 @@ When a template contains `{{variable}}` tags, the matching data is hydrated dire
 Pass `promptOverride` per-call for one-off instructions. **Runtime overrides apply only to that single call — they do not persist for future auto-runs triggered by `write()`.**
 
 ```typescript
-// Override the base default AND global config for this single execution
+// Override the base default AND global config for this single execution.
+// Each override must include the JSON output contract (replaces the entire default prompt).
 await wikiMemory.runLibrarian('user-123', {
-  promptOverride: `One-off extraction task:\n{{events}}`,
+  promptOverride: `One-off extraction task:\n{{events}}\n\nReturn ONLY valid JSON: { "facts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain|inferred|tentative" }], "tasks": [{ "description": "string", "priority": 0 }] }. No markdown.`,
 });
 
 await wikiMemory.runHeal('user-123', {
-  promptOverride: `Domain-specific healing: {{healCandidates}}`,
+  promptOverride: `Domain-specific healing: {{healCandidates}}\n\nReturn ONLY valid JSON: { "downgraded": ["factId"], "deleted": ["factId"], "newFacts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain|inferred|tentative" }] }. No markdown.`,
 });
 
 await wikiMemory.ingestDocument('user-123', {
   sourceRef: 'doc-1',
   sourceHash: sha256(content),
   documentChunk: content,
-  promptOverride: `Strict technical extraction: {{documentChunk}}`,
+  promptOverride: `Strict technical extraction: {{documentChunk}}\n\nReturn ONLY valid JSON: { "facts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain|inferred|tentative" }] }. No markdown.`,
 });
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -93,7 +93,8 @@ const wikiMemory = new WikiMemory(db, {
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
 
-    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
+    // ingestSystemPrompt applies only to explicit ingestDocument() calls.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `You are an expert curator. Synthesize these thoughts:\n{{events}}\n\nCurrent Facts:\n{{currentFacts}}`,
@@ -151,7 +152,7 @@ await wikiMemory.runHeal('user-123', {
 
 await wikiMemory.ingestDocument('user-123', {
   sourceRef: 'doc-1',
-  sourceHash: 'abc...',
+  sourceHash: sha256(content),
   documentChunk: content,
   promptOverride: `Strict technical extraction: {{documentChunk}}`,
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -115,7 +115,7 @@ Core maintenance tasks (`ingestDocument`, `runLibrarian`, `runHeal`) use system 
 > | Operation | Required JSON shape |
 > |-----------|-------------------|
 > | `ingestDocument` | `{ "facts": [{ "title": "string", "body": "string", "tags": ["string"], "confidence": "certain\|inferred\|tentative" }] }` |
-> | `runLibrarian` | `{ "facts": [...], "tasks": [{ "description": "string", "priority": 0-10 }] }` |
+> | `runLibrarian` | `{ "facts": [...], "tasks": [{ "description": "string", "priority": 5 }] }` — `priority` is an integer 0–10 |
 > | `runHeal` | `{ "downgraded": ["factId"], "deleted": ["factId"], "newFacts": [...] }` |
 
 ### Global Overrides (Auto-Runs)

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -221,4 +221,35 @@ describe('WikiMemory — prompt override API', () => {
     const libCall = localCalls.find(c => c.systemPrompt === 'auto-run global prompt');
     expect(libCall).toBeDefined();
   });
+
+  it('global heal prompt reaches LLM when write() auto-triggers heal', async () => {
+    const db3 = createMockDb();
+    const localCalls: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const wikiWithGlobalHeal = new WikiMemory(db3, {
+      llmProvider: {
+        generateText: vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+          localCalls.push(params);
+          return JSON.stringify({ facts: [], tasks: [] });
+        }),
+      },
+      config: {
+        autoLibrarianThreshold: 1,
+        autoHealThreshold: 1,
+        prompts: {
+          librarianSystemPrompt: 'auto-run global librarian prompt',
+          healSystemPrompt: 'auto-run global heal prompt',
+        },
+      },
+    });
+    await wikiWithGlobalHeal.setup();
+
+    vi.spyOn((wikiWithGlobalHeal as any).eventRepo, 'count').mockResolvedValue(1);
+    vi.spyOn(wikiWithGlobalHeal.__testAccess.metadataRepo, 'getCheckpoint').mockResolvedValue({ memory: 0, heal: 0 });
+
+    await wikiWithGlobalHeal.write('e4', { event_type: 'observation', summary: 'trigger heal' });
+    await new Promise<void>((r) => setImmediate(r));
+
+    const healCall = localCalls.find(c => c.systemPrompt === 'auto-run global heal prompt');
+    expect(healCall).toBeDefined();
+  });
 });

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -191,4 +191,34 @@ describe('WikiMemory — prompt override API', () => {
     const libCall = capturedCalls.find(c => c.systemPrompt === 'global lib from config');
     expect(libCall).toBeDefined();
   });
+
+  it('global config.prompts reaches LLM when write() triggers auto-run', async () => {
+    const db2 = createMockDb();
+    const localCalls: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const wikiWithGlobal = new WikiMemory(db2, {
+      llmProvider: {
+        generateText: vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+          localCalls.push(params);
+          return JSON.stringify({ facts: [], tasks: [] });
+        }),
+      },
+      config: {
+        autoLibrarianThreshold: 1,
+        prompts: { librarianSystemPrompt: 'auto-run global prompt' },
+      },
+    });
+    await wikiWithGlobal.setup();
+
+    // Make eventRepo.count return 1 so write() crosses the threshold
+    vi.spyOn((wikiWithGlobal as any).eventRepo, 'count').mockResolvedValue(1);
+    vi.spyOn(wikiWithGlobal.__testAccess.metadataRepo, 'getCheckpoint').mockResolvedValue({ memory: 0 });
+
+    await wikiWithGlobal.write('e3', { event_type: 'observation', summary: 'trigger' });
+
+    // Drain the fire-and-forget maintenance task
+    await new Promise<void>((r) => setImmediate(r));
+
+    const libCall = localCalls.find(c => c.systemPrompt === 'auto-run global prompt');
+    expect(libCall).toBeDefined();
+  });
 });

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -114,3 +114,81 @@ describe('WikiMemory (Facade Layer)', () => {
     });
   });
 });
+
+describe('WikiMemory — prompt override API', () => {
+  let wiki: WikiMemory;
+  let capturedCalls: Array<{ systemPrompt: string; userPrompt: string }>;
+
+  beforeEach(async () => {
+    capturedCalls = [];
+    const db = createMockDb();
+    wiki = new WikiMemory(db, {
+      llmProvider: {
+        generateText: vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+          capturedCalls.push(params);
+          return JSON.stringify({ facts: [], tasks: [] });
+        }),
+      },
+    });
+    await wiki.setup();
+  });
+
+  it('runLibrarian accepts promptOverride and routes it to llmProvider', async () => {
+    await wiki.write('e1', { event_type: 'observation', summary: 'test event' });
+    await wiki.runLibrarian('e1', { promptOverride: 'custom lib prompt' });
+    const libCall = capturedCalls.find(c => c.systemPrompt === 'custom lib prompt');
+    expect(libCall).toBeDefined();
+  });
+
+  it('runHeal accepts promptOverride and routes it to llmProvider', async () => {
+    const healResponse = JSON.stringify({ downgraded: [], deleted: [], newFacts: [] });
+    (wiki as any).options.llmProvider.generateText = vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+      capturedCalls.push(params);
+      return healResponse;
+    });
+    await wiki.runHeal('e1', { promptOverride: 'custom heal prompt' });
+    const healCall = capturedCalls.find(c => c.systemPrompt === 'custom heal prompt');
+    expect(healCall).toBeDefined();
+  });
+
+  it('ingestDocument accepts promptOverride and routes it to llmProvider', async () => {
+    const ingestResponse = JSON.stringify({ facts: [] });
+    (wiki as any).options.llmProvider.generateText = vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+      capturedCalls.push(params);
+      return ingestResponse;
+    });
+    await wiki.ingestDocument('e1', {
+      sourceRef: 'doc://test',
+      sourceHash: 'c'.repeat(64),
+      documentChunk: 'some text',
+      promptOverride: 'custom ingest prompt',
+    });
+    expect(capturedCalls[0]?.systemPrompt).toBe('custom ingest prompt');
+  });
+
+  it('__testAccess exposes promptService', () => {
+    const access = wiki.__testAccess;
+    expect(access.promptService).toBeDefined();
+    expect(typeof access.promptService.buildLibrarianPrompt).toBe('function');
+  });
+
+  it('global config.prompts flows into PromptService', async () => {
+    const db2 = createMockDb();
+    const wikiWithGlobal = new WikiMemory(db2, {
+      llmProvider: {
+        generateText: vi.fn(async (params: { systemPrompt: string; userPrompt: string }) => {
+          capturedCalls.push(params);
+          return JSON.stringify({ facts: [], tasks: [] });
+        }),
+      },
+      config: {
+        prompts: { librarianSystemPrompt: 'global lib from config' },
+      },
+    });
+    await wikiWithGlobal.setup();
+    await wikiWithGlobal.write('e2', { event_type: 'observation', summary: 'x' });
+    await wikiWithGlobal.runLibrarian('e2');
+    const libCall = capturedCalls.find(c => c.systemPrompt === 'global lib from config');
+    expect(libCall).toBeDefined();
+  });
+});

--- a/packages/core/__tests__/ingest.test.ts
+++ b/packages/core/__tests__/ingest.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WikiMemory } from '../src/WikiMemory';
 import { IngestionService } from '../src/services/IngestionService';
 import { PromptService } from '../src/services/PromptService';
+import { INGEST_SYSTEM_PROMPT } from '../src/prompts';
 
 describe('IngestionService — PromptService injection', () => {
   const fakeLlmResponse = JSON.stringify({ facts: [{ title: 'T', body: 'B', tags: [], confidence: 'certain' }] });
@@ -52,7 +53,7 @@ describe('IngestionService — PromptService injection', () => {
 
     expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        systemPrompt: expect.any(String),
+        systemPrompt: INGEST_SYSTEM_PROMPT,
         userPrompt: expect.stringContaining('hello world'),
       })
     );

--- a/packages/core/__tests__/ingest.test.ts
+++ b/packages/core/__tests__/ingest.test.ts
@@ -1,5 +1,80 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WikiMemory } from '../src/WikiMemory';
+import { IngestionService } from '../src/services/IngestionService';
+import { PromptService } from '../src/services/PromptService';
+
+describe('IngestionService — PromptService injection', () => {
+  const fakeLlmResponse = JSON.stringify({ facts: [{ title: 'T', body: 'B', tags: [], confidence: 'certain' }] });
+  let mockDb: any;
+  let mockOptions: any;
+  let mockEntryRepo: any;
+  let mockSearchService: any;
+  let mockJobManager: any;
+  let mockEmbeddingService: any;
+
+  beforeEach(() => {
+    mockDb = {
+      withTransactionAsync: vi.fn(async (fn: (tx: any) => Promise<void>) => fn(mockDb)),
+      runAsync: vi.fn().mockResolvedValue({ changes: 0, lastInsertRowId: 0 }),
+      getAllAsync: vi.fn().mockResolvedValue([]),
+      getFirstAsync: vi.fn().mockResolvedValue(null),
+    };
+    mockOptions = { llmProvider: { generateText: vi.fn().mockResolvedValue(fakeLlmResponse) } };
+    mockEntryRepo = {
+      findIdsBySource: vi.fn().mockResolvedValue([]),
+      softDeleteBySource: vi.fn().mockResolvedValue(undefined),
+      upsert: vi.fn().mockResolvedValue(undefined),
+    };
+    mockSearchService = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      evictCache: vi.fn(),
+    };
+    mockJobManager = {
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+    };
+    mockEmbeddingService = {
+      embedFact: vi.fn().mockResolvedValue(true),
+      notifyEmbeddingPersisted: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it('passes systemPrompt and userPrompt from PromptService to llmProvider', async () => {
+    const promptService = new PromptService();
+    const svc = new IngestionService(mockDb, 'llm_wiki_', mockOptions, mockEntryRepo, mockSearchService, mockJobManager, mockEmbeddingService, promptService);
+
+    const sourceHash = 'a'.repeat(64);
+    await svc.ingestDocument('entity1', {
+      sourceRef: 'doc://test',
+      sourceHash,
+      documentChunk: 'hello world',
+    });
+
+    expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: expect.any(String),
+        userPrompt: expect.stringContaining('hello world'),
+      })
+    );
+  });
+
+  it('applies runtime promptOverride via PromptService', async () => {
+    const promptService = new PromptService();
+    const svc = new IngestionService(mockDb, 'llm_wiki_', mockOptions, mockEntryRepo, mockSearchService, mockJobManager, mockEmbeddingService, promptService);
+
+    const sourceHash = 'b'.repeat(64);
+    await svc.ingestDocument('entity1', {
+      sourceRef: 'doc://test2',
+      sourceHash,
+      documentChunk: 'chunk text',
+      promptOverride: 'custom system prompt',
+    });
+
+    expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: 'custom system prompt' })
+    );
+  });
+});
 
 type Row = Record<string, any>;
 

--- a/packages/core/__tests__/services/MaintenanceService.test.ts
+++ b/packages/core/__tests__/services/MaintenanceService.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MaintenanceService } from '../../src/services/MaintenanceService';
+import { PromptService } from '../../src/services/PromptService';
+import { LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT } from '../../src/prompts';
+
+describe('MaintenanceService — PromptService injection', () => {
+  let mockDb: any;
+  let mockOptions: any;
+  let mockEntryRepo: any;
+  let mockTaskRepo: any;
+  let mockEventRepo: any;
+  let mockMetadataRepo: any;
+  let mockSearchService: any;
+  let mockJobManager: any;
+  let mockEmbeddingService: any;
+
+  const librarianResponse = JSON.stringify({ facts: [], tasks: [] });
+  const healResponse = JSON.stringify({ downgraded: [], deleted: [], newFacts: [] });
+
+  beforeEach(() => {
+    mockDb = {
+      withTransactionAsync: vi.fn(async (fn: (tx: any) => Promise<void>) => fn(mockDb)),
+      runAsync: vi.fn().mockResolvedValue({ changes: 0, lastInsertRowId: 0 }),
+    };
+    mockOptions = { llmProvider: { generateText: vi.fn() } };
+    mockEntryRepo = {
+      findRecentByEntityId: vi.fn().mockResolvedValue([]),
+      findAllByEntityId: vi.fn().mockResolvedValue([]),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      markOrphaned: vi.fn().mockResolvedValue(undefined),
+      downgradeStaleInferred: vi.fn().mockResolvedValue(undefined),
+      downgradeByIds: vi.fn().mockResolvedValue(undefined),
+      softDeleteByIds: vi.fn().mockResolvedValue(undefined),
+    };
+    mockTaskRepo = {
+      findAllPending: vi.fn().mockResolvedValue([]),
+      upsert: vi.fn().mockResolvedValue(undefined),
+    };
+    mockEventRepo = {
+      getRecent: vi.fn().mockResolvedValue([]),
+    };
+    mockMetadataRepo = {};
+    mockSearchService = {
+      sync: vi.fn().mockResolvedValue(undefined),
+      evictCache: vi.fn(),
+    };
+    mockJobManager = {
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+    };
+    mockEmbeddingService = {
+      embedFact: vi.fn().mockResolvedValue(true),
+      notifyEmbeddingPersisted: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  function makeService(promptService: PromptService) {
+    return new MaintenanceService(
+      mockDb, 'llm_wiki_', mockOptions,
+      mockEntryRepo, mockTaskRepo, mockEventRepo, mockMetadataRepo,
+      mockSearchService, mockJobManager, mockEmbeddingService,
+      promptService,
+    );
+  }
+
+  describe('runLibrarian', () => {
+    it('uses base LIBRARIAN_SYSTEM_PROMPT by default', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(librarianResponse);
+      const svc = makeService(new PromptService());
+      await svc.runLibrarian('entity1');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: LIBRARIAN_SYSTEM_PROMPT })
+      );
+    });
+
+    it('uses global librarianSystemPrompt override', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(librarianResponse);
+      const svc = makeService(new PromptService({ librarianSystemPrompt: 'global lib' }));
+      await svc.runLibrarian('entity1');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'global lib' })
+      );
+    });
+
+    it('uses runtime promptOverride over global', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(librarianResponse);
+      const svc = makeService(new PromptService({ librarianSystemPrompt: 'global lib' }));
+      await svc.runLibrarian('entity1', { promptOverride: 'runtime lib' });
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'runtime lib' })
+      );
+    });
+  });
+
+  describe('runHeal', () => {
+    it('uses base HEAL_SYSTEM_PROMPT by default', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(healResponse);
+      const svc = makeService(new PromptService());
+      await svc.runHeal('entity1');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: HEAL_SYSTEM_PROMPT })
+      );
+    });
+
+    it('uses global healSystemPrompt override', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(healResponse);
+      const svc = makeService(new PromptService({ healSystemPrompt: 'global heal' }));
+      await svc.runHeal('entity1');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'global heal' })
+      );
+    });
+
+    it('uses runtime promptOverride over global', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(healResponse);
+      const svc = makeService(new PromptService({ healSystemPrompt: 'global heal' }));
+      await svc.runHeal('entity1', { promptOverride: 'runtime heal' });
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'runtime heal' })
+      );
+    });
+  });
+
+  describe('doRunLibrarian', () => {
+    it('accepts promptOverride and passes it to PromptService', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(librarianResponse);
+      const svc = makeService(new PromptService());
+      await svc.doRunLibrarian('entity1', 'custom lib override');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'custom lib override' })
+      );
+    });
+  });
+
+  describe('doRunHeal', () => {
+    it('accepts promptOverride and passes it to PromptService', async () => {
+      mockOptions.llmProvider.generateText.mockResolvedValue(healResponse);
+      const svc = makeService(new PromptService());
+      await svc.doRunHeal('entity1', 'custom heal override');
+      expect(mockOptions.llmProvider.generateText).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: 'custom heal override' })
+      );
+    });
+  });
+});

--- a/packages/core/__tests__/services/PromptService.test.ts
+++ b/packages/core/__tests__/services/PromptService.test.ts
@@ -118,5 +118,14 @@ describe('PromptService', () => {
       const { systemPrompt } = svc.buildHealPrompt([{ id: 'f1' }], [], [], [], template);
       expect(systemPrompt).toContain('{{unknown}}');
     });
+
+    it('hydrates {{recentEvents}} even without primary heal variables', () => {
+      const svc = new PromptService();
+      const events = [{ id: 'ev1', summary: 'recent thing' }];
+      const template = 'Recent: {{recentEvents}}';
+      const { systemPrompt, userPrompt } = svc.buildHealPrompt([], [], [], events, template);
+      expect(systemPrompt).toContain('"recent thing"');
+      expect(userPrompt).toBe('Please heal the memory graph.');
+    });
   });
 });

--- a/packages/core/__tests__/services/PromptService.test.ts
+++ b/packages/core/__tests__/services/PromptService.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { PromptService } from '../../src/services/PromptService';
+import {
+  INGEST_SYSTEM_PROMPT,
+  LIBRARIAN_SYSTEM_PROMPT,
+  HEAL_SYSTEM_PROMPT,
+} from '../../src/prompts';
+
+describe('PromptService', () => {
+  describe('buildIngestPrompt', () => {
+    it('falls back to base INGEST_SYSTEM_PROMPT when no overrides', () => {
+      const svc = new PromptService();
+      const { systemPrompt, userPrompt } = svc.buildIngestPrompt('hello doc');
+      expect(systemPrompt).toBe(INGEST_SYSTEM_PROMPT);
+      expect(userPrompt).toBe('Document Chunk:\nhello doc');
+    });
+
+    it('uses global override over base', () => {
+      const svc = new PromptService({ ingestSystemPrompt: 'global ingest' });
+      const { systemPrompt } = svc.buildIngestPrompt('chunk');
+      expect(systemPrompt).toBe('global ingest');
+    });
+
+    it('uses runtime override over global', () => {
+      const svc = new PromptService({ ingestSystemPrompt: 'global ingest' });
+      const { systemPrompt } = svc.buildIngestPrompt('chunk', 'runtime ingest');
+      expect(systemPrompt).toBe('runtime ingest');
+    });
+
+    it('hydrates {{documentChunk}} into systemPrompt when present', () => {
+      const svc = new PromptService();
+      const template = 'Process this: {{documentChunk}}';
+      const { systemPrompt, userPrompt } = svc.buildIngestPrompt('my content', template);
+      expect(systemPrompt).toBe('Process this: my content');
+      expect(userPrompt).toBe('Please extract the facts.');
+    });
+
+    it('leaves un-hydrated {{unknown}} tags intact', () => {
+      const svc = new PromptService();
+      const template = 'Data: {{documentChunk}} Extra: {{unknown}}';
+      const { systemPrompt } = svc.buildIngestPrompt('val', template);
+      expect(systemPrompt).toBe('Data: val Extra: {{unknown}}');
+    });
+  });
+
+  describe('buildLibrarianPrompt', () => {
+    it('falls back to base LIBRARIAN_SYSTEM_PROMPT', () => {
+      const svc = new PromptService();
+      const { systemPrompt, userPrompt } = svc.buildLibrarianPrompt([{ id: 'e1' }], [{ id: 'f1' }]);
+      expect(systemPrompt).toBe(LIBRARIAN_SYSTEM_PROMPT);
+      expect(userPrompt).toContain('Events:');
+      expect(userPrompt).toContain('Current Facts:');
+    });
+
+    it('uses global librarianSystemPrompt override', () => {
+      const svc = new PromptService({ librarianSystemPrompt: 'global lib' });
+      const { systemPrompt } = svc.buildLibrarianPrompt([], []);
+      expect(systemPrompt).toBe('global lib');
+    });
+
+    it('uses runtime override over global', () => {
+      const svc = new PromptService({ librarianSystemPrompt: 'global lib' });
+      const { systemPrompt } = svc.buildLibrarianPrompt([], [], 'runtime lib');
+      expect(systemPrompt).toBe('runtime lib');
+    });
+
+    it('hydrates {{events}} and {{currentFacts}} into systemPrompt', () => {
+      const svc = new PromptService();
+      const events = [{ id: 'e1', summary: 'did thing' }];
+      const facts = [{ id: 'f1', title: 'fact one' }];
+      const template = 'Events: {{events}} Facts: {{currentFacts}}';
+      const { systemPrompt, userPrompt } = svc.buildLibrarianPrompt(events, facts, template);
+      expect(systemPrompt).toContain('"did thing"');
+      expect(systemPrompt).toContain('"fact one"');
+      expect(userPrompt).toBe('Please synthesize the context.');
+    });
+  });
+
+  describe('buildHealPrompt', () => {
+    it('falls back to base HEAL_SYSTEM_PROMPT', () => {
+      const svc = new PromptService();
+      const { systemPrompt, userPrompt } = svc.buildHealPrompt([], [], [], []);
+      expect(systemPrompt).toBe(HEAL_SYSTEM_PROMPT);
+      expect(userPrompt).toContain('Heal Candidates:');
+    });
+
+    it('uses global healSystemPrompt override', () => {
+      const svc = new PromptService({ healSystemPrompt: 'global heal' });
+      const { systemPrompt } = svc.buildHealPrompt([], [], [], []);
+      expect(systemPrompt).toBe('global heal');
+    });
+
+    it('uses runtime override over global', () => {
+      const svc = new PromptService({ healSystemPrompt: 'global heal' });
+      const { systemPrompt } = svc.buildHealPrompt([], [], [], [], 'runtime heal');
+      expect(systemPrompt).toBe('runtime heal');
+    });
+
+    it('hydrates {{healCandidates}} into systemPrompt', () => {
+      const svc = new PromptService();
+      const candidates = [{ id: 'f1', title: 'stale fact' }];
+      const template = 'Candidates: {{healCandidates}}';
+      const { systemPrompt, userPrompt } = svc.buildHealPrompt(candidates, [], [], [], template);
+      expect(systemPrompt).toContain('"stale fact"');
+      expect(userPrompt).toBe('Please heal the memory graph.');
+    });
+  });
+});

--- a/packages/core/__tests__/services/PromptService.test.ts
+++ b/packages/core/__tests__/services/PromptService.test.ts
@@ -74,6 +74,13 @@ describe('PromptService', () => {
       expect(systemPrompt).toContain('"fact one"');
       expect(userPrompt).toBe('Please synthesize the context.');
     });
+
+    it('leaves un-hydrated {{unknown}} tags intact', () => {
+      const svc = new PromptService();
+      const template = 'Events: {{events}} Extra: {{unknown}}';
+      const { systemPrompt } = svc.buildLibrarianPrompt([{ id: 'e1' }], [], template);
+      expect(systemPrompt).toContain('{{unknown}}');
+    });
   });
 
   describe('buildHealPrompt', () => {
@@ -103,6 +110,13 @@ describe('PromptService', () => {
       const { systemPrompt, userPrompt } = svc.buildHealPrompt(candidates, [], [], [], template);
       expect(systemPrompt).toContain('"stale fact"');
       expect(userPrompt).toBe('Please heal the memory graph.');
+    });
+
+    it('leaves un-hydrated {{unknown}} tags intact', () => {
+      const svc = new PromptService();
+      const template = 'Candidates: {{healCandidates}} Extra: {{unknown}}';
+      const { systemPrompt } = svc.buildHealPrompt([{ id: 'f1' }], [], [], [], template);
+      expect(systemPrompt).toContain('{{unknown}}');
     });
   });
 });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -137,7 +137,8 @@ export class WikiMemory {
       : undefined;
 
     if (
-      processEnv?.NODE_ENV !== 'test' &&
+      processEnv !== undefined &&
+      processEnv.NODE_ENV !== 'test' &&
       !this.#testAccessNonTestEnvWarned
     ) {
       this.#testAccessNonTestEnvWarned = true;

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -23,6 +23,7 @@ import { ImportExportService } from './services/ImportExportService';
 import { EmbeddingService } from './services/EmbeddingService';
 import { RetrievalService } from './services/RetrievalService';
 import { WriteService } from './services/WriteService';
+import { PromptService } from './services/PromptService';
 
 export { WikiBusyError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER } from './types';
 
@@ -34,6 +35,7 @@ export interface WikiMemoryTestAccess {
   maintenanceService: MaintenanceService;
   retrievalService: RetrievalService;
   writeService: WriteService;
+  promptService: PromptService;
   entryRepo: EntryRepository;
   metadataRepo: MetadataRepository;
   jobManager: JobManager;
@@ -59,6 +61,7 @@ export class WikiMemory {
   private importExportService: ImportExportService;
   private retrievalService: RetrievalService;
   private writeService: WriteService;
+  private promptService: PromptService;
 
   constructor(db: SQLiteAdapter, options: WikiOptions) {
     this.db = db;
@@ -72,6 +75,7 @@ export class WikiMemory {
     this.embeddingService = new EmbeddingService(this.db, this.options, this.entryRepo, this.metadataRepo);
     this.searchService = new SearchService(this.entryRepo);
     this.jobManager = new JobManager(this.prefix);
+    this.promptService = new PromptService(options.config?.prompts);
     this.ingestionService = new IngestionService(
       this.db,
       this.prefix,
@@ -80,6 +84,7 @@ export class WikiMemory {
       this.searchService,
       this.jobManager,
       this.embeddingService,
+      this.promptService,
     );
     this.maintenanceService = new MaintenanceService(
       this.db,
@@ -92,6 +97,7 @@ export class WikiMemory {
       this.searchService,
       this.jobManager,
       this.embeddingService,
+      this.promptService,
     );
     this.importExportService = new ImportExportService(
       this.db,
@@ -144,6 +150,7 @@ export class WikiMemory {
       maintenanceService: this.maintenanceService,
       retrievalService: this.retrievalService,
       writeService: this.writeService,
+      promptService: this.promptService,
       entryRepo: this.entryRepo,
       metadataRepo: this.metadataRepo,
       jobManager: this.jobManager,
@@ -243,12 +250,22 @@ export class WikiMemory {
     return this.writeService.write(entityId, event);
   }
 
-  async runLibrarian(entityId: string): Promise<void> {
-    return this.maintenanceService.runLibrarian(entityId);
+  /**
+   * @param options.promptOverride - Applies only to this manual call. Does NOT affect
+   * WriteService-triggered auto-runs. For persistent prompt customization across auto-runs,
+   * set `options.config.prompts.librarianSystemPrompt` at WikiMemory construction time.
+   */
+  async runLibrarian(entityId: string, options?: { promptOverride?: string }): Promise<void> {
+    return this.maintenanceService.runLibrarian(entityId, options);
   }
 
-  async runHeal(entityId: string): Promise<void> {
-    return this.maintenanceService.runHeal(entityId);
+  /**
+   * @param options.promptOverride - Applies only to this manual call. Does NOT affect
+   * WriteService-triggered auto-runs. For persistent prompt customization across auto-runs,
+   * set `options.config.prompts.healSystemPrompt` at WikiMemory construction time.
+   */
+  async runHeal(entityId: string, options?: { promptOverride?: string }): Promise<void> {
+    return this.maintenanceService.runHeal(entityId, options);
   }
 
   async runReembed(entityId?: string, opts?: { force?: boolean; skipExisting?: boolean }): Promise<{ embedded: number; skipped: number; failed: number }> {
@@ -282,7 +299,23 @@ export class WikiMemory {
     return this.maintenanceService.forget(entityId, params);
   }
 
-  async ingestDocument(entityId: string, params: { sourceRef: string; sourceHash: string; documentChunk: string; maxChunkLength?: number; chunkOverlap?: number; chunkConcurrency?: number }): Promise<{ truncated: boolean; chunks: number }> {
+  /**
+   * @param params.promptOverride - Overrides the system prompt for this ingest call only.
+   * For persistent customization, set `options.config.prompts.ingestSystemPrompt` at
+   * WikiMemory construction time.
+   */
+  async ingestDocument(
+    entityId: string,
+    params: {
+      sourceRef: string;
+      sourceHash: string;
+      documentChunk: string;
+      maxChunkLength?: number;
+      chunkOverlap?: number;
+      chunkConcurrency?: number;
+      promptOverride?: string;
+    }
+  ): Promise<{ truncated: boolean; chunks: number }> {
     return this.ingestionService.ingestDocument(entityId, params);
   }
 }

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -36,6 +36,7 @@ export interface WikiMemoryTestAccess {
   writeService: WriteService;
   entryRepo: EntryRepository;
   metadataRepo: MetadataRepository;
+  jobManager: JobManager;
 }
 
 export class WikiMemory {
@@ -125,9 +126,12 @@ export class WikiMemory {
    * If `NODE_ENV` is not `"test"`, emits a single `console.warn` per instance (skipped when `process` is undefined).
    */
   get __testAccess(): WikiMemoryTestAccess {
+    const processEnv = typeof globalThis !== 'undefined'
+      ? (globalThis as any).process?.env
+      : undefined;
+
     if (
-      typeof process !== 'undefined' &&
-      process.env.NODE_ENV !== 'test' &&
+      processEnv?.NODE_ENV !== 'test' &&
       !this.#testAccessNonTestEnvWarned
     ) {
       this.#testAccessNonTestEnvWarned = true;
@@ -142,6 +146,7 @@ export class WikiMemory {
       writeService: this.writeService,
       entryRepo: this.entryRepo,
       metadataRepo: this.metadataRepo,
+      jobManager: this.jobManager,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export { formatContext } from './utils/formatContext';
 export { formatMemoryDump } from './utils/formatMemoryDump';
 export { parseEmbedding } from './utils/embedding';
 export * from './librarianPrompt';
+export { PromptService } from './services/PromptService';
 
 export function createWiki(db: SQLiteAdapter, options: WikiOptions): WikiMemory {
   return new WikiMemory(db, options);

--- a/packages/core/src/services/IngestionService.ts
+++ b/packages/core/src/services/IngestionService.ts
@@ -21,6 +21,7 @@ export class IngestionService {
     private embeddingService: EmbeddingService,
     promptService?: PromptService,
   ) {
+    // Fallback for direct instantiation outside WikiMemory facade (e.g. isolated tests).
     this.promptService = promptService ?? new PromptService(this.options.config?.prompts);
   }
 

--- a/packages/core/src/services/IngestionService.ts
+++ b/packages/core/src/services/IngestionService.ts
@@ -1,5 +1,4 @@
 import { chunkText, withConcurrency, validateFact, parseJsonResponse, normalizeSourceRef, normalizeSourceHash } from '../utils/pure';
-import { INGEST_SYSTEM_PROMPT } from '../prompts';
 import { generateId } from '../utils/ids';
 import type { WikiOptions, ExtractedFact, WikiFact } from '../types';
 import type { SQLiteAdapter } from '../types';
@@ -7,8 +6,11 @@ import type { EntryRepository } from '../repositories/EntryRepository';
 import type { SearchService } from './SearchService';
 import type { JobManager } from './JobManager';
 import type { EmbeddingService } from './EmbeddingService';
+import { PromptService } from './PromptService';
 
 export class IngestionService {
+  private promptService: PromptService;
+
   constructor(
     private db: SQLiteAdapter,
     private prefix: string,
@@ -17,7 +19,10 @@ export class IngestionService {
     private searchService: SearchService,
     private jobManager: JobManager,
     private embeddingService: EmbeddingService,
-  ) {}
+    promptService?: PromptService,
+  ) {
+    this.promptService = promptService ?? new PromptService();
+  }
 
   async ingestDocument(
     entityId: string,
@@ -28,6 +33,7 @@ export class IngestionService {
       maxChunkLength?: number;
       chunkOverlap?: number;
       chunkConcurrency?: number;
+      promptOverride?: string;
     }
   ): Promise<{ truncated: boolean; chunks: number }> {
     const sourceRef = normalizeSourceRef(params.sourceRef);
@@ -58,11 +64,8 @@ export class IngestionService {
 
       const chunkResults = await withConcurrency(
         chunks.map((chunk) => async () => {
-          const userPrompt = `Document Chunk:\n${chunk}`;
-          const responseText = await this.options.llmProvider.generateText({
-            systemPrompt: INGEST_SYSTEM_PROMPT,
-            userPrompt,
-          });
+          const { systemPrompt, userPrompt } = this.promptService.buildIngestPrompt(chunk, params.promptOverride);
+          const responseText = await this.options.llmProvider.generateText({ systemPrompt, userPrompt });
           const result = parseJsonResponse<{ facts: ExtractedFact[] }>(responseText);
           return (Array.isArray(result.facts) ? result.facts : [])
             .map(validateFact)

--- a/packages/core/src/services/IngestionService.ts
+++ b/packages/core/src/services/IngestionService.ts
@@ -21,7 +21,7 @@ export class IngestionService {
     private embeddingService: EmbeddingService,
     promptService?: PromptService,
   ) {
-    this.promptService = promptService ?? new PromptService();
+    this.promptService = promptService ?? new PromptService(this.options.config?.prompts);
   }
 
   async ingestDocument(

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -1,5 +1,5 @@
 import { parseJsonResponse, validateFact, validateTask, titleTokens, jaccardScore, normalizeSourceRef, normalizeSourceHash } from '../utils/pure';
-import type { PromptService } from './PromptService';
+import { PromptService } from './PromptService';
 import { generateId } from '../utils/ids';
 import { parseEmbedding } from '../utils/embedding';
 import { PrunePartialFailureError } from '../types';
@@ -18,6 +18,8 @@ const FUZZY_THRESHOLD = 0.5;
 const MIN_TOKENS_TO_QUALIFY = 3;
 
 export class MaintenanceService {
+  private promptService: PromptService;
+
   constructor(
     private db: SQLiteAdapter,
     private prefix: string,
@@ -29,8 +31,10 @@ export class MaintenanceService {
     private searchService: SearchService,
     private jobManager: JobManager,
     private embeddingService: EmbeddingService,
-    private promptService: PromptService,
-  ) {}
+    promptService?: PromptService,
+  ) {
+    this.promptService = promptService ?? new PromptService(this.options.config?.prompts);
+  }
 
   async runPrune(entityId: string, options?: { retainSoftDeletedFor?: number | null; retainEventsFor?: number | null; vacuum?: boolean }): Promise<{ entries: number; tasks: number; events: number }> {
     this.jobManager.acquireLock('prune', entityId);

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -1,5 +1,5 @@
 import { parseJsonResponse, validateFact, validateTask, titleTokens, jaccardScore, normalizeSourceRef, normalizeSourceHash } from '../utils/pure';
-import { LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT } from '../prompts';
+import type { PromptService } from './PromptService';
 import { generateId } from '../utils/ids';
 import { parseEmbedding } from '../utils/embedding';
 import { PrunePartialFailureError } from '../types';
@@ -29,6 +29,7 @@ export class MaintenanceService {
     private searchService: SearchService,
     private jobManager: JobManager,
     private embeddingService: EmbeddingService,
+    private promptService: PromptService,
   ) {}
 
   async runPrune(entityId: string, options?: { retainSoftDeletedFor?: number | null; retainEventsFor?: number | null; vacuum?: boolean }): Promise<{ entries: number; tasks: number; events: number }> {
@@ -111,19 +112,19 @@ export class MaintenanceService {
     }
   }
 
-  async runLibrarian(entityId: string): Promise<void> {
+  async runLibrarian(entityId: string, options?: { promptOverride?: string }): Promise<void> {
     this.jobManager.acquireLock('librarian', entityId);
     try {
-      await this.doRunLibrarian(entityId);
+      await this.doRunLibrarian(entityId, options?.promptOverride);
     } finally {
       this.jobManager.releaseLock('librarian', entityId);
     }
   }
 
-  async runHeal(entityId: string): Promise<void> {
+  async runHeal(entityId: string, options?: { promptOverride?: string }): Promise<void> {
     this.jobManager.acquireLock('heal', entityId);
     try {
-      await this.doRunHeal(entityId);
+      await this.doRunHeal(entityId, options?.promptOverride);
     } finally {
       this.jobManager.releaseLock('heal', entityId);
     }
@@ -272,7 +273,7 @@ export class MaintenanceService {
   }
 
   /** Core librarian pass (locks handled by {@link runLibrarian}). Package-internal orchestration hook. */
-  async doRunLibrarian(entityId: string): Promise<void> {
+  async doRunLibrarian(entityId: string, promptOverride?: string): Promise<void> {
     const events = await this.eventRepo.getRecent(entityId, 50);
     const currentFactsRows = await this.entryRepo.findRecentByEntityId(entityId, 100);
 
@@ -284,12 +285,13 @@ export class MaintenanceService {
       };
     });
 
-    const userPrompt = `Events:\n${JSON.stringify(events.reverse(), null, 2)}\n\nCurrent Facts:\n${JSON.stringify(currentFacts, null, 2)}`;
+    const { systemPrompt, userPrompt } = this.promptService.buildLibrarianPrompt(
+      events.reverse(),
+      currentFacts,
+      promptOverride,
+    );
 
-    const responseText = await this.options.llmProvider.generateText({
-      systemPrompt: LIBRARIAN_SYSTEM_PROMPT,
-      userPrompt,
-    });
+    const responseText = await this.options.llmProvider.generateText({ systemPrompt, userPrompt });
 
     const result = parseJsonResponse<{ facts: ExtractedFact[], tasks: ExtractedTask[] }>(responseText);
     const facts = Array.isArray(result.facts) ? result.facts : [];
@@ -354,7 +356,7 @@ export class MaintenanceService {
   }
 
   /** Core heal pass (locks handled by {@link runHeal}). Package-internal orchestration hook. */
-  async doRunHeal(entityId: string): Promise<void> {
+  async doRunHeal(entityId: string, promptOverride?: string): Promise<void> {
     const now = Date.now();
     const orphanAfterDays = this.options.config?.orphanAfterDays !== undefined ? this.options.config?.orphanAfterDays : 30;
     const staleInferredAfterDays = this.options.config?.staleInferredAfterDays !== undefined ? this.options.config?.staleInferredAfterDays : 60;
@@ -387,19 +389,20 @@ export class MaintenanceService {
       .filter(f => f.source_type === 'immutable_document')
       .map(({ id, title, source_ref }) => ({ id, title, source_ref }));
 
-    const userPrompt = `Heal Candidates:\n${JSON.stringify(healCandidates.map(f => {
+    const healCandidatesForPrompt = healCandidates.map(f => {
       const { embedding: _embedding, embedding_blob: _blob, ...rest } = f as WikiFact & { embedding?: unknown; embedding_blob?: unknown };
       return { ...rest, tags: typeof rest.tags === 'string' ? JSON.parse(rest.tags) : rest.tags };
-    }), null, 2)}
-\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}
-\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}
-\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}
-\nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`.`;
-
-    const responseText = await this.options.llmProvider.generateText({
-      systemPrompt: HEAL_SYSTEM_PROMPT,
-      userPrompt,
     });
+
+    const { systemPrompt, userPrompt } = this.promptService.buildHealPrompt(
+      healCandidatesForPrompt,
+      documentAnchors,
+      allTasks,
+      recentEvents,
+      promptOverride,
+    );
+
+    const responseText = await this.options.llmProvider.generateText({ systemPrompt, userPrompt });
 
     const result = parseJsonResponse<{ downgraded: string[], deleted: string[], newFacts: ExtractedFact[] }>(responseText);
 

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -33,6 +33,7 @@ export class MaintenanceService {
     private embeddingService: EmbeddingService,
     promptService?: PromptService,
   ) {
+    // Fallback for direct instantiation outside WikiMemory facade (e.g. isolated tests).
     this.promptService = promptService ?? new PromptService(this.options.config?.prompts);
   }
 

--- a/packages/core/src/services/PromptService.ts
+++ b/packages/core/src/services/PromptService.ts
@@ -57,7 +57,9 @@ export class PromptService {
     const template = runtimeOverride ?? this.globalOverrides?.healSystemPrompt ?? HEAL_SYSTEM_PROMPT;
     if (
       template.includes('{{healCandidates}}') ||
-      template.includes('{{documentAnchors}}')
+      template.includes('{{documentAnchors}}') ||
+      template.includes('{{allTasks}}') ||
+      template.includes('{{recentEvents}}')
     ) {
       return {
         systemPrompt: this.hydrate(template, { healCandidates, documentAnchors, allTasks, recentEvents }),

--- a/packages/core/src/services/PromptService.ts
+++ b/packages/core/src/services/PromptService.ts
@@ -7,7 +7,7 @@ export class PromptService {
   private hydrate(template: string, variables: Record<string, unknown>): string {
     return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_match, key) => {
       const value = variables[key];
-      if (value === undefined) return `{{${key}}}`;
+      if (value === undefined) return _match;
       return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
     });
   }
@@ -17,7 +17,7 @@ export class PromptService {
     runtimeOverride?: string,
   ): { systemPrompt: string; userPrompt: string } {
     const template = runtimeOverride ?? this.globalOverrides?.ingestSystemPrompt ?? INGEST_SYSTEM_PROMPT;
-    if (template.includes('{{documentChunk}}')) {
+    if (/\{\{\s*documentChunk\s*\}\}/.test(template)) {
       return {
         systemPrompt: this.hydrate(template, { documentChunk }),
         userPrompt: 'Please extract the facts.',
@@ -35,7 +35,7 @@ export class PromptService {
     runtimeOverride?: string,
   ): { systemPrompt: string; userPrompt: string } {
     const template = runtimeOverride ?? this.globalOverrides?.librarianSystemPrompt ?? LIBRARIAN_SYSTEM_PROMPT;
-    if (template.includes('{{events}}') || template.includes('{{currentFacts}}')) {
+    if (/\{\{\s*events\s*\}\}/.test(template) || /\{\{\s*currentFacts\s*\}\}/.test(template)) {
       return {
         systemPrompt: this.hydrate(template, { events, currentFacts }),
         userPrompt: 'Please synthesize the context.',
@@ -56,10 +56,10 @@ export class PromptService {
   ): { systemPrompt: string; userPrompt: string } {
     const template = runtimeOverride ?? this.globalOverrides?.healSystemPrompt ?? HEAL_SYSTEM_PROMPT;
     if (
-      template.includes('{{healCandidates}}') ||
-      template.includes('{{documentAnchors}}') ||
-      template.includes('{{allTasks}}') ||
-      template.includes('{{recentEvents}}')
+      /\{\{\s*healCandidates\s*\}\}/.test(template) ||
+      /\{\{\s*documentAnchors\s*\}\}/.test(template) ||
+      /\{\{\s*allTasks\s*\}\}/.test(template) ||
+      /\{\{\s*recentEvents\s*\}\}/.test(template)
     ) {
       return {
         systemPrompt: this.hydrate(template, { healCandidates, documentAnchors, allTasks, recentEvents }),

--- a/packages/core/src/services/PromptService.ts
+++ b/packages/core/src/services/PromptService.ts
@@ -1,0 +1,72 @@
+import { INGEST_SYSTEM_PROMPT, LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT } from '../prompts';
+import type { PromptOverrides } from '../types';
+
+export class PromptService {
+  constructor(private globalOverrides?: PromptOverrides) {}
+
+  private hydrate(template: string, variables: Record<string, unknown>): string {
+    return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_match, key) => {
+      const value = variables[key];
+      if (value === undefined) return `{{${key}}}`;
+      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    });
+  }
+
+  buildIngestPrompt(
+    documentChunk: string,
+    runtimeOverride?: string,
+  ): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.ingestSystemPrompt ?? INGEST_SYSTEM_PROMPT;
+    if (template.includes('{{documentChunk}}')) {
+      return {
+        systemPrompt: this.hydrate(template, { documentChunk }),
+        userPrompt: 'Please extract the facts.',
+      };
+    }
+    return {
+      systemPrompt: template,
+      userPrompt: `Document Chunk:\n${documentChunk}`,
+    };
+  }
+
+  buildLibrarianPrompt(
+    events: unknown[],
+    currentFacts: unknown[],
+    runtimeOverride?: string,
+  ): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.librarianSystemPrompt ?? LIBRARIAN_SYSTEM_PROMPT;
+    if (template.includes('{{events}}') || template.includes('{{currentFacts}}')) {
+      return {
+        systemPrompt: this.hydrate(template, { events, currentFacts }),
+        userPrompt: 'Please synthesize the context.',
+      };
+    }
+    return {
+      systemPrompt: template,
+      userPrompt: `Events:\n${JSON.stringify(events, null, 2)}\n\nCurrent Facts:\n${JSON.stringify(currentFacts, null, 2)}`,
+    };
+  }
+
+  buildHealPrompt(
+    healCandidates: unknown[],
+    documentAnchors: unknown[],
+    allTasks: unknown[],
+    recentEvents: unknown[],
+    runtimeOverride?: string,
+  ): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.healSystemPrompt ?? HEAL_SYSTEM_PROMPT;
+    if (
+      template.includes('{{healCandidates}}') ||
+      template.includes('{{documentAnchors}}')
+    ) {
+      return {
+        systemPrompt: this.hydrate(template, { healCandidates, documentAnchors, allTasks, recentEvents }),
+        userPrompt: 'Please heal the memory graph.',
+      };
+    }
+    return {
+      systemPrompt: template,
+      userPrompt: `Heal Candidates:\n${JSON.stringify(healCandidates, null, 2)}\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}`,
+    };
+  }
+}

--- a/packages/core/src/services/PromptService.ts
+++ b/packages/core/src/services/PromptService.ts
@@ -68,7 +68,7 @@ export class PromptService {
     }
     return {
       systemPrompt: template,
-      userPrompt: `Heal Candidates:\n${JSON.stringify(healCandidates, null, 2)}\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}`,
+      userPrompt: `Heal Candidates:\n${JSON.stringify(healCandidates, null, 2)}\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}\nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`.`,
     };
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,7 +47,7 @@ export interface WikiConfig {
    * Default: undefined (pure semantic when embed provided).
    */
   hybridWeight?: number;
-  /** Global prompt overrides applied to all LLM calls. Runtime overrides on individual method calls take precedence. */
+  /** Global prompt overrides for text generation calls (`ingestDocument`, `runLibrarian`, `runHeal`). Does not affect embedding generation. Runtime overrides on individual method calls take precedence. */
   prompts?: PromptOverrides;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,12 @@ export interface SQLiteAdapter {
   closeAsync(): Promise<void>;
 }
 
+export interface PromptOverrides {
+  ingestSystemPrompt?: string;
+  librarianSystemPrompt?: string;
+  healSystemPrompt?: string;
+}
+
 export interface WikiConfig {
   tablePrefix?: string;
   maxResults?: number;
@@ -41,6 +47,8 @@ export interface WikiConfig {
    * Default: undefined (pure semantic when embed provided).
    */
   hybridWeight?: number;
+  /** Global prompt overrides applied to all LLM calls. Runtime overrides on individual method calls take precedence. */
+  prompts?: PromptOverrides;
 }
 
 export interface ReadOptions {

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -117,6 +117,8 @@ const wiki = createWiki(db, {
 
     // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
     // ingestSystemPrompt applies only to explicit ingestDocument() calls.
+    // ⚠ Overrides replace the entire default prompt, including the JSON output contract.
+    // Your prompt must instruct the LLM to return the required JSON shape — see packages/core/README.md#prompt-management--overrides.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
@@ -179,7 +181,8 @@ await wiki.setup();
 // Auto-runs: uses config.prompts for background librarian/heal triggers
 await wiki.write('user-123', { event_type: 'observation', summary: '...' });
 
-// Manual executions: runtime promptOverride applies only to this single call
+// Manual executions: runtime promptOverride applies only to this single call.
+// Must include the JSON output contract — overrides replace the entire default prompt.
 await wiki.runLibrarian('user-123', {
   promptOverride: `Strict domain extraction task:\n{{events}}`,
 });

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -114,6 +114,13 @@ const wiki = createWiki(db, {
     staleInferredAfterDays: 60,        // default: 60 (days before runHeal downgrades inferred facts; null to disable)
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
+
+    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    prompts: {
+      ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
+      librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
+      healSystemPrompt: `Fix the memory graph based on these candidates: {{healCandidates}}`,
+    },
   },
 });
 ```
@@ -168,8 +175,20 @@ const wiki = createWiki(db, {
 // Initialize tables (call once on app startup)
 await wiki.setup();
 
-// Use wiki instance
+// Auto-runs: uses config.prompts for background librarian/heal triggers
 await wiki.write('user-123', { event_type: 'observation', summary: '...' });
+
+// Manual executions: runtime promptOverride applies only to this single call
+await wiki.runLibrarian('user-123', {
+  promptOverride: `Strict domain extraction task:\n{{events}}`,
+});
+
+await wiki.ingestDocument('user-123', {
+  sourceRef: 'doc-1',
+  sourceHash: 'abc...',
+  documentChunk: content,
+  promptOverride: `Focus strictly on technical APIs: {{documentChunk}}`,
+});
 ```
 
 ## With React
@@ -289,7 +308,7 @@ const memory = await wiki.read(
 // tasks capped at min(20 × entityCount, 200); events at min(10 × entityCount, 100)
 ```
 
-For Librarian prompt utilities (`hydrateLibrarianPrompt`, `validateLibrarianPromptTemplate`, etc.), see [`packages/core/README.md`](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#librarian-prompt-override-contract).
+For full details on `{{mustache}}` prompt templating and the strict distinction between global auto-runs and runtime overrides, see [Prompt Management & Overrides](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#prompt-management--overrides) in `@equationalapplications/core-llm-wiki`.
 
 ## License
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -115,7 +115,8 @@ const wiki = createWiki(db, {
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
 
-    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
+    // ingestSystemPrompt applies only to explicit ingestDocument() calls.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
@@ -185,7 +186,7 @@ await wiki.runLibrarian('user-123', {
 
 await wiki.ingestDocument('user-123', {
   sourceRef: 'doc-1',
-  sourceHash: 'abc...',
+  sourceHash: sha256(content),
   documentChunk: content,
   promptOverride: `Focus strictly on technical APIs: {{documentChunk}}`,
 });

--- a/packages/integration/__tests__/maintenance.test.ts
+++ b/packages/integration/__tests__/maintenance.test.ts
@@ -179,13 +179,13 @@ describe('maintenance — Scenario 4: prune lock blocks runLibrarian; different 
     await wiki.setup();
 
     // Inject prune lock to simulate runPrune in-flight
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:entity-a:prune');
+    wiki.__testAccess.jobManager.acquireLock('prune', 'entity-a');
 
     const err = await wiki.runLibrarian('entity-a').catch(e => e);
     expect(err).toBeInstanceOf(WikiBusyError);
     expect((err as WikiBusyError).operation).toBe('prune');
 
-    (wiki as any).activeMaintenanceJobs.delete('llm_wiki_:entity-a:prune');
+    wiki.__testAccess.jobManager.releaseLock('prune', 'entity-a');
   });
 
   it('runLibrarian on entity-b proceeds normally while entity-a prune lock is held', async () => {
@@ -193,12 +193,12 @@ describe('maintenance — Scenario 4: prune lock blocks runLibrarian; different 
     const wiki = new WikiMemory(db, { llmProvider: stubLLM() });
     await wiki.setup();
 
-    (wiki as any).activeMaintenanceJobs.add('llm_wiki_:entity-a:prune');
+    wiki.__testAccess.jobManager.acquireLock('prune', 'entity-a');
 
     // entity-b has no lock — resolves without error
     await expect(wiki.runLibrarian('entity-b')).resolves.toBeUndefined();
 
-    (wiki as any).activeMaintenanceJobs.delete('llm_wiki_:entity-a:prune');
+    wiki.__testAccess.jobManager.releaseLock('prune', 'entity-a');
   });
 });
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -113,6 +113,13 @@ const wiki = createWiki(adapter, {
     staleInferredAfterDays: 60,        // default: 60 (days before runHeal downgrades inferred facts; null to disable)
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
+
+    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    prompts: {
+      ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
+      librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
+      healSystemPrompt: `Fix the memory graph based on these candidates: {{healCandidates}}`,
+    },
   },
 });
 ```
@@ -243,6 +250,8 @@ const handleIngest = async (document: string) => {
       sourceRef: 'doc-readme',
       sourceHash,
       documentChunk: document,
+      // Optional: runtime override for this specific ingest call only
+      promptOverride: `Strict technical extraction. Focus on APIs: {{documentChunk}}`,
     });
   } catch (e) {
     console.error('Ingest failed:', e);
@@ -275,6 +284,11 @@ const { runLibrarian, runHeal, runReembed, runPrune, isPending, error, lastResul
 
 // Deduplicate and consolidate facts from events
 await runLibrarian('user-123');
+
+// Run with a one-off runtime override (applies only to this call, not future auto-runs)
+await runLibrarian('user-123', {
+  promptOverride: `One-off extraction task:\n{{events}}`,
+});
 
 // LLM-driven fact review: remove orphaned/stale facts, repair incorrect inferences
 await runHeal('user-123');
@@ -340,7 +354,7 @@ if (data) {
   console.log(data.metadata);   // { query, entityIds, tierWeights }
 }
 
-For Librarian prompt utilities, see [`packages/core/README.md`](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#librarian-prompt-override-contract).
+For full details on `{{mustache}}` prompt templating and the strict distinction between global auto-runs and runtime overrides, see [Prompt Management & Overrides](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#prompt-management--overrides) in `@equationalapplications/core-llm-wiki`.
 
 ## Component Lifecycle
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -114,7 +114,8 @@ const wiki = createWiki(adapter, {
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
 
-    // Global prompt overrides — applied to all background auto-runs triggered by write()
+    // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
+    // ingestSystemPrompt applies only to explicit ingestDocument() calls.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -116,6 +116,8 @@ const wiki = createWiki(adapter, {
 
     // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
     // ingestSystemPrompt applies only to explicit ingestDocument() calls.
+    // ⚠ Overrides replace the entire default prompt, including the JSON output contract.
+    // Your prompt must instruct the LLM to return the required JSON shape — see packages/core/README.md#prompt-management--overrides.
     prompts: {
       ingestSystemPrompt: `Extract core facts from this document: {{documentChunk}}`,
       librarianSystemPrompt: `Synthesize these thoughts into insights:\n{{events}}`,
@@ -251,7 +253,8 @@ const handleIngest = async (document: string) => {
       sourceRef: 'doc-readme',
       sourceHash,
       documentChunk: document,
-      // Optional: runtime override for this specific ingest call only
+      // Optional: runtime override for this specific ingest call only.
+      // Must include the JSON output contract — overrides replace the entire default prompt.
       promptOverride: `Strict technical extraction. Focus on APIs: {{documentChunk}}`,
     });
   } catch (e) {
@@ -286,7 +289,8 @@ const { runLibrarian, runHeal, runReembed, runPrune, isPending, error, lastResul
 // Deduplicate and consolidate facts from events
 await runLibrarian('user-123');
 
-// Run with a one-off runtime override (applies only to this call, not future auto-runs)
+// Run with a one-off runtime override (applies only to this call, not future auto-runs).
+// Must include the JSON output contract — overrides replace the entire default prompt.
 await runLibrarian('user-123', {
   promptOverride: `One-off extraction task:\n{{events}}`,
 });

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -480,6 +480,26 @@ describe('useWikiMaintenance', () => {
     expect(result.current.lastResult).toEqual({ operation: 'heal', result: undefined });
   });
 
+  it('runLibrarian forwards promptOverride to wiki.runLibrarian', async () => {
+    const { result } = renderHook(() => useWikiMaintenance(), { wrapper: wrapper(wiki) });
+
+    await act(async () => {
+      await result.current.runLibrarian('user-1', { promptOverride: 'custom lib prompt' });
+    });
+
+    expect(wiki.runLibrarian).toHaveBeenCalledWith('user-1', { promptOverride: 'custom lib prompt' });
+  });
+
+  it('runHeal forwards promptOverride to wiki.runHeal', async () => {
+    const { result } = renderHook(() => useWikiMaintenance(), { wrapper: wrapper(wiki) });
+
+    await act(async () => {
+      await result.current.runHeal('user-1', { promptOverride: 'custom heal prompt' });
+    });
+
+    expect(wiki.runHeal).toHaveBeenCalledWith('user-1', { promptOverride: 'custom heal prompt' });
+  });
+
   it('runPrune returns pruned counts and sets lastResult', async () => {
     wiki.runPrune.mockResolvedValue({ entries: 3, tasks: 1, events: 2 });
     const { result } = renderHook(() => useWikiMaintenance(), { wrapper: wrapper(wiki) });
@@ -576,6 +596,27 @@ describe('useWikiIngest', () => {
     expect(ingestResult).toEqual({ truncated: false, chunks: 3 });
     expect(result.current.lastResult).toEqual({ truncated: false, chunks: 3 });
     expect(result.current.isPending).toBe(false);
+  });
+
+  it('forwards promptOverride to wiki.ingestDocument', async () => {
+    wiki.ingestDocument.mockResolvedValue({ truncated: false, chunks: 3 });
+    const { result } = renderHook(() => useWikiIngest(), { wrapper: wrapper(wiki) });
+
+    await act(async () => {
+      await result.current.execute('user-1', {
+        sourceRef: 'doc1',
+        sourceHash: 'abc',
+        documentChunk: 'hello world',
+        promptOverride: 'custom ingest prompt',
+      });
+    });
+
+    expect(wiki.ingestDocument).toHaveBeenCalledWith('user-1', {
+      sourceRef: 'doc1',
+      sourceHash: 'abc',
+      documentChunk: 'hello world',
+      promptOverride: 'custom ingest prompt',
+    });
   });
 
   it('sets error state and re-throws when ingestDocument rejects', async () => {

--- a/packages/react/src/useWikiIngest.ts
+++ b/packages/react/src/useWikiIngest.ts
@@ -6,6 +6,7 @@ interface IngestParams {
   sourceHash: string;
   documentChunk: string;
   maxChunkLength?: number;
+  promptOverride?: string;
 }
 
 type IngestResult = { truncated: boolean; chunks: number };

--- a/packages/react/src/useWikiMaintenance.ts
+++ b/packages/react/src/useWikiMaintenance.ts
@@ -22,7 +22,7 @@ export function useWikiMaintenance() {
     setIsPending(true);
     setLastResult(null);
     try {
-      await wikiRef.current.runLibrarian(entityId, options);
+      await (options ? wikiRef.current.runLibrarian(entityId, options) : wikiRef.current.runLibrarian(entityId));
       setLastResult({ operation: 'librarian', result: undefined });
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
@@ -40,7 +40,7 @@ export function useWikiMaintenance() {
     setIsPending(true);
     setLastResult(null);
     try {
-      await wikiRef.current.runHeal(entityId, options);
+      await (options ? wikiRef.current.runHeal(entityId, options) : wikiRef.current.runHeal(entityId));
       setLastResult({ operation: 'heal', result: undefined });
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));

--- a/packages/react/src/useWikiMaintenance.ts
+++ b/packages/react/src/useWikiMaintenance.ts
@@ -16,13 +16,13 @@ export function useWikiMaintenance() {
   // Counter so any overlapping maintenance operation keeps isPending=true until all complete
   const pendingCount = useRef(0);
 
-  const runLibrarian = useCallback(async (entityId: string): Promise<void> => {
+  const runLibrarian = useCallback(async (entityId: string, options?: { promptOverride?: string }): Promise<void> => {
     setError(null);
     pendingCount.current += 1;
     setIsPending(true);
     setLastResult(null);
     try {
-      await wikiRef.current.runLibrarian(entityId);
+      await wikiRef.current.runLibrarian(entityId, options);
       setLastResult({ operation: 'librarian', result: undefined });
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));
@@ -34,13 +34,13 @@ export function useWikiMaintenance() {
     }
   }, []);
 
-  const runHeal = useCallback(async (entityId: string): Promise<void> => {
+  const runHeal = useCallback(async (entityId: string, options?: { promptOverride?: string }): Promise<void> => {
     setError(null);
     pendingCount.current += 1;
     setIsPending(true);
     setLastResult(null);
     try {
-      await wikiRef.current.runHeal(entityId);
+      await wikiRef.current.runHeal(entityId, options);
       setLastResult({ operation: 'heal', result: undefined });
     } catch (e) {
       const err = e instanceof Error ? e : new Error(String(e));


### PR DESCRIPTION
## Summary

- Adds `PromptService` with three-tier override resolution (runtime > global config > base constant) and `{{mustache}}` variable hydration for `ingestDocument`, `runLibrarian`, and `runHeal`
- Adds `PromptOverrides` interface and `WikiConfig.prompts` field for global prompt customization at `WikiMemory` construction time
- Updates `IngestionService`, `MaintenanceService`, and `WikiMemory` public API to accept optional `promptOverride` per call; runtime overrides are scoped to that single call and never flow through `WriteService` auto-runs
- Exposes `promptService` via `WikiMemoryTestAccess.__testAccess`
- Adds comprehensive docs across all four READMEs: new "Prompt Management & Overrides" section in `packages/core`, config examples with `prompts` block in all packages, and explicit global-vs-runtime distinction throughout

## Implementation structure

Four sequential PRs implemented in isolated worktrees, merged into this branch:

1. **Foundation** — `PromptService` class, `PromptOverrides` type, `WikiConfig.prompts`
2. **IngestionService** — accepts `PromptService`, `ingestDocument` gets `promptOverride` param
3. **MaintenanceService** — accepts `PromptService`, `runLibrarian`/`runHeal` get `options.promptOverride`
4. **WikiMemory facade** — wires `PromptService` from `config.prompts`, updates public API, docs

## Test plan

- [ ] `packages/core`: 475 tests pass — `npx vitest run` from `packages/core`
- [ ] TypeScript: zero errors — `npx tsc --noEmit` from `packages/core`
- [ ] `PromptService` unit tests: override precedence, mustache hydration, unknown-tag preservation for all three prompt types
- [ ] `MaintenanceService` unit tests: base/global/runtime override for `runLibrarian` and `runHeal`
- [ ] `WikiMemory` integration tests: `promptOverride` routed through to `llmProvider.generateText`, `config.prompts` flows into `PromptService`, `__testAccess.promptService` exposed
- [ ] Manual smoke: construct `WikiMemory` with `config.prompts.librarianSystemPrompt`, call `write()` past threshold, confirm custom prompt reaches LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)