### PR TITLE
feat: transactional outbox pattern — prisma-outbox package + core consumer API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
           publish_if_needed "./packages/core/package.json" pnpm --filter "./packages/core" publish --no-git-checks --access public
           publish_if_needed "./packages/react/package.json" pnpm --filter "./packages/react" publish --no-git-checks --access public
           publish_if_needed "./packages/expo/package.json" pnpm --filter "./packages/expo" publish --no-git-checks --access public
+          publish_if_needed "./packages/prisma-outbox/package.json" pnpm --filter "./packages/prisma-outbox" publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .codegraph/
 .worktrees/
 docs/superpowers/plans
+*.tsbuildinfo

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,11 +11,11 @@
       "npmPublish": false
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
+      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
     }],
     "@semantic-release/github",
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json"],
+      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }]
   ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=expo)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=core)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)
+
 ## Persistent, episodic memory for AI Agents.
 
 expo-llm-wiki is a cross-platform TypeScript and SQLite library for long-term LLM memory. It bridges the gap between raw conversation logs and a structured knowledge base, supporting background fact extraction, semantic embedding search, and memory pruning.

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -367,13 +367,16 @@ const worker = new PrismaOutboxWorker({
     if (event.table_name.endsWith('entries')) {
       switch (event.operation) {
         case 'INSERT':
-          await tx.myFact.create({
-            data: {
+          // mapEvent must be idempotent; use upsert so retries after ack failure are safe.
+          await tx.myFact.upsert({
+            where: { id: event.record_id },
+            create: {
               id: event.record_id,
               ownerId: event.entity_id,
               title: event.payload.title,
               body: event.payload.body,
             },
+            update: { title: event.payload.title, body: event.payload.body },
           });
           break;
         case 'UPDATE':

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -246,38 +246,45 @@ expo-llm-wiki/
 // packages/prisma-outbox/src/types.ts
 
 import type { WikiMemory, WikiOutboxEvent } from '@equationalapplications/core-llm-wiki';
-import type { PrismaClient, Prisma } from '@prisma/client';
 
-export interface PrismaOutboxConfig {
+/** Minimal Prisma client shape required by the worker — avoids depending on generated types. */
+export interface PrismaLike<TTx> {
+  $transaction: (fn: (tx: TTx) => Promise<void>) => Promise<unknown>;
+}
+
+export interface PrismaOutboxConfig<TTx = unknown> {
   wikiMemory: WikiMemory;
-  prisma: PrismaClient;
+  prisma: PrismaLike<TTx>;
   /**
    * Maps one outbox event to Prisma operations executed inside a Prisma transaction.
-   * Uses Prisma.TransactionClient — safer than the manual Omit<PrismaClient, ...> form
-   * and automatically tracks new non-transactional properties added by Prisma.
+   * `tx` is the Prisma transaction client passed by `prisma.$transaction`.
    */
-  mapEvent: (event: WikiOutboxEvent, tx: Prisma.TransactionClient) => Promise<void>;
+  mapEvent: (event: WikiOutboxEvent, tx: TTx) => Promise<void>;
   /** Max events fetched per poll cycle. Default: 100 */
   batchSize?: number;
   /** Milliseconds between poll cycles. Default: 5000 */
   pollIntervalMs?: number;
   /** Called when an event fails; return true to skip and continue, false/undefined to halt. */
   onError?: (error: Error, event: WikiOutboxEvent) => boolean | undefined;
+  /** Called when a worker-level error occurs (e.g. SQLite read/ack failure). Not called for per-event errors handled by onError. */
+  onWorkerError?: (error: Error) => void;
 }
 ```
 
 ```typescript
 // packages/prisma-outbox/src/PrismaOutboxWorker.ts
 
-export class PrismaOutboxWorker {
+export class PrismaOutboxWorker<TTx = unknown> {
   private timer?: ReturnType<typeof setInterval>;
+  private backlogTimer?: ReturnType<typeof setTimeout>;
+  private running = false;
 
-  constructor(private config: PrismaOutboxConfig) {}
+  constructor(private config: PrismaOutboxConfig<TTx>) {}
 
   start(): void {
     if (this.timer) return;
     this.timer = setInterval(
-      () => void this.syncBatch(),
+      () => { this.syncBatch().catch(err => this.#workerError(err)); },
       this.config.pollIntervalMs ?? 5000
     );
   }
@@ -285,32 +292,53 @@ export class PrismaOutboxWorker {
   stop(): void {
     clearInterval(this.timer);
     this.timer = undefined;
+    clearTimeout(this.backlogTimer);
+    this.backlogTimer = undefined;
   }
 
   async syncBatch(): Promise<void> {
-    const batchSize = this.config.batchSize ?? 100;
-    const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
-    if (events.length === 0) return;
+    if (this.running) return;
+    this.running = true;
+    try {
+      const batchSize = this.config.batchSize ?? 100;
+      const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
+      if (events.length === 0) return;
 
-    const processedIds: string[] = [];
+      const processedIds: string[] = [];
+      let halted = false;
 
-    for (const event of events) {
-      try {
-        await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
-        processedIds.push(event.id);
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        const skip = this.config.onError?.(error, event);
-        if (!skip) break; // halt to preserve ordering
+      for (const event of events) {
+        try {
+          await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
+          processedIds.push(event.id);
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          let skip = false;
+          try {
+            skip = this.config.onError?.(error, event) ?? false;
+          } catch {
+            halted = true;
+            break;
+          }
+          if (skip) {
+            processedIds.push(event.id);
+          } else {
+            halted = true;
+            break; // halt to preserve ordering
+          }
+        }
       }
-    }
 
-    await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
+      await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
 
-    // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
-    // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
-    if (events.length === batchSize) {
-      setTimeout(() => void this.syncBatch(), 0);
+      // Backlog optimization: full batch without halt means more events likely waiting.
+      // Only schedule when worker is still running (stop() not called) to avoid post-stop leaks.
+      if (!halted && events.length === batchSize && this.timer !== undefined) {
+        clearTimeout(this.backlogTimer);
+        this.backlogTimer = setTimeout(() => { this.syncBatch().catch(err => this.#workerError(err)); }, 0);
+      }
+    } finally {
+      this.running = false;
     }
   }
 }

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -1,0 +1,415 @@
+# Spec: Transactional Outbox Pattern
+
+**Date:** 2026-05-16
+**Status:** Core implemented; prisma-outbox package pending
+
+---
+
+## Problem
+
+Developers using `expo-llm-wiki` need to synchronize the local SQLite memory graph with external systems (PostgreSQL via Prisma, search indexes, analytics pipelines) without risking dual-write failures. There is no current mechanism to safely observe mutations after they commit.
+
+---
+
+## Solution
+
+Implement a Transactional Outbox pattern inside the core library. Every mutation writes an event to an internal `llm_wiki_outbox` SQLite table **within the same `withTransactionAsync` call** as the domain write. External consumers poll this table and delete rows after successful processing.
+
+---
+
+## Current Implementation State
+
+`OutboxRepository` already exists at `packages/core/src/repositories/OutboxRepository.ts` with:
+
+- `push(params, tx)` — inserts a row atomically within the caller's transaction
+- `fetchPending(limit)` — reads pending rows ordered by `created_at ASC`
+- `acknowledge(ids)` — deletes processed rows by ID
+
+`EntryRepository` and `TaskRepository` both instantiate `OutboxRepository` and call `outboxRepo.push()` unconditionally on every mutation. **There is no `enableOutbox` flag today** — writes are always-on.
+
+`WikiMemory` does not yet expose `getUnprocessedOutboxEvents` or `markOutboxEventsProcessed`. Exposing them is an explicit implementation gap (see [Consumer API](#consumer-api-on-wikimemory) below).
+
+---
+
+## Design Decisions
+
+### Outbox lives inside core SQLite (not a separate store)
+
+The outbox table lives in the same SQLite database as `facts`, `tasks`, and `events`. This gives:
+
+- **100% atomicity:** if the domain write rolls back, the outbox event is aborted with it — no divergence possible
+- **Zero new dependencies:** no message broker, no network, no additional processes
+- **Strict total ordering:** a single SQLite table guarantees sequential event IDs and `created_at` timestamps
+
+### Opt-in via `WikiConfig.enableOutbox` (implemented)
+
+The feature is off by default. The gate lives in `OutboxRepository.push()` — it returns early when `enableOutbox` is `false`. This is the single chokepoint for all 14 call sites across `EntryRepository` and `TaskRepository`, so no per-call-site wrapping is needed.
+
+`WikiMemory` passes `!!options.config?.enableOutbox` into `OutboxRepository`'s constructor. `EntryRepository` and `TaskRepository` call sites are unchanged.
+
+### Schema always created, writes conditional (after gating is added)
+
+`setup()` always runs `CREATE TABLE IF NOT EXISTS llm_wiki_outbox`. An empty SQLite table costs ~bytes. Toggling `enableOutbox: true` after initial deployment requires no migration — the table is already present.
+
+### Delete on process (not update `processed_at`)
+
+`OutboxRepository.acknowledge()` issues a `DELETE` rather than setting `processed_at`. The outbox is a delivery mechanism, not a historical ledger — that role belongs to the `events` table already managed by `runPrune`. Deleting processed rows keeps the outbox at ~zero bytes when the consumer is running.
+
+### Consumer APIs work even when `enableOutbox: false`
+
+If a developer disables the outbox after a period of use, `getUnprocessedOutboxEvents` and `markOutboxEventsProcessed` continue to function so the background worker can drain the remaining queue gracefully before going idle.
+
+### Prisma integration lives in a separate package
+
+Core stays zero-dependency. The Prisma adapter ships as `@equationalapplications/prisma-outbox` with `@prisma/client` declared as a **peer dependency** (not a bundled dependency) so the adapter uses the host app's generated Prisma schema.
+
+### Mapping via callback, not fixed schema
+
+The adapter does not assume Prisma model names. Developers supply a mapping function that receives a `WikiOutboxEvent` and executes arbitrary Prisma operations. This decouples the library from any specific Prisma schema shape.
+
+---
+
+## Event Schema
+
+The actual SQLite outbox table schema (defined in `packages/core/src/db/schema.ts` and `migrations.ts`) is:
+
+```sql
+CREATE TABLE IF NOT EXISTS ${prefix}outbox (
+  id         TEXT    PRIMARY KEY,
+  entity_id  TEXT    NOT NULL,
+  table_name TEXT    NOT NULL,   -- e.g. 'llm_wiki_entries', 'llm_wiki_tasks'
+  record_id  TEXT    NOT NULL,   -- primary key of the mutated row
+  operation  TEXT    NOT NULL,   -- 'INSERT' | 'UPDATE' | 'DELETE'
+  payload    TEXT    NOT NULL,   -- JSON-serialized domain object
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ${prefix}outbox_entity_id_created_at
+  ON ${prefix}outbox (entity_id, created_at);
+```
+
+Note: `processed_at` column is **not** included — rows are deleted on processing.
+
+The corresponding TypeScript type exposed to consumers:
+
+```typescript
+// packages/core/src/outbox/types.ts
+
+export interface WikiOutboxEvent<T = unknown> {
+  id: string;           // prefixed ID, e.g. 'out_abc123'
+  entity_id: string;    // namespace / user identifier
+  table_name: string;   // which table was mutated
+  record_id: string;    // primary key of the mutated row
+  operation: 'INSERT' | 'UPDATE' | 'DELETE';
+  payload: T;           // deserialized domain object
+  created_at: number;   // epoch ms
+}
+```
+
+---
+
+## `WikiConfig` Extension
+
+```typescript
+export interface WikiConfig {
+  // ... existing fields ...
+
+  /**
+   * When true, every mutation appends an event to the internal outbox table.
+   * The table is always created; this flag only controls whether writes occur.
+   *
+   * NOTE: the current implementation writes unconditionally. Adding this flag
+   * requires adding guards at OutboxRepository.push() call sites in
+   * EntryRepository and TaskRepository.
+   *
+   * @default false
+   */
+  enableOutbox?: boolean;
+}
+```
+
+---
+
+## Internal Write Pattern
+
+Every domain mutation in `EntryRepository` and `TaskRepository` calls `outboxRepo.push()` unconditionally. The gate lives inside `OutboxRepository.push()` — it returns early when `enableOutbox` is false:
+
+```typescript
+// OutboxRepository.push() — single gate for all 14 call sites
+async push(params, tx): Promise<void> {
+  if (!this.enableOutbox) return;
+  // ... INSERT INTO outbox ...
+}
+```
+
+Call sites in the repositories are unchanged:
+
+```typescript
+await this.db.withTransactionAsync(async (tx) => {
+  // Domain write
+  await tx.runAsync(`INSERT INTO ${prefix}entries (...) VALUES (...)`, [...]);
+
+  // Outbox — no-op when enableOutbox: false
+  await this.outbox.push(
+    { entityId, tableName: 'entries', recordId: id, operation: 'INSERT', payload: fact },
+    tx,
+  );
+});
+```
+
+---
+
+## Consumer API on `WikiMemory`
+
+**Implementation gap:** `WikiMemory` does not currently expose these methods. They must be added as thin delegations to `OutboxRepository`.
+
+```typescript
+export interface WikiMemory {
+  // ... existing methods ...
+
+  /**
+   * Returns up to `limit` unprocessed outbox events, oldest first.
+   * Delegates to OutboxRepository.fetchPending().
+   * Works regardless of enableOutbox value (allows draining after disabling).
+   */
+  getUnprocessedOutboxEvents(limit?: number): Promise<WikiOutboxEvent[]>;
+
+  /**
+   * Deletes the given event IDs from the outbox table.
+   * Delegates to OutboxRepository.acknowledge().
+   * Call after successfully committing events to the external system.
+   */
+  markOutboxEventsProcessed(eventIds: string[]): Promise<void>;
+}
+```
+
+### Implementation (additions to `WikiMemory.ts`)
+
+```typescript
+async getUnprocessedOutboxEvents(limit = 100): Promise<WikiOutboxEvent[]> {
+  const rows = await this.outboxRepo.fetchPending(limit);
+  return rows.map(row => {
+    let payload: unknown = null;
+    try {
+      payload = JSON.parse(row.payload);
+    } catch {
+      // corrupted row — surface null payload rather than poisoning the batch
+    }
+    return { ...row, payload } as WikiOutboxEvent;
+  });
+}
+
+async markOutboxEventsProcessed(eventIds: string[]): Promise<void> {
+  await this.outboxRepo.acknowledge(eventIds);
+}
+```
+
+Defensive JSON parse: a single malformed row returns `payload: null` rather than throwing and halting the entire batch. `outboxRepo` is already a private field — no structural changes needed, only the two method additions.
+
+---
+
+## Prisma Adapter Package
+
+### Monorepo location
+
+```
+expo-llm-wiki/
+└── packages/
+    ├── core/
+    ├── expo/
+    ├── react/
+    └── prisma-outbox/          # new
+        ├── package.json
+        ├── tsup.config.ts
+        └── src/
+            ├── index.ts
+            ├── PrismaOutboxWorker.ts
+            └── types.ts
+```
+
+### `package.json` (key fields)
+
+```json
+{
+  "name": "@equationalapplications/prisma-outbox",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@equationalapplications/core-llm-wiki": "workspace:*",
+    "@prisma/client": "^5.0.0 || ^6.0.0"
+  },
+  "devDependencies": {
+    "@prisma/client": "^5.0.0",
+    "prisma": "^5.0.0"
+  }
+}
+```
+
+### Adapter API
+
+```typescript
+// packages/prisma-outbox/src/types.ts
+
+import type { WikiMemory, WikiOutboxEvent } from '@equationalapplications/core-llm-wiki';
+import type { PrismaClient, Prisma } from '@prisma/client';
+
+export interface PrismaOutboxConfig {
+  wikiMemory: WikiMemory;
+  prisma: PrismaClient;
+  /**
+   * Maps one outbox event to Prisma operations executed inside a Prisma transaction.
+   * Uses Prisma.TransactionClient — safer than the manual Omit<PrismaClient, ...> form
+   * and automatically tracks new non-transactional properties added by Prisma.
+   */
+  mapEvent: (event: WikiOutboxEvent, tx: Prisma.TransactionClient) => Promise<void>;
+  /** Max events fetched per poll cycle. Default: 100 */
+  batchSize?: number;
+  /** Milliseconds between poll cycles. Default: 5000 */
+  pollIntervalMs?: number;
+  /** Called when an event fails; return true to skip and continue, false/undefined to halt. */
+  onError?: (error: Error, event: WikiOutboxEvent) => boolean | undefined;
+}
+```
+
+```typescript
+// packages/prisma-outbox/src/PrismaOutboxWorker.ts
+
+export class PrismaOutboxWorker {
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(private config: PrismaOutboxConfig) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(
+      () => void this.syncBatch(),
+      this.config.pollIntervalMs ?? 5000
+    );
+  }
+
+  stop(): void {
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  async syncBatch(): Promise<void> {
+    const batchSize = this.config.batchSize ?? 100;
+    const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
+    if (events.length === 0) return;
+
+    const processedIds: string[] = [];
+
+    for (const event of events) {
+      try {
+        await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
+        processedIds.push(event.id);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const skip = this.config.onError?.(error, event);
+        if (!skip) break; // halt to preserve ordering
+      }
+    }
+
+    await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
+
+    // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
+    // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
+    if (events.length === batchSize) {
+      setTimeout(() => void this.syncBatch(), 0);
+    }
+  }
+}
+```
+
+### Developer usage example
+
+Note that `event.table_name` + `event.operation` replace the former `event.event_type` field:
+
+```typescript
+import { WikiMemory } from '@equationalapplications/core-llm-wiki';
+import { PrismaOutboxWorker } from '@equationalapplications/prisma-outbox';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const worker = new PrismaOutboxWorker({
+  wikiMemory,
+  prisma,
+  batchSize: 50,
+  pollIntervalMs: 3000,
+  async mapEvent(event, tx) {
+    if (event.table_name.endsWith('entries')) {
+      switch (event.operation) {
+        case 'INSERT':
+          await tx.myFact.create({
+            data: {
+              id: event.record_id,
+              ownerId: event.entity_id,
+              title: event.payload.title,
+              body: event.payload.body,
+            },
+          });
+          break;
+        case 'UPDATE':
+          await tx.myFact.update({
+            where: { id: event.record_id },
+            data: { title: event.payload.title, body: event.payload.body },
+          });
+          break;
+        case 'DELETE':
+          await tx.myFact.delete({ where: { id: event.record_id } });
+          break;
+      }
+    }
+    // handle other table_name values (tasks, etc.) similarly
+  },
+  onError(error, event) {
+    console.error(`Outbox event ${event.id} failed:`, error);
+    return false; // halt
+  },
+});
+
+worker.start();
+```
+
+---
+
+## Behaviour Matrix
+
+| `enableOutbox` | Outbox table exists | New events written | Consumer APIs functional |
+|---|---|---|---|
+| `false` (default) | Yes | No | Yes (drain remaining rows) |
+| `true` | Yes | Yes | Yes |
+| Toggled `true → false` | Yes | No | Yes (graceful drain) |
+
+---
+
+## Out of Scope
+
+- **Replay from outbox:** If the Prisma database needs a full rebuild, consumers should query `facts`/`tasks` tables directly rather than replaying transient outbox history.
+- **Outbox pruning job:** Not needed — `markOutboxEventsProcessed` deletes rows immediately.
+- **`processed_at` column:** Not included — rows are deleted, not marked.
+- **Fixed Prisma schema names:** The adapter uses developer-supplied `mapEvent` callbacks; no model name conventions are imposed.
+- **React Native / Expo background workers:** Scheduling `PrismaOutboxWorker` in a mobile runtime is the host app's responsibility (e.g., via Expo background tasks). The worker exposes `syncBatch()` for manual invocation in addition to `start()`/`stop()`.
+
+---
+
+## Files Affected
+
+| Package | File | Action | Status |
+|---|---|---|---|
+| `core` | `src/outbox/types.ts` | Create — `WikiOutboxEvent` interface | Done |
+| `core` | `src/types.ts` | Modify — add `enableOutbox?: boolean` to `WikiConfig` | Done |
+| `core` | `src/repositories/OutboxRepository.ts` | Modify — accept `enableOutbox` flag in constructor; `push()` returns early when false | Done |
+| `core` | `src/WikiMemory.ts` | Modify — pass `enableOutbox` to `OutboxRepository`; add `getUnprocessedOutboxEvents`, `markOutboxEventsProcessed` | Done |
+| `core` | `src/index.ts` | Modify — export `WikiOutboxEvent` | Done |
+| `prisma-outbox` | `packages/prisma-outbox/src/types.ts` | Create | Pending |
+| `prisma-outbox` | `packages/prisma-outbox/src/PrismaOutboxWorker.ts` | Create | Pending |
+| `prisma-outbox` | `packages/prisma-outbox/src/index.ts` | Create | Pending |
+| `prisma-outbox` | `packages/prisma-outbox/package.json` | Create | Pending |
+| `prisma-outbox` | `packages/prisma-outbox/tsup.config.ts` | Create | Pending |
+
+---
+
+## Open Questions
+
+None — all design decisions resolved above.

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -47,7 +47,7 @@ The feature is off by default. The gate lives in `OutboxRepository.push()` — i
 
 `WikiMemory` passes `!!options.config?.enableOutbox` into `OutboxRepository`'s constructor. `EntryRepository` and `TaskRepository` call sites are unchanged.
 
-### Schema always created, writes conditional (after gating is added)
+### Schema always created, writes conditional
 
 `setup()` always runs `CREATE TABLE IF NOT EXISTS llm_wiki_outbox`. An empty SQLite table costs ~bytes. Toggling `enableOutbox: true` after initial deployment requires no migration — the table is already present.
 

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -39,7 +39,7 @@ The outbox table lives in the same SQLite database as `facts`, `tasks`, and `eve
 
 - **100% atomicity:** if the domain write rolls back, the outbox event is aborted with it — no divergence possible
 - **Zero new dependencies:** no message broker, no network, no additional processes
-- **Strict total ordering:** a single SQLite table guarantees sequential event IDs and `created_at` timestamps
+- **Strict total ordering:** events are fetched `ORDER BY created_at ASC, rowid ASC`; `created_at` is millisecond-resolution and IDs are random (`out_<uuid>`), so rowid is the deterministic tie-breaker for same-millisecond writes
 
 ### Opt-in via `WikiConfig.enableOutbox` (implemented)
 

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -86,6 +86,9 @@ CREATE TABLE IF NOT EXISTS ${prefix}outbox (
 
 CREATE INDEX IF NOT EXISTS ${prefix}outbox_entity_id_created_at
   ON ${prefix}outbox (entity_id, created_at);
+
+CREATE INDEX IF NOT EXISTS ${prefix}outbox_created_at
+  ON ${prefix}outbox (created_at);
 ```
 
 Note: `processed_at` column is **not** included — rows are deleted on processing.

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -77,7 +77,7 @@ The actual SQLite outbox table schema (defined in `packages/core/src/db/schema.t
 CREATE TABLE IF NOT EXISTS ${prefix}outbox (
   id         TEXT    PRIMARY KEY,
   entity_id  TEXT    NOT NULL,
-  table_name TEXT    NOT NULL,   -- e.g. 'llm_wiki_entries', 'llm_wiki_tasks'
+  table_name TEXT    NOT NULL,   -- e.g. 'entries', 'tasks'
   record_id  TEXT    NOT NULL,   -- primary key of the mutated row
   operation  TEXT    NOT NULL,   -- 'INSERT' | 'UPDATE' | 'DELETE'
   payload    TEXT    NOT NULL,   -- JSON-serialized domain object

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -118,10 +118,6 @@ export interface WikiConfig {
    * When true, every mutation appends an event to the internal outbox table.
    * The table is always created; this flag only controls whether writes occur.
    *
-   * NOTE: the current implementation writes unconditionally. Adding this flag
-   * requires adding guards at OutboxRepository.push() call sites in
-   * EntryRepository and TaskRepository.
-   *
    * @default false
    */
   enableOutbox?: boolean;
@@ -161,7 +157,7 @@ await this.db.withTransactionAsync(async (tx) => {
 
 ## Consumer API on `WikiMemory`
 
-**Implementation gap:** `WikiMemory` does not currently expose these methods. They must be added as thin delegations to `OutboxRepository`.
+`WikiMemory` exposes these methods as thin delegations to `OutboxRepository`.
 
 ```typescript
 export interface WikiMemory {

--- a/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
+++ b/docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md
@@ -1,7 +1,7 @@
 # Spec: Transactional Outbox Pattern
 
 **Date:** 2026-05-16
-**Status:** Core implemented; prisma-outbox package pending
+**Status:** Fully implemented
 
 ---
 
@@ -25,9 +25,9 @@ Implement a Transactional Outbox pattern inside the core library. Every mutation
 - `fetchPending(limit)` — reads pending rows ordered by `created_at ASC`
 - `acknowledge(ids)` — deletes processed rows by ID
 
-`EntryRepository` and `TaskRepository` both instantiate `OutboxRepository` and call `outboxRepo.push()` unconditionally on every mutation. **There is no `enableOutbox` flag today** — writes are always-on.
+`EntryRepository` and `TaskRepository` instantiate `OutboxRepository` and call `outboxRepo.push()` on every mutation; the `enableOutbox` flag in `OutboxRepository`'s constructor gates those writes.
 
-`WikiMemory` does not yet expose `getUnprocessedOutboxEvents` or `markOutboxEventsProcessed`. Exposing them is an explicit implementation gap (see [Consumer API](#consumer-api-on-wikimemory) below).
+`WikiMemory` exposes `getUnprocessedOutboxEvents` and `markOutboxEventsProcessed` as thin delegations to `OutboxRepository`.
 
 ---
 
@@ -402,11 +402,11 @@ worker.start();
 | `core` | `src/repositories/OutboxRepository.ts` | Modify — accept `enableOutbox` flag in constructor; `push()` returns early when false | Done |
 | `core` | `src/WikiMemory.ts` | Modify — pass `enableOutbox` to `OutboxRepository`; add `getUnprocessedOutboxEvents`, `markOutboxEventsProcessed` | Done |
 | `core` | `src/index.ts` | Modify — export `WikiOutboxEvent` | Done |
-| `prisma-outbox` | `packages/prisma-outbox/src/types.ts` | Create | Pending |
-| `prisma-outbox` | `packages/prisma-outbox/src/PrismaOutboxWorker.ts` | Create | Pending |
-| `prisma-outbox` | `packages/prisma-outbox/src/index.ts` | Create | Pending |
-| `prisma-outbox` | `packages/prisma-outbox/package.json` | Create | Pending |
-| `prisma-outbox` | `packages/prisma-outbox/tsup.config.ts` | Create | Pending |
+| `prisma-outbox` | `packages/prisma-outbox/src/types.ts` | Create | Done |
+| `prisma-outbox` | `packages/prisma-outbox/src/PrismaOutboxWorker.ts` | Create | Done |
+| `prisma-outbox` | `packages/prisma-outbox/src/index.ts` | Create | Done |
+| `prisma-outbox` | `packages/prisma-outbox/package.json` | Create | Done |
+| `prisma-outbox` | `packages/prisma-outbox/tsup.config.ts` | Create | Done |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:core": "pnpm --filter @equationalapplications/core-llm-wiki build",
     "build:expo": "pnpm --filter @equationalapplications/expo-llm-wiki build",
     "build:react": "pnpm --filter @equationalapplications/react-llm-wiki build",
-    "test": "pnpm -r --filter=!@equationalapplications/integration-llm-wiki test",
+    "test": "pnpm -r --filter=!@equationalapplications/integration-llm-wiki test && pnpm run integration-test",
     "typecheck": "pnpm -r typecheck",
     "dev:workspace": "pnpm -r --parallel dev",
     "dev:root": "tsup src/index.ts src/react/index.ts --format cjs,esm --dts --external react --external expo-sqlite --external @equationalapplications/core-llm-wiki --external @equationalapplications/expo-llm-wiki --external @equationalapplications/react-llm-wiki --out-dir dist --watch",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,6 +96,7 @@ const wikiMemory = new WikiMemory(db, {
     staleInferredAfterDays: 60,        // default: 60 (days before runHeal downgrades inferred facts; null to disable)
     preFilterLimit: 50,                // default: undefined — MiniSearch pre-filter before cosine scan; recommended for >500 facts
     hybridWeight: 0.7,                 // default: undefined — blend semantic (1.0) ↔ keyword (0.0); pure semantic when unset
+    enableOutbox: false,               // default: false — when true, entry/task mutations write to an internal SQLite outbox table for external sync (e.g. via @equationalapplications/prisma-outbox)
 
     // Global prompt overrides — librarianSystemPrompt and healSystemPrompt apply to write() auto-runs;
     // ingestSystemPrompt applies only to explicit ingestDocument() calls.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,6 +2,10 @@
 
 Pure TypeScript business logic for LLM Wiki Memory.
 
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=core)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
 ## Features

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -253,3 +253,95 @@ describe('WikiMemory — prompt override API', () => {
     expect(healCall).toBeDefined();
   });
 });
+
+describe('WikiMemory outbox API', () => {
+  let mockDb: SQLiteAdapter;
+
+  function makeWiki(enableOutbox?: boolean): WikiMemory {
+    mockDb = {
+      runAsync: vi.fn().mockResolvedValue({ changes: 0, lastInsertRowId: 0 }),
+      getAllAsync: vi.fn().mockResolvedValue([]),
+      getFirstAsync: vi.fn().mockResolvedValue(null),
+      withTransactionAsync: vi.fn(async (cb: (tx: SQLiteAdapter) => Promise<unknown>) => cb(mockDb as SQLiteAdapter)),
+      execAsync: vi.fn().mockResolvedValue(undefined),
+      closeAsync: vi.fn().mockResolvedValue(undefined),
+    } as SQLiteAdapter;
+    return new WikiMemory(mockDb, {
+      llmProvider: {
+        generateText: vi.fn().mockResolvedValue('{}'),
+        embed: vi.fn().mockResolvedValue(new Array(1536).fill(0)),
+      },
+      config: { tablePrefix: 'test_', enableOutbox },
+    });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getUnprocessedOutboxEvents returns [] when table is empty', async () => {
+    const wiki = makeWiki();
+    const result = await wiki.getUnprocessedOutboxEvents();
+    expect(result).toEqual([]);
+  });
+
+  it('getUnprocessedOutboxEvents passes limit to getAllAsync', async () => {
+    const wiki = makeWiki();
+    await wiki.getUnprocessedOutboxEvents(42);
+    const call = (mockDb.getAllAsync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => String(c[0]).includes('outbox'),
+    );
+    expect(call).toBeDefined();
+    expect(call![1]).toContain(42);
+  });
+
+  it('getUnprocessedOutboxEvents deserializes valid JSON payload', async () => {
+    const wiki = makeWiki();
+    (mockDb.getAllAsync as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: 'e1', entity_id: 'u1', table_name: 'entries', record_id: 'r1', operation: 'INSERT', payload: '{"key":"val"}', created_at: 1 },
+    ]);
+    const [event] = await wiki.getUnprocessedOutboxEvents();
+    expect(event.payload).toEqual({ key: 'val' });
+  });
+
+  it('getUnprocessedOutboxEvents converts malformed payload to null', async () => {
+    const wiki = makeWiki();
+    (mockDb.getAllAsync as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: 'e2', entity_id: 'u1', table_name: 'entries', record_id: 'r1', operation: 'INSERT', payload: 'NOT_JSON', created_at: 1 },
+    ]);
+    const [event] = await wiki.getUnprocessedOutboxEvents();
+    expect(event.payload).toBeNull();
+  });
+
+  it('markOutboxEventsProcessed issues DELETE for given IDs', async () => {
+    const wiki = makeWiki();
+    await wiki.markOutboxEventsProcessed(['id1', 'id2']);
+    const runCall = (mockDb.runAsync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => String(c[0]).includes('DELETE'),
+    );
+    expect(runCall).toBeDefined();
+    expect(runCall![1]).toContain('id1');
+    expect(runCall![1]).toContain('id2');
+  });
+
+  it('markOutboxEventsProcessed is a no-op for empty array', async () => {
+    const wiki = makeWiki();
+    await wiki.markOutboxEventsProcessed([]);
+    const runCalls = (mockDb.runAsync as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => String(c[0]).includes('DELETE'),
+    );
+    expect(runCalls).toHaveLength(0);
+  });
+
+  it('outbox writes are gated by enableOutbox flag — no rows when disabled', async () => {
+    const wiki = makeWiki(false);
+    (mockDb.getAllAsync as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const events = await wiki.getUnprocessedOutboxEvents();
+    expect(events).toHaveLength(0);
+    // Verify getAllAsync was called (table exists and is readable even when disabled)
+    const outboxCall = (mockDb.getAllAsync as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => String(c[0]).includes('outbox'),
+    );
+    expect(outboxCall).toBeDefined();
+  });
+});

--- a/packages/core/__tests__/integration/outbox-atomicity.test.ts
+++ b/packages/core/__tests__/integration/outbox-atomicity.test.ts
@@ -46,7 +46,7 @@ async function makeWiki(
 ): Promise<WikiMemory> {
   const wiki = new WikiMemory(db, {
     llmProvider: makeMockLlmProvider(facts),
-    config: { tablePrefix: PREFIX },
+    config: { tablePrefix: PREFIX, enableOutbox: true },
   });
   await wiki.setup();
   return wiki;
@@ -184,7 +184,7 @@ describe('Transaction integrity: entry and outbox writes are atomic', () => {
   beforeEach(async () => {
     db = openTestDatabase();
     await setupWithOutbox(db, PREFIX);
-    outboxRepo = new OutboxRepository(db, PREFIX);
+    outboxRepo = new OutboxRepository(db, PREFIX, true);
     entryRepo = new EntryRepository(db, PREFIX, outboxRepo);
   });
 

--- a/packages/core/__tests__/repositories/EntryRepository.test.ts
+++ b/packages/core/__tests__/repositories/EntryRepository.test.ts
@@ -47,7 +47,7 @@ describe('EntryRepository', () => {
     if (migration) {
       await migration.run(db, 'llm_wiki_');
     }
-    outbox = new OutboxRepository(db, 'llm_wiki_');
+    outbox = new OutboxRepository(db, 'llm_wiki_', true);
     repo = new EntryRepository(db, 'llm_wiki_', outbox);
   });
 
@@ -142,7 +142,7 @@ describe('EntryRepository with OutboxRepository', () => {
   beforeEach(async () => {
     db = openTestDatabase();
     await setupWithOutbox(db, 'llm_wiki_');
-    outbox = new OutboxRepository(db, 'llm_wiki_');
+    outbox = new OutboxRepository(db, 'llm_wiki_', true);
     repo = new EntryRepository(db, 'llm_wiki_', outbox);
   });
 

--- a/packages/core/__tests__/repositories/OutboxRepository.test.ts
+++ b/packages/core/__tests__/repositories/OutboxRepository.test.ts
@@ -23,7 +23,7 @@ describe('OutboxRepository', () => {
   beforeEach(async () => {
     db = openTestDatabase();
     await setupOutboxDatabase(db);
-    repo = new OutboxRepository(db, PREFIX);
+    repo = new OutboxRepository(db, PREFIX, true);
   });
 
   it('push() inserts a row with correct columns', async () => {

--- a/packages/core/__tests__/repositories/OutboxRepository.test.ts
+++ b/packages/core/__tests__/repositories/OutboxRepository.test.ts
@@ -104,6 +104,25 @@ describe('OutboxRepository', () => {
     expect(empty.length).toBe(0);
   });
 
+  it('acknowledge() deletes more than 500 IDs by chunking', async () => {
+    const count = 502;
+    const ids: string[] = [];
+    const now = Date.now();
+    for (let i = 0; i < count; i++) {
+      const id = `out_bulk_${i}`;
+      ids.push(id);
+      await db.runAsync(
+        `INSERT INTO ${PREFIX}outbox (id, entity_id, table_name, record_id, operation, payload, created_at) VALUES (?, 'e1', 't', 'r', 'INSERT', '{}', ?)`,
+        [id, now + i],
+      );
+    }
+
+    await repo.acknowledge(ids);
+
+    const remaining = await db.getAllAsync<any>(`SELECT id FROM ${PREFIX}outbox`);
+    expect(remaining.length).toBe(0);
+  });
+
   it('push() is a no-op when enableOutbox is false', async () => {
     const disabledRepo = new OutboxRepository(db, PREFIX, false);
     await db.withTransactionAsync(async () => {

--- a/packages/core/__tests__/repositories/OutboxRepository.test.ts
+++ b/packages/core/__tests__/repositories/OutboxRepository.test.ts
@@ -104,6 +104,24 @@ describe('OutboxRepository', () => {
     expect(empty.length).toBe(0);
   });
 
+  it('push() is a no-op when enableOutbox is false', async () => {
+    const disabledRepo = new OutboxRepository(db, PREFIX, false);
+    await db.withTransactionAsync(async () => {
+      await disabledRepo.push(
+        {
+          entityId: 'entity_disabled',
+          tableName: 'entries',
+          recordId: 'rec_disabled',
+          operation: 'INSERT',
+          payload: { should: 'not appear' },
+        },
+        db,
+      );
+    });
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}outbox`);
+    expect(rows.length).toBe(0);
+  });
+
   it('push() uses the provided tx — rollback prevents row from being persisted', async () => {
     const sentinel = new Error('intentional rollback');
 

--- a/packages/core/__tests__/repositories/TaskRepository.test.ts
+++ b/packages/core/__tests__/repositories/TaskRepository.test.ts
@@ -40,7 +40,7 @@ describe('TaskRepository', () => {
   beforeEach(async () => {
     db = openTestDatabase();
     await setupTaskDatabase(db);
-    outbox = new OutboxRepository(db, PREFIX);
+    outbox = new OutboxRepository(db, PREFIX, true);
     repo = new TaskRepository(db, PREFIX, outbox);
   });
 

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -328,6 +328,7 @@ export class WikiMemory {
    * Works regardless of enableOutbox value — allows draining after disabling.
    */
   async getUnprocessedOutboxEvents(limit = 100): Promise<WikiOutboxEvent[]> {
+    if (Number.isFinite(limit) && limit <= 0) return [];
     const safeLimit = Number.isFinite(limit) && limit >= 1 ? Math.trunc(limit) : 100;
     const rows = await this.outboxRepo.fetchPending(safeLimit);
     return rows.map(row => {

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1,4 +1,5 @@
 import type { SQLiteAdapter } from './types';
+import type { WikiOutboxEvent } from './outbox/types';
 import { setupDatabase } from './db/schema';
 import { MIGRATIONS, CURRENT_SCHEMA_VERSION } from './db/migrations';
 import {
@@ -68,7 +69,7 @@ export class WikiMemory {
     this.db = db;
     this.options = options;
     this.prefix = options.config?.tablePrefix || 'llm_wiki_';
-    this.outboxRepo = new OutboxRepository(db, this.prefix);
+    this.outboxRepo = new OutboxRepository(db, this.prefix, !!options.config?.enableOutbox);
     this.entryRepo = new EntryRepository(db, this.prefix, this.outboxRepo);
     this.taskRepo = new TaskRepository(db, this.prefix, this.outboxRepo);
     this.eventRepo = new EventRepository(db, this.prefix);
@@ -320,6 +321,31 @@ export class WikiMemory {
     }
   ): Promise<{ truncated: boolean; chunks: number }> {
     return this.ingestionService.ingestDocument(entityId, params);
+  }
+
+  /**
+   * Returns up to `limit` unprocessed outbox events, oldest first.
+   * Works regardless of enableOutbox value — allows draining after disabling.
+   */
+  async getUnprocessedOutboxEvents(limit = 100): Promise<WikiOutboxEvent[]> {
+    const rows = await this.outboxRepo.fetchPending(limit);
+    return rows.map(row => {
+      let payload: unknown = null;
+      try {
+        payload = JSON.parse(row.payload);
+      } catch {
+        // corrupted row — surface null payload rather than poisoning the batch
+      }
+      return { ...row, payload } as WikiOutboxEvent;
+    });
+  }
+
+  /**
+   * Deletes the given event IDs from the outbox table.
+   * Call after successfully committing events to the external system.
+   */
+  async markOutboxEventsProcessed(eventIds: string[]): Promise<void> {
+    await this.outboxRepo.acknowledge(eventIds);
   }
 }
 

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -328,7 +328,8 @@ export class WikiMemory {
    * Works regardless of enableOutbox value — allows draining after disabling.
    */
   async getUnprocessedOutboxEvents(limit = 100): Promise<WikiOutboxEvent[]> {
-    const rows = await this.outboxRepo.fetchPending(limit);
+    const safeLimit = Number.isFinite(limit) && limit >= 1 ? Math.trunc(limit) : 100;
+    const rows = await this.outboxRepo.fetchPending(safeLimit);
     return rows.map(row => {
       let payload: unknown = null;
       try {

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -74,5 +74,8 @@ export async function setupDatabase(db: SQLiteAdapter, prefix: string) {
 
     CREATE INDEX IF NOT EXISTS ${prefix}outbox_entity_id_created_at
       ON ${prefix}outbox (entity_id, created_at);
+
+    CREATE INDEX IF NOT EXISTS ${prefix}outbox_created_at
+      ON ${prefix}outbox (created_at);
   `);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ import { WikiMemory } from './WikiMemory';
 import type { SQLiteAdapter, WikiOptions } from './types';
 
 export * from './types';
+export type { WikiOutboxEvent } from './outbox/types';
 export { WikiMemory } from './WikiMemory';
 export type { WikiMemoryTestAccess } from './WikiMemory';
 export { formatContext } from './utils/formatContext';

--- a/packages/core/src/outbox/types.ts
+++ b/packages/core/src/outbox/types.ts
@@ -1,0 +1,9 @@
+export interface WikiOutboxEvent<T = unknown> {
+  id: string;
+  entity_id: string;
+  table_name: string;
+  record_id: string;
+  operation: 'INSERT' | 'UPDATE' | 'DELETE';
+  payload: T;
+  created_at: number;
+}

--- a/packages/core/src/repositories/OutboxRepository.ts
+++ b/packages/core/src/repositories/OutboxRepository.ts
@@ -55,10 +55,14 @@ export class OutboxRepository extends BaseRepository {
    */
   async acknowledge(ids: string[]): Promise<void> {
     if (ids.length === 0) return;
-    const placeholders = ids.map(() => '?').join(', ');
-    await this.db.runAsync(
-      `DELETE FROM ${this.prefix}outbox WHERE id IN (${placeholders})`,
-      ids,
-    );
+    const chunkSize = 500;
+    for (let i = 0; i < ids.length; i += chunkSize) {
+      const chunk = ids.slice(i, i + chunkSize);
+      const placeholders = chunk.map(() => '?').join(', ');
+      await this.db.runAsync(
+        `DELETE FROM ${this.prefix}outbox WHERE id IN (${placeholders})`,
+        chunk,
+      );
+    }
   }
 }

--- a/packages/core/src/repositories/OutboxRepository.ts
+++ b/packages/core/src/repositories/OutboxRepository.ts
@@ -38,7 +38,7 @@ export class OutboxRepository extends BaseRepository {
   }
 
   /**
-   * Fetch pending outbox rows ordered by created_at ASC, id ASC.
+   * Fetch pending outbox rows ordered by created_at ASC, rowid ASC.
    * Reads directly from `this.db` (not a transaction).
    */
   async fetchPending(limit = 50): Promise<any[]> {

--- a/packages/core/src/repositories/OutboxRepository.ts
+++ b/packages/core/src/repositories/OutboxRepository.ts
@@ -38,12 +38,12 @@ export class OutboxRepository extends BaseRepository {
   }
 
   /**
-   * Fetch pending outbox rows ordered by created_at ASC.
+   * Fetch pending outbox rows ordered by created_at ASC, id ASC.
    * Reads directly from `this.db` (not a transaction).
    */
   async fetchPending(limit = 50): Promise<any[]> {
     return this.db.getAllAsync<any>(
-      `SELECT * FROM ${this.prefix}outbox ORDER BY created_at ASC LIMIT ?`,
+      `SELECT * FROM ${this.prefix}outbox ORDER BY created_at ASC, rowid ASC LIMIT ?`,
       [limit],
     );
   }

--- a/packages/core/src/repositories/OutboxRepository.ts
+++ b/packages/core/src/repositories/OutboxRepository.ts
@@ -3,8 +3,16 @@ import type { SQLiteAdapter } from '../types';
 import { generateId } from '../utils/ids';
 
 export class OutboxRepository extends BaseRepository {
+  private enableOutbox: boolean;
+
+  constructor(db: SQLiteAdapter, prefix: string, enableOutbox = false) {
+    super(db, prefix);
+    this.enableOutbox = enableOutbox;
+  }
+
   /**
    * Insert a new outbox event within the provided transaction.
+   * No-op when enableOutbox is false.
    * `tx` is required — callers must always pass the active transaction
    * so the write is atomic with the main table mutation.
    */
@@ -18,6 +26,7 @@ export class OutboxRepository extends BaseRepository {
     },
     tx: SQLiteAdapter,
   ): Promise<void> {
+    if (!this.enableOutbox) return;
     const executor = this.getExecutor(tx);
     const id = generateId('out_');
     const now = Date.now();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,6 +49,12 @@ export interface WikiConfig {
   hybridWeight?: number;
   /** Global prompt overrides for text generation calls (`ingestDocument`, `runLibrarian`, `runHeal`). Does not affect embedding generation. Runtime overrides on individual method calls take precedence. */
   prompts?: PromptOverrides;
+  /**
+   * When true, every mutation appends an event to the internal outbox table.
+   * The table is always created; this flag only controls whether writes occur.
+   * @default false
+   */
+  enableOutbox?: boolean;
 }
 
 export interface ReadOptions {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,7 +50,7 @@ export interface WikiConfig {
   /** Global prompt overrides for text generation calls (`ingestDocument`, `runLibrarian`, `runHeal`). Does not affect embedding generation. Runtime overrides on individual method calls take precedence. */
   prompts?: PromptOverrides;
   /**
-   * When true, every mutation appends an event to the internal outbox table.
+   * When true, entry and task mutations append an event to the internal outbox table.
    * The table is always created; this flag only controls whether writes occur.
    * @default false
    */

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -3,9 +3,7 @@
 Expo/React Native adapter for @equationalapplications/core-llm-wiki, powered by `expo-sqlite`.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=npm)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)
-[![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)
-[![bundlephobia](https://img.shields.io/bundlephobia/minzip/%40equationalapplications%2Fexpo-llm-wiki?label=gzip)](https://bundlephobia.com/package/@equationalapplications/expo-llm-wiki)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).

--- a/packages/prisma-outbox/LICENSE
+++ b/packages/prisma-outbox/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Equational Applications
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -1,0 +1,82 @@
+# @equationalapplications/prisma-outbox
+
+Prisma adapter for the [expo-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki) transactional outbox pattern.
+
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fprisma-outbox?label=prisma-outbox)](https://www.npmjs.com/package/@equationalapplications/prisma-outbox)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
+Polls the SQLite outbox table written by `@equationalapplications/core-llm-wiki` and syncs events to your Prisma-backed system inside a Prisma transaction, with configurable batch size, poll interval, error handling, and a concurrency guard.
+
+## Installation
+
+```bash
+npm install @equationalapplications/prisma-outbox
+# peer deps
+npm install @equationalapplications/core-llm-wiki @prisma/client
+```
+
+## Quick start
+
+```typescript
+import { PrismaOutboxWorker } from '@equationalapplications/prisma-outbox';
+import { WikiMemory } from '@equationalapplications/core-llm-wiki';
+import { PrismaClient } from '@prisma/client';
+
+const wiki = new WikiMemory(db, {
+  llmProvider,
+  config: { enableOutbox: true },
+});
+await wiki.setup();
+
+const prisma = new PrismaClient();
+
+const worker = new PrismaOutboxWorker({
+  wikiMemory: wiki,
+  prisma,
+  mapEvent: async (event, tx) => {
+    if (event.operation === 'INSERT' && event.table_name.includes('entries')) {
+      await tx.wikiEntry.create({ data: { id: event.record_id, ...event.payload } });
+    }
+  },
+  pollIntervalMs: 5000,
+  batchSize: 100,
+  onError: (err, event) => {
+    console.error('Outbox event failed', event.id, err);
+    return false; // halt to preserve ordering; return true to skip poison-pill
+  },
+});
+
+worker.start();
+
+// On shutdown:
+worker.stop();
+```
+
+## API
+
+### `PrismaOutboxWorker`
+
+| Method | Description |
+|--------|-------------|
+| `start()` | Begins polling on the configured interval. Idempotent. |
+| `stop()` | Clears the poll interval and any pending backlog timeout. |
+| `syncBatch()` | Manually trigger one poll cycle (useful for testing). |
+
+### `PrismaOutboxConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wikiMemory` | `WikiMemory` | required | The `WikiMemory` instance to poll. |
+| `prisma` | `PrismaClient` | required | The Prisma client. |
+| `mapEvent` | `(event, tx) => Promise<void>` | required | Maps one outbox event to Prisma operations inside a transaction. |
+| `batchSize` | `number` | `100` | Max events fetched per cycle. |
+| `pollIntervalMs` | `number` | `5000` | Milliseconds between poll cycles. |
+| `onError` | `(err, event) => boolean \| undefined` | — | Return `true` to skip a failing event; `false`/`undefined` to halt. |
+
+## How it works
+
+1. Every `WikiMemory` mutation (when `enableOutbox: true`) atomically writes an event to the SQLite `outbox` table in the same transaction as the domain write.
+2. `PrismaOutboxWorker` polls `getUnprocessedOutboxEvents()` and calls `mapEvent` inside a Prisma transaction for each event.
+3. Successfully processed event IDs are passed to `markOutboxEventsProcessed()`, which deletes them from SQLite.
+4. If a full batch is consumed without error, an immediate follow-up cycle runs (backlog optimization) to drain queues faster than the poll interval.

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -73,6 +73,7 @@ worker.stop();
 | `batchSize` | `number` | `100` | Max events fetched per cycle. |
 | `pollIntervalMs` | `number` | `5000` | Milliseconds between poll cycles. |
 | `onError` | `(err, event) => boolean \| undefined` | — | Return `true` to skip a failing event; `false`/`undefined` to halt. |
+| `onWorkerError` | `(err: Error) => void` | — | Called for worker-level errors (SQLite read/ack failures) not delivered to `onError`. |
 
 ## How it works
 

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -35,8 +35,14 @@ const worker = new PrismaOutboxWorker({
   wikiMemory: wiki,
   prisma,
   mapEvent: async (event, tx) => {
+    // mapEvent must be idempotent: at-least-once delivery means the same event
+    // can be retried if acknowledgement fails after the Prisma transaction commits.
     if (event.operation === 'INSERT' && event.table_name.includes('entries')) {
-      await tx.wikiEntry.create({ data: { id: event.record_id, ...(event.payload as Record<string, unknown>) } });
+      await tx.wikiEntry.upsert({
+        where: { id: event.record_id },
+        create: { id: event.record_id, ...(event.payload as Record<string, unknown>) },
+        update: {},
+      });
     }
   },
   pollIntervalMs: 5000,

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -87,3 +87,7 @@ worker.stop();
 2. `PrismaOutboxWorker` polls `getUnprocessedOutboxEvents()` and calls `mapEvent` inside a Prisma transaction for each event.
 3. Successfully processed event IDs are passed to `markOutboxEventsProcessed()`, which deletes them from SQLite.
 4. If a full batch is consumed without error, an immediate follow-up cycle runs (backlog optimization) to drain queues faster than the poll interval.
+
+## Limitations
+
+- **Single-instance only.** The worker does not use row-level locking or leases. Running two `PrismaOutboxWorker` instances against the same SQLite file will cause duplicate Prisma writes. Run exactly one worker per SQLite database. `mapEvent` must still be idempotent to tolerate at-least-once delivery (acknowledgement can fail after a successful Prisma commit).

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -36,7 +36,7 @@ const worker = new PrismaOutboxWorker({
   prisma,
   mapEvent: async (event, tx) => {
     if (event.operation === 'INSERT' && event.table_name.includes('entries')) {
-      await tx.wikiEntry.create({ data: { id: event.record_id, ...event.payload } });
+      await tx.wikiEntry.create({ data: { id: event.record_id, ...(event.payload as Record<string, unknown>) } });
     }
   },
   pollIntervalMs: 5000,
@@ -68,8 +68,8 @@ worker.stop();
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `wikiMemory` | `WikiMemory` | required | The `WikiMemory` instance to poll. |
-| `prisma` | `PrismaClient` | required | The Prisma client. |
-| `mapEvent` | `(event, tx) => Promise<void>` | required | Maps one outbox event to Prisma operations inside a transaction. |
+| `prisma` | `PrismaLike<TTx>` | required | Any Prisma client with a `$transaction` method (your generated `PrismaClient` satisfies this). |
+| `mapEvent` | `(event, tx: TTx) => Promise<void>` | required | Maps one outbox event to Prisma operations inside a transaction. `tx` is inferred from your `PrismaClient`. |
 | `batchSize` | `number` | `100` | Max events fetched per cycle. |
 | `pollIntervalMs` | `number` | `5000` | Milliseconds between poll cycles. |
 | `onError` | `(err, event) => boolean \| undefined` | — | Return `true` to skip a failing event; `false`/`undefined` to halt. |

--- a/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
+++ b/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
@@ -188,5 +188,76 @@ describe('PrismaOutboxWorker', () => {
 
       expect(getEvents).toHaveBeenCalledWith(25);
     });
+
+    it('backlog optimization triggers another syncBatch when full batch processed without halt', async () => {
+      vi.useFakeTimers();
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const getEvents = vi.fn()
+        .mockResolvedValueOnce(events)
+        .mockResolvedValue([]);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        batchSize: 2,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      worker.start(); // ensures this.timer !== undefined
+
+      await worker.syncBatch(); // processes full batch; schedules setTimeout(0)
+      await vi.advanceTimersByTimeAsync(0); // fires the backlog setTimeout; second syncBatch runs
+
+      expect(getEvents).toHaveBeenCalledTimes(2);
+      worker.stop();
+    });
+
+    it('backlog optimization does NOT trigger when batch halted', async () => {
+      vi.useFakeTimers();
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const transaction = vi.fn().mockRejectedValueOnce(new Error('fail'));
+      const getEvents = vi.fn().mockResolvedValue(events);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        prisma: { $transaction: transaction } as any,
+        onError: () => false,
+        batchSize: 2,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      worker.start();
+
+      await worker.syncBatch(); // halts on id1 failure — should NOT schedule backlog
+      await vi.advanceTimersByTimeAsync(0); // if backlog wrongly scheduled, fires it
+
+      // Only the one explicit syncBatch call
+      expect(getEvents).toHaveBeenCalledTimes(1);
+      worker.stop();
+    });
+
+    it('stop() cancels a pending backlog setTimeout', async () => {
+      vi.useFakeTimers();
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const getEvents = vi.fn()
+        .mockResolvedValueOnce(events)
+        .mockResolvedValue([]);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        batchSize: 2,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      worker.start();
+
+      await worker.syncBatch(); // schedules backlog setTimeout(0)
+      worker.stop(); // cancels the backlog
+      await vi.advanceTimersByTimeAsync(0); // would fire backlog if not cancelled
+
+      expect(getEvents).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
+++ b/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
@@ -174,6 +174,25 @@ describe('PrismaOutboxWorker', () => {
       expect(config.wikiMemory.markOutboxEventsProcessed).toHaveBeenCalledWith(['id1', 'id2']);
     });
 
+    it('passes event and tx client into mapEvent via $transaction callback', async () => {
+      const event = makeEvent('id1');
+      const fakeTx = { model: 'fake' } as any;
+      const mapEvent = vi.fn().mockResolvedValue(undefined);
+      const transaction = vi.fn().mockImplementation((cb: (tx: unknown) => Promise<void>) => cb(fakeTx));
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: vi.fn().mockResolvedValue([event]),
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        prisma: { $transaction: transaction } as any,
+        mapEvent,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+
+      expect(mapEvent).toHaveBeenCalledWith(event, fakeTx);
+    });
+
     it('passes batchSize to getUnprocessedOutboxEvents', async () => {
       const getEvents = vi.fn().mockResolvedValue([]);
       const config = makeConfig({

--- a/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
+++ b/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
@@ -256,6 +256,34 @@ describe('PrismaOutboxWorker', () => {
       worker.stop();
     });
 
+    it('double syncBatch() calls clear the earlier backlog handle so stop() cancels both', async () => {
+      vi.useFakeTimers();
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const getEvents = vi.fn()
+        .mockResolvedValueOnce(events)
+        .mockResolvedValueOnce(events)
+        .mockResolvedValue([]);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        batchSize: 2,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      worker.start();
+
+      // Two manual full-batch calls each schedule a backlog timeout.
+      // With the fix, the second clears the first so there is at most one pending.
+      await worker.syncBatch();
+      await worker.syncBatch();
+      worker.stop(); // cancels the single remaining backlog handle
+      await vi.advanceTimersByTimeAsync(0); // would fire any uncancelled handle
+
+      // Only the 2 explicit syncBatch calls — no backlog drain after stop().
+      expect(getEvents).toHaveBeenCalledTimes(2);
+    });
+
     it('stop() cancels a pending backlog setTimeout', async () => {
       vi.useFakeTimers();
       const events = [makeEvent('id1'), makeEvent('id2')];

--- a/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
+++ b/packages/prisma-outbox/__tests__/PrismaOutboxWorker.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PrismaOutboxWorker } from '../src/PrismaOutboxWorker';
+import type { PrismaOutboxConfig } from '../src/types';
+import type { WikiOutboxEvent } from '@equationalapplications/core-llm-wiki';
+
+function makeEvent(id: string): WikiOutboxEvent {
+  return {
+    id,
+    entity_id: 'e1',
+    table_name: 'entries',
+    record_id: 'r1',
+    operation: 'INSERT',
+    payload: { key: 'val' },
+    created_at: Date.now(),
+  };
+}
+
+function makeConfig(overrides: Partial<PrismaOutboxConfig> = {}): PrismaOutboxConfig {
+  return {
+    wikiMemory: {
+      getUnprocessedOutboxEvents: vi.fn().mockResolvedValue([]),
+      markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    prisma: {
+      $transaction: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    mapEvent: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('PrismaOutboxWorker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('start() / stop()', () => {
+    it('start() fires syncBatch on interval', async () => {
+      vi.useFakeTimers();
+      const config = makeConfig();
+      const worker = new PrismaOutboxWorker(config);
+      const spy = vi.spyOn(worker, 'syncBatch').mockResolvedValue(undefined);
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      worker.stop();
+    });
+
+    it('start() is idempotent — second call does not create a second interval', async () => {
+      vi.useFakeTimers();
+      const config = makeConfig();
+      const worker = new PrismaOutboxWorker(config);
+      const spy = vi.spyOn(worker, 'syncBatch').mockResolvedValue(undefined);
+
+      worker.start();
+      worker.start();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      worker.stop();
+    });
+
+    it('stop() prevents further syncBatch calls', async () => {
+      vi.useFakeTimers();
+      const config = makeConfig();
+      const worker = new PrismaOutboxWorker(config);
+      const spy = vi.spyOn(worker, 'syncBatch').mockResolvedValue(undefined);
+
+      worker.start();
+      worker.stop();
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('uses custom pollIntervalMs', async () => {
+      vi.useFakeTimers();
+      const config = makeConfig({ pollIntervalMs: 1000 });
+      const worker = new PrismaOutboxWorker(config);
+      const spy = vi.spyOn(worker, 'syncBatch').mockResolvedValue(undefined);
+
+      worker.start();
+      await vi.advanceTimersByTimeAsync(999);
+      expect(spy).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      worker.stop();
+    });
+  });
+
+  describe('syncBatch()', () => {
+    it('does nothing when no events', async () => {
+      const config = makeConfig();
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+      expect(config.prisma.$transaction).not.toHaveBeenCalled();
+      expect(config.wikiMemory.markOutboxEventsProcessed).not.toHaveBeenCalled();
+    });
+
+    it('maps events and acknowledges processed IDs', async () => {
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: vi.fn().mockResolvedValue(events),
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+
+      expect(config.prisma.$transaction).toHaveBeenCalledTimes(2);
+      expect(config.wikiMemory.markOutboxEventsProcessed).toHaveBeenCalledWith(['id1', 'id2']);
+    });
+
+    it('concurrency guard prevents overlapping runs', async () => {
+      let resolveFirst!: () => void;
+      const firstCallPromise = new Promise<void>(r => { resolveFirst = r; });
+      const getEvents = vi.fn()
+        .mockReturnValueOnce(firstCallPromise.then(() => []))
+        .mockResolvedValue([]);
+
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+      });
+      const worker = new PrismaOutboxWorker(config);
+
+      const first = worker.syncBatch();
+      const second = worker.syncBatch(); // should be a no-op
+      resolveFirst();
+      await Promise.all([first, second]);
+
+      expect(getEvents).toHaveBeenCalledTimes(1);
+    });
+
+    it('halts processing on error when onError returns false/undefined', async () => {
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const transaction = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue(undefined);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: vi.fn().mockResolvedValue(events),
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        prisma: { $transaction: transaction } as any,
+        onError: () => false,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+
+      // id1 failed and halt — only empty processedIds acknowledged
+      expect(config.wikiMemory.markOutboxEventsProcessed).toHaveBeenCalledWith([]);
+    });
+
+    it('skips poison-pill event and continues when onError returns true', async () => {
+      const events = [makeEvent('id1'), makeEvent('id2')];
+      const transaction = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue(undefined);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: vi.fn().mockResolvedValue(events),
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        prisma: { $transaction: transaction } as any,
+        onError: () => true,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+
+      // id1 skipped (acknowledged) + id2 processed
+      expect(config.wikiMemory.markOutboxEventsProcessed).toHaveBeenCalledWith(['id1', 'id2']);
+    });
+
+    it('passes batchSize to getUnprocessedOutboxEvents', async () => {
+      const getEvents = vi.fn().mockResolvedValue([]);
+      const config = makeConfig({
+        wikiMemory: {
+          getUnprocessedOutboxEvents: getEvents,
+          markOutboxEventsProcessed: vi.fn().mockResolvedValue(undefined),
+        } as any,
+        batchSize: 25,
+      });
+      const worker = new PrismaOutboxWorker(config);
+      await worker.syncBatch();
+
+      expect(getEvents).toHaveBeenCalledWith(25);
+    });
+  });
+});

--- a/packages/prisma-outbox/package.json
+++ b/packages/prisma-outbox/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "files": [
@@ -39,6 +41,7 @@
     "@prisma/client": "^5.0.0",
     "prisma": "^5.0.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "4.1.5"
   }
 }

--- a/packages/prisma-outbox/package.json
+++ b/packages/prisma-outbox/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@equationalapplications/prisma-outbox",
+  "version": "1.0.0",
+  "description": "Prisma adapter for the expo-llm-wiki transactional outbox pattern.",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "peerDependencies": {
+    "@equationalapplications/core-llm-wiki": "workspace:*",
+    "@prisma/client": "^5.0.0 || ^6.0.0"
+  },
+  "devDependencies": {
+    "@equationalapplications/core-llm-wiki": "workspace:*",
+    "@prisma/client": "^5.0.0",
+    "prisma": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -2,6 +2,7 @@ import type { PrismaOutboxConfig } from './types';
 
 export class PrismaOutboxWorker {
   private timer?: ReturnType<typeof setInterval>;
+  private backlogTimer?: ReturnType<typeof setTimeout>;
   private running = false;
 
   constructor(private config: PrismaOutboxConfig) {}
@@ -17,6 +18,8 @@ export class PrismaOutboxWorker {
   stop(): void {
     clearInterval(this.timer);
     this.timer = undefined;
+    clearTimeout(this.backlogTimer);
+    this.backlogTimer = undefined;
   }
 
   async syncBatch(): Promise<void> {
@@ -28,6 +31,7 @@ export class PrismaOutboxWorker {
       if (events.length === 0) return;
 
       const processedIds: string[] = [];
+      let halted = false;
 
       for (const event of events) {
         try {
@@ -39,6 +43,7 @@ export class PrismaOutboxWorker {
           if (skip) {
             processedIds.push(event.id); // acknowledge so the event isn't re-fetched
           } else {
+            halted = true;
             break; // halt to preserve ordering
           }
         }
@@ -46,10 +51,11 @@ export class PrismaOutboxWorker {
 
       await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
 
-      // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
+      // Backlog optimization: full batch without halt means more events likely waiting.
+      // Only schedule when worker is still running (stop() not called) to avoid post-stop leaks.
       // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
-      if (events.length === batchSize) {
-        setTimeout(() => void this.syncBatch(), 0);
+      if (!halted && events.length === batchSize && this.timer !== undefined) {
+        this.backlogTimer = setTimeout(() => void this.syncBatch(), 0);
       }
     } finally {
       this.running = false;

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -2,6 +2,7 @@ import type { PrismaOutboxConfig } from './types';
 
 export class PrismaOutboxWorker {
   private timer?: ReturnType<typeof setInterval>;
+  private running = false;
 
   constructor(private config: PrismaOutboxConfig) {}
 
@@ -19,29 +20,35 @@ export class PrismaOutboxWorker {
   }
 
   async syncBatch(): Promise<void> {
-    const batchSize = this.config.batchSize ?? 100;
-    const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
-    if (events.length === 0) return;
+    if (this.running) return;
+    this.running = true;
+    try {
+      const batchSize = this.config.batchSize ?? 100;
+      const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
+      if (events.length === 0) return;
 
-    const processedIds: string[] = [];
+      const processedIds: string[] = [];
 
-    for (const event of events) {
-      try {
-        await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
-        processedIds.push(event.id);
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        const skip = this.config.onError?.(error, event);
-        if (!skip) break; // halt to preserve ordering
+      for (const event of events) {
+        try {
+          await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
+          processedIds.push(event.id);
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          const skip = this.config.onError?.(error, event);
+          if (!skip) break; // halt to preserve ordering
+        }
       }
-    }
 
-    await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
+      await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
 
-    // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
-    // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
-    if (events.length === batchSize) {
-      setTimeout(() => void this.syncBatch(), 0);
+      // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
+      // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
+      if (events.length === batchSize) {
+        setTimeout(() => void this.syncBatch(), 0);
+      }
+    } finally {
+      this.running = false;
     }
   }
 }

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -1,0 +1,47 @@
+import type { PrismaOutboxConfig } from './types';
+
+export class PrismaOutboxWorker {
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(private config: PrismaOutboxConfig) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(
+      () => void this.syncBatch(),
+      this.config.pollIntervalMs ?? 5000
+    );
+  }
+
+  stop(): void {
+    clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  async syncBatch(): Promise<void> {
+    const batchSize = this.config.batchSize ?? 100;
+    const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
+    if (events.length === 0) return;
+
+    const processedIds: string[] = [];
+
+    for (const event of events) {
+      try {
+        await this.config.prisma.$transaction(tx => this.config.mapEvent(event, tx));
+        processedIds.push(event.id);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const skip = this.config.onError?.(error, event);
+        if (!skip) break; // halt to preserve ordering
+      }
+    }
+
+    await this.config.wikiMemory.markOutboxEventsProcessed(processedIds);
+
+    // Backlog optimization: full batch means more events likely waiting — skip the interval delay.
+    // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
+    if (events.length === batchSize) {
+      setTimeout(() => void this.syncBatch(), 0);
+    }
+  }
+}

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -1,11 +1,11 @@
 import type { PrismaOutboxConfig } from './types';
 
-export class PrismaOutboxWorker {
+export class PrismaOutboxWorker<TTx = unknown> {
   private timer?: ReturnType<typeof setInterval>;
   private backlogTimer?: ReturnType<typeof setTimeout>;
   private running = false;
 
-  constructor(private config: PrismaOutboxConfig) {}
+  constructor(private config: PrismaOutboxConfig<TTx>) {}
 
   start(): void {
     if (this.timer) return;

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -10,9 +10,14 @@ export class PrismaOutboxWorker<TTx = unknown> {
   start(): void {
     if (this.timer) return;
     this.timer = setInterval(
-      () => { this.syncBatch().catch(() => {}); },
+      () => { this.syncBatch().catch(err => this.#workerError(err)); },
       this.config.pollIntervalMs ?? 5000
     );
+  }
+
+  #workerError(err: unknown): void {
+    const error = err instanceof Error ? err : new Error(String(err));
+    this.config.onWorkerError?.(error);
   }
 
   stop(): void {
@@ -62,7 +67,7 @@ export class PrismaOutboxWorker<TTx = unknown> {
       // Only schedule when worker is still running (stop() not called) to avoid post-stop leaks.
       // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
       if (!halted && events.length === batchSize && this.timer !== undefined) {
-        this.backlogTimer = setTimeout(() => { this.syncBatch().catch(() => {}); }, 0);
+        this.backlogTimer = setTimeout(() => { this.syncBatch().catch(err => this.#workerError(err)); }, 0);
       }
     } finally {
       this.running = false;

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -9,9 +9,11 @@ export class PrismaOutboxWorker<TTx = unknown> {
 
   start(): void {
     if (this.timer) return;
+    const rawInterval = this.config.pollIntervalMs ?? 5000;
+    const pollIntervalMs = Number.isFinite(rawInterval) && rawInterval >= 1 ? Math.trunc(rawInterval) : 5000;
     this.timer = setInterval(
       () => { this.syncBatch().catch(err => this.#workerError(err)); },
-      this.config.pollIntervalMs ?? 5000
+      pollIntervalMs
     );
   }
 

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -31,7 +31,8 @@ export class PrismaOutboxWorker<TTx = unknown> {
     if (this.running) return;
     this.running = true;
     try {
-      const batchSize = this.config.batchSize ?? 100;
+      const rawSize = this.config.batchSize ?? 100;
+      const batchSize = Number.isFinite(rawSize) && rawSize >= 1 ? Math.trunc(rawSize) : 100;
       const events = await this.config.wikiMemory.getUnprocessedOutboxEvents(batchSize);
       if (events.length === 0) return;
 

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -67,6 +67,7 @@ export class PrismaOutboxWorker<TTx = unknown> {
       // Only schedule when worker is still running (stop() not called) to avoid post-stop leaks.
       // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
       if (!halted && events.length === batchSize && this.timer !== undefined) {
+        clearTimeout(this.backlogTimer);
         this.backlogTimer = setTimeout(() => { this.syncBatch().catch(err => this.#workerError(err)); }, 0);
       }
     } finally {

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -39,7 +39,14 @@ export class PrismaOutboxWorker<TTx = unknown> {
           processedIds.push(event.id);
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
-          const skip = this.config.onError?.(error, event);
+          let skip = false;
+          try {
+            skip = this.config.onError?.(error, event) ?? false;
+          } catch {
+            // thrown handler treated as halt; processedIds acknowledged below
+            halted = true;
+            break;
+          }
           if (skip) {
             processedIds.push(event.id); // acknowledge so the event isn't re-fetched
           } else {

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -36,7 +36,11 @@ export class PrismaOutboxWorker {
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));
           const skip = this.config.onError?.(error, event);
-          if (!skip) break; // halt to preserve ordering
+          if (skip) {
+            processedIds.push(event.id); // acknowledge so the event isn't re-fetched
+          } else {
+            break; // halt to preserve ordering
+          }
         }
       }
 

--- a/packages/prisma-outbox/src/PrismaOutboxWorker.ts
+++ b/packages/prisma-outbox/src/PrismaOutboxWorker.ts
@@ -10,7 +10,7 @@ export class PrismaOutboxWorker<TTx = unknown> {
   start(): void {
     if (this.timer) return;
     this.timer = setInterval(
-      () => void this.syncBatch(),
+      () => { this.syncBatch().catch(() => {}); },
       this.config.pollIntervalMs ?? 5000
     );
   }
@@ -55,7 +55,7 @@ export class PrismaOutboxWorker<TTx = unknown> {
       // Only schedule when worker is still running (stop() not called) to avoid post-stop leaks.
       // Use setTimeout(0) instead of setImmediate for React Native / Hermes compatibility.
       if (!halted && events.length === batchSize && this.timer !== undefined) {
-        this.backlogTimer = setTimeout(() => void this.syncBatch(), 0);
+        this.backlogTimer = setTimeout(() => { this.syncBatch().catch(() => {}); }, 0);
       }
     } finally {
       this.running = false;

--- a/packages/prisma-outbox/src/index.ts
+++ b/packages/prisma-outbox/src/index.ts
@@ -1,0 +1,2 @@
+export { PrismaOutboxWorker } from './PrismaOutboxWorker';
+export type { PrismaOutboxConfig } from './types';

--- a/packages/prisma-outbox/src/index.ts
+++ b/packages/prisma-outbox/src/index.ts
@@ -1,2 +1,2 @@
 export { PrismaOutboxWorker } from './PrismaOutboxWorker';
-export type { PrismaOutboxConfig } from './types';
+export type { PrismaOutboxConfig, PrismaLike } from './types';

--- a/packages/prisma-outbox/src/types.ts
+++ b/packages/prisma-outbox/src/types.ts
@@ -1,15 +1,18 @@
 import type { WikiMemory, WikiOutboxEvent } from '@equationalapplications/core-llm-wiki';
-import type { PrismaClient, Prisma } from '@prisma/client';
 
-export interface PrismaOutboxConfig {
+/** Minimal Prisma client shape required by the worker — avoids depending on generated types. */
+export interface PrismaLike<TTx> {
+  $transaction: (fn: (tx: TTx) => Promise<void>) => Promise<unknown>;
+}
+
+export interface PrismaOutboxConfig<TTx = unknown> {
   wikiMemory: WikiMemory;
-  prisma: PrismaClient;
+  prisma: PrismaLike<TTx>;
   /**
    * Maps one outbox event to Prisma operations executed inside a Prisma transaction.
-   * Uses Prisma.TransactionClient — safer than the manual Omit<PrismaClient, ...> form
-   * and automatically tracks new non-transactional properties added by Prisma.
+   * `tx` is the Prisma transaction client passed by `prisma.$transaction`.
    */
-  mapEvent: (event: WikiOutboxEvent, tx: Prisma.TransactionClient) => Promise<void>;
+  mapEvent: (event: WikiOutboxEvent, tx: TTx) => Promise<void>;
   /** Max events fetched per poll cycle. Default: 100 */
   batchSize?: number;
   /** Milliseconds between poll cycles. Default: 5000 */

--- a/packages/prisma-outbox/src/types.ts
+++ b/packages/prisma-outbox/src/types.ts
@@ -28,4 +28,6 @@ export interface PrismaOutboxConfig<TTx = unknown> {
   pollIntervalMs?: number;
   /** Called when an event fails; return true to skip and continue, false/undefined to halt. */
   onError?: (error: Error, event: WikiOutboxEvent) => boolean | undefined;
+  /** Called when a worker-level error occurs (e.g. SQLite read/ack failure). Not called for per-event errors handled by onError. */
+  onWorkerError?: (error: Error) => void;
 }

--- a/packages/prisma-outbox/src/types.ts
+++ b/packages/prisma-outbox/src/types.ts
@@ -6,6 +6,15 @@ export interface PrismaLike<TTx> {
 }
 
 export interface PrismaOutboxConfig<TTx = unknown> {
+  /**
+   * The WikiMemory instance to poll for outbox events.
+   *
+   * **Singleton requirement:** run at most one `PrismaOutboxWorker` per SQLite database
+   * at a time. The in-process `running` guard prevents overlapping calls within a single
+   * worker, but two workers (or two processes) sharing the same database can fetch and
+   * process the same unclaimed rows concurrently, producing duplicate Prisma writes.
+   * If you need multi-process fan-out, add a claim/lease column to the outbox table.
+   */
   wikiMemory: WikiMemory;
   prisma: PrismaLike<TTx>;
   /**

--- a/packages/prisma-outbox/src/types.ts
+++ b/packages/prisma-outbox/src/types.ts
@@ -1,0 +1,19 @@
+import type { WikiMemory, WikiOutboxEvent } from '@equationalapplications/core-llm-wiki';
+import type { PrismaClient, Prisma } from '@prisma/client';
+
+export interface PrismaOutboxConfig {
+  wikiMemory: WikiMemory;
+  prisma: PrismaClient;
+  /**
+   * Maps one outbox event to Prisma operations executed inside a Prisma transaction.
+   * Uses Prisma.TransactionClient — safer than the manual Omit<PrismaClient, ...> form
+   * and automatically tracks new non-transactional properties added by Prisma.
+   */
+  mapEvent: (event: WikiOutboxEvent, tx: Prisma.TransactionClient) => Promise<void>;
+  /** Max events fetched per poll cycle. Default: 100 */
+  batchSize?: number;
+  /** Milliseconds between poll cycles. Default: 5000 */
+  pollIntervalMs?: number;
+  /** Called when an event fails; return true to skip and continue, false/undefined to halt. */
+  onError?: (error: Error, event: WikiOutboxEvent) => boolean | undefined;
+}

--- a/packages/prisma-outbox/tsconfig.json
+++ b/packages/prisma-outbox/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "ES2022.Error"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/prisma-outbox/tsconfig.json
+++ b/packages/prisma-outbox/tsconfig.json
@@ -9,7 +9,8 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/prisma-outbox/tsup.config.ts
+++ b/packages/prisma-outbox/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+});

--- a/packages/prisma-outbox/vitest.config.ts
+++ b/packages/prisma-outbox/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,6 +2,10 @@
 
 React hooks and web utilities for @equationalapplications/core-llm-wiki, designed for web and Expo.
 
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
 ## Features

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,27 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/prisma-outbox:
+    devDependencies:
+      '@equationalapplications/core-llm-wiki':
+        specifier: workspace:*
+        version: link:../core
+      '@prisma/client':
+        specifier: ^5.0.0
+        version: 5.22.0(prisma@5.22.0)
+      prisma:
+        specifier: ^5.0.0
+        version: 5.22.0
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.13)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/react:
     dependencies:
       '@equationalapplications/core-llm-wiki':
@@ -1222,6 +1243,30 @@ packages:
   '@pnpm/npm-conf@3.0.2':
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+
+  '@prisma/debug@5.22.0':
+    resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
+    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
+
+  '@prisma/engines@5.22.0':
+    resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
+
+  '@prisma/fetch-engine@5.22.0':
+    resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
+
+  '@prisma/get-platform@5.22.0':
+    resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
   '@react-native/assets-registry@0.83.6':
     resolution: {integrity: sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg==}
@@ -3802,6 +3847,11 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  prisma@5.22.0:
+    resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6003,6 +6053,31 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
+
+  '@prisma/debug@5.22.0': {}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
+
+  '@prisma/engines@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/fetch-engine': 5.22.0
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/fetch-engine@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/get-platform@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
 
   '@react-native/assets-registry@0.83.6': {}
 
@@ -8654,6 +8729,12 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  prisma@5.22.0:
+    dependencies:
+      '@prisma/engines': 5.22.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   proc-log@4.2.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
   "references": [
     { "path": "./packages/core" },
     { "path": "./packages/expo" },
-    { "path": "./packages/react" }
+    { "path": "./packages/react" },
+    { "path": "./packages/prisma-outbox" }
   ]
 }


### PR DESCRIPTION
## Summary

Speciifiicatiion docs/superpowers/specs/2026-05-16-transactional-outbox-spec.md

- Adds `@equationalapplications/prisma-outbox` package: `PrismaOutboxWorker` polls the SQLite outbox table and syncs events to Prisma via `prisma.$transaction`, with configurable batch size, poll interval, error handling, and concurrency guard
- Adds `getUnprocessedOutboxEvents` / `markOutboxEventsProcessed` to `WikiMemory` as thin delegations to `OutboxRepository`
- `enableOutbox` flag on `WikiConfig` gates all outbox writes; table is always created so toggling on later requires no migration

## Test Plan

- [ ] `pnpm test` — all 539 tests pass (480 core, 49 react, 10 expo)
- [ ] Verify `packages/prisma-outbox` builds: `pnpm --filter @equationalapplications/prisma-outbox build`
- [ ] Verify typechecks: `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)