### PR TITLE
fix: release workflow by adding files array to root tsconfig

### DIFF
--- a/packages/prisma-outbox/tsconfig.json
+++ b/packages/prisma-outbox/tsconfig.json
@@ -9,8 +9,7 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "skipLibCheck": true,
-    "composite": true
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "jsx": "react-jsx"
   },
+  "files": [],
   "references": [
     { "path": "./packages/core" },
     { "path": "./packages/expo" },


### PR DESCRIPTION
This PR fixes two related TypeScript configuration issues that were breaking the build.

- `tsconfig.json`: adds an explicit `files: []` entry at the repository root so root project references do not accidentally include package source files during release builds.
- `packages/prisma-outbox/tsconfig.json`: removes `composite: true` so `tsup` can successfully emit declaration files for the Prisma outbox adapter package.

These changes are meant to restore the repository build and release workflow without changing runtime behavior.