### PR TITLE
feat(core-llm-tools): add platform-agnostic tool schema and scope injector package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
           # Publish in dependency order so each package exists on npm before dependents are published.
           # pnpm publish replaces workspace:* dependency ranges with the real version at pack time.
           # Workspace package versions are already set by semantic-release's prepare phase.
+          publish_if_needed "./packages/core-llm-tools/package.json" pnpm --filter "./packages/core-llm-tools" publish --no-git-checks --access public
           publish_if_needed "./packages/core/package.json" pnpm --filter "./packages/core" publish --no-git-checks --access public
           publish_if_needed "./packages/react/package.json" pnpm --filter "./packages/react" publish --no-git-checks --access public
           publish_if_needed "./packages/expo/package.json" pnpm --filter "./packages/expo" publish --no-git-checks --access public

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,11 +11,11 @@
       "npmPublish": false
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
+      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox','core-llm-tools'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
     }],
     "@semantic-release/github",
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json"],
+      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json", "packages/core-llm-tools/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }]
   ]

--- a/packages/core-llm-tools/LICENSE
+++ b/packages/core-llm-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Equational Applications LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -1,0 +1,87 @@
+# @equationalapplications/core-llm-tools
+
+Platform-agnostic Gemini tool schemas and a capability-based scope injector.
+
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-tools?label=core-llm-tools)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
+[![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-tools?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
+> A universal registry bridging the gap between Edge AI (Expo/React Native) and Cloud Agents (Cloud Run).
+
+## Overview
+
+`core-llm-tools` provides a shared, strictly-typed repository of JSON Function Declarations (Tools) for Gemini models. By decoupling the **Tool Interface** (the schema) from the **Tool Implementation** (the executing code), this package allows client-side triage agents and heavy backend cloud agents to share the exact same capabilities without importing Node.js server dependencies into the browser or mobile environments.
+
+It also introduces a robust **Capability-Based Scope Model** (similar to OAuth 2.0), ensuring that Large Language Models are only injected with tools the user has explicitly authorized.
+
+## Features
+
+- **Platform-Agnostic** — Zero runtime dependencies. Pure TypeScript. Compiles safely for Node.js, the browser, and the React Native Hermes engine.
+- **Capability-Based Security** — Tools are locked behind specific scopes (e.g., `calendar:read`, `messages:send`). The injector ensures models cannot hallucinate calls to unauthorized tools.
+- **Strict Typings** — Provides rigid interfaces (`AgentToolSchema`, `AgentToolManifest`) to prevent malformed Gemini API requests.
+- **Harmonized Edge/Cloud Routing** — Enables lightweight edge models (like Gemini Nano) to triage intents using the exact same schemas the heavy Cloud Run backend uses to execute them.
+
+## Installation
+
+```bash
+npm install @equationalapplications/core-llm-tools
+# or
+pnpm add @equationalapplications/core-llm-tools
+```
+
+## Quick Start
+
+### 1. Defining a Tool Manifest
+
+Tools are defined by wrapping a standard Gemini JSON schema with a required security scope.
+
+```typescript
+import { AgentToolManifest } from '@equationalapplications/core-llm-tools';
+
+export const getCalendarEventsManifest: AgentToolManifest = {
+  name: 'get_calendar_events',
+  scope: 'calendar:read', // Security scope required to use this tool
+  schema: {
+    name: 'get_calendar_events',
+    description: 'Fetch the user\'s schedule for a given date.',
+    parameters: {
+      type: 'object',
+      properties: {
+        date: { type: 'string' }
+      }
+    }
+  }
+};
+```
+
+### 2. Injecting Authorized Tools
+
+At runtime, use `buildAuthorizedSchemaArray` to filter your tool library against the user's granted permissions before passing them to the LLM.
+
+```typescript
+import { buildAuthorizedSchemaArray, escalateToCloudManifest } from '@equationalapplications/core-llm-tools';
+
+// 1. Gather all manifests known to your app
+const allAppTools = [escalateToCloudManifest, getCalendarEventsManifest];
+
+// 2. Fetch the user's authorized scopes from your DB (e.g., SQLite/Postgres)
+const userGrantedScopes = ['calendar:read'];
+
+// 3. The injector automatically includes 'core' tools and authorized scoped tools
+const schemasForLlm = buildAuthorizedSchemaArray(allAppTools, userGrantedScopes);
+
+// 4. Pass safely to Gemini
+const response = await ai.models.generateContent({
+  model: 'gemini-2.5-flash',
+  contents: userInput,
+  tools: [{ functionDeclarations: schemasForLlm }],
+});
+```
+
+## Helpful Resources & Links
+
+- [Google Gen AI: Function Calling Tutorial](https://ai.google.dev/gemini-api/docs/function-calling) — Official docs on how the JSON schemas in this package interact with Gemini models.
+- [JSON Schema Specification](https://json-schema.org/understanding-json-schema/) — Structural foundation for `AgentToolSchema.parameters`.
+- [OAuth 2.0 Scope Concepts](https://oauth.net/2/scope/) — Inspiration behind the capability-based `AgentScope` permission hierarchy.
+- [@google/adk (Agent Development Kit)](https://github.com/google/adk-python) — Server-side framework used by Cloud Run backends to wrap and execute the schemas defined in this package.

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -37,7 +37,7 @@ pnpm add @equationalapplications/core-llm-tools
 Tools are defined by wrapping a standard Gemini JSON schema with a required security scope.
 
 ```typescript
-import { AgentToolManifest } from '@equationalapplications/core-llm-tools';
+import type { AgentToolManifest } from '@equationalapplications/core-llm-tools';
 
 export const getCalendarEventsManifest: AgentToolManifest = {
   name: 'get_calendar_events',

--- a/packages/core-llm-tools/__tests__/injector.test.ts
+++ b/packages/core-llm-tools/__tests__/injector.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { buildAuthorizedSchemaArray } from '../src/injector';
+import type { AgentToolManifest } from '../src/types';
+
+const coreTool: AgentToolManifest = {
+  name: 'get_current_time',
+  scope: 'core',
+  schema: { name: 'get_current_time', description: 'Get time' },
+};
+
+const calendarReadTool: AgentToolManifest = {
+  name: 'read_calendar',
+  scope: 'calendar:read',
+  schema: { name: 'read_calendar', description: 'Read calendar events' },
+};
+
+const messagesSendTool: AgentToolManifest = {
+  name: 'send_message',
+  scope: 'messages:send',
+  schema: { name: 'send_message', description: 'Send a message' },
+};
+
+describe('buildAuthorizedSchemaArray', () => {
+  it('always includes core-scoped tools regardless of granted scopes', () => {
+    const result = buildAuthorizedSchemaArray([coreTool, calendarReadTool], []);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(coreTool.schema);
+  });
+
+  it('includes non-core tool when its scope is granted', () => {
+    const result = buildAuthorizedSchemaArray(
+      [coreTool, calendarReadTool],
+      ['calendar:read']
+    );
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(calendarReadTool.schema);
+  });
+
+  it('excludes non-core tool when its scope is not granted', () => {
+    const result = buildAuthorizedSchemaArray(
+      [coreTool, calendarReadTool, messagesSendTool],
+      ['calendar:read']
+    );
+    expect(result).toHaveLength(2);
+    expect(result).not.toContainEqual(messagesSendTool.schema);
+  });
+
+  it('returns raw schema objects, not manifest wrappers', () => {
+    const result = buildAuthorizedSchemaArray([coreTool], []);
+    expect(result[0]).not.toHaveProperty('scope');
+    expect(result[0]).toHaveProperty('name');
+    expect(result[0]).toHaveProperty('description');
+  });
+
+  it('returns empty array when manifests list is empty', () => {
+    const result = buildAuthorizedSchemaArray([], ['calendar:read']);
+    expect(result).toHaveLength(0);
+  });
+
+  it('includes multiple granted scopes', () => {
+    const result = buildAuthorizedSchemaArray(
+      [coreTool, calendarReadTool, messagesSendTool],
+      ['calendar:read', 'messages:send']
+    );
+    expect(result).toHaveLength(3);
+  });
+});

--- a/packages/core-llm-tools/__tests__/manifests.test.ts
+++ b/packages/core-llm-tools/__tests__/manifests.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getCurrentTimeManifest, escalateToCloudManifest } from '../src/manifests/core';
+
+describe('getCurrentTimeManifest', () => {
+  it('has name get_current_time', () => {
+    expect(getCurrentTimeManifest.name).toBe('get_current_time');
+  });
+
+  it('scope is core', () => {
+    expect(getCurrentTimeManifest.scope).toBe('core');
+  });
+
+  it('schema name matches manifest name', () => {
+    expect(getCurrentTimeManifest.schema.name).toBe(getCurrentTimeManifest.name);
+  });
+
+  it('schema has a description', () => {
+    expect(getCurrentTimeManifest.schema.description.length).toBeGreaterThan(0);
+  });
+
+  it('schema parameters is empty object properties', () => {
+    expect(getCurrentTimeManifest.schema.parameters?.properties).toEqual({});
+  });
+});
+
+describe('escalateToCloudManifest', () => {
+  it('has name escalate_to_cloud_agent', () => {
+    expect(escalateToCloudManifest.name).toBe('escalate_to_cloud_agent');
+  });
+
+  it('scope is core', () => {
+    expect(escalateToCloudManifest.scope).toBe('core');
+  });
+
+  it('schema name matches manifest name', () => {
+    expect(escalateToCloudManifest.schema.name).toBe(escalateToCloudManifest.name);
+  });
+
+  it('schema has a description', () => {
+    expect(escalateToCloudManifest.schema.description.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core-llm-tools/__tests__/types.test.ts
+++ b/packages/core-llm-tools/__tests__/types.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { AgentScope, AgentToolManifest } from '../src/types';
+
+describe('AgentScope', () => {
+  it('accepts all valid scope literals', () => {
+    const scopes: AgentScope[] = [
+      'core',
+      'location:read',
+      'calendar:read',
+      'calendar:write',
+      'messages:send',
+      'memory:read',
+      'memory:write',
+    ];
+    expectTypeOf(scopes).toMatchTypeOf<AgentScope[]>();
+  });
+});
+
+describe('AgentToolManifest', () => {
+  it('requires name, scope, and schema fields', () => {
+    expectTypeOf<AgentToolManifest>().toHaveProperty('name');
+    expectTypeOf<AgentToolManifest>().toHaveProperty('scope');
+    expectTypeOf<AgentToolManifest>().toHaveProperty('schema');
+  });
+
+  it('schema requires name and description', () => {
+    type Schema = AgentToolManifest['schema'];
+    expectTypeOf<Schema>().toHaveProperty('name');
+    expectTypeOf<Schema>().toHaveProperty('description');
+  });
+});

--- a/packages/core-llm-tools/package.json
+++ b/packages/core-llm-tools/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@equationalapplications/core-llm-tools",
+  "version": "0.1.0",
+  "description": "Platform-agnostic Gemini tool schemas and capability-based scope injector.",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/core-llm-tools/src/index.ts
+++ b/packages/core-llm-tools/src/index.ts
@@ -1,0 +1,3 @@
+export type { AgentScope, AgentToolManifest, AgentToolSchema } from './types';
+export { buildAuthorizedSchemaArray } from './injector';
+export { getCurrentTimeManifest, escalateToCloudManifest } from './manifests/core';

--- a/packages/core-llm-tools/src/injector.ts
+++ b/packages/core-llm-tools/src/injector.ts
@@ -1,0 +1,13 @@
+import type { AgentToolManifest, AgentToolSchema } from './types';
+
+export function buildAuthorizedSchemaArray(
+  availableManifests: AgentToolManifest[],
+  userGrantedScopes: string[]
+): AgentToolSchema[] {
+  return availableManifests
+    .filter(
+      (manifest) =>
+        manifest.scope === 'core' || userGrantedScopes.includes(manifest.scope)
+    )
+    .map((manifest) => manifest.schema);
+}

--- a/packages/core-llm-tools/src/manifests/core.ts
+++ b/packages/core-llm-tools/src/manifests/core.ts
@@ -1,0 +1,23 @@
+import type { AgentToolManifest } from '../types';
+
+export const getCurrentTimeManifest: AgentToolManifest = {
+  name: 'get_current_time',
+  scope: 'core',
+  schema: {
+    name: 'get_current_time',
+    description:
+      'Get the exact current date and time. Always call this tool first if resolving relative temporal words like "today" or "tomorrow".',
+    parameters: { type: 'object', properties: {} },
+  },
+};
+
+export const escalateToCloudManifest: AgentToolManifest = {
+  name: 'escalate_to_cloud_agent',
+  scope: 'core',
+  schema: {
+    name: 'escalate_to_cloud_agent',
+    description:
+      'Use this tool when the user asks to schedule a reminder, perform deep memory searches, or execute a complex workflow that requires cloud resources.',
+    parameters: { type: 'object', properties: {} },
+  },
+};

--- a/packages/core-llm-tools/src/types.ts
+++ b/packages/core-llm-tools/src/types.ts
@@ -11,7 +11,7 @@ export interface AgentToolSchema {
   name: string;
   description: string;
   parameters?: {
-    type: 'object' | 'string' | 'number' | 'boolean' | 'array';
+    type: 'object';
     properties: Record<string, unknown>;
     required?: string[];
   };

--- a/packages/core-llm-tools/src/types.ts
+++ b/packages/core-llm-tools/src/types.ts
@@ -1,0 +1,24 @@
+export type AgentScope =
+  | 'core'
+  | 'location:read'
+  | 'calendar:read'
+  | 'calendar:write'
+  | 'messages:send'
+  | 'memory:read'
+  | 'memory:write';
+
+export interface AgentToolSchema {
+  name: string;
+  description: string;
+  parameters?: {
+    type: 'object' | 'string' | 'number' | 'boolean' | 'array';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export interface AgentToolManifest {
+  name: string;
+  scope: AgentScope;
+  schema: AgentToolSchema;
+}

--- a/packages/core-llm-tools/tsconfig.json
+++ b/packages/core-llm-tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core-llm-tools/tsup.config.ts
+++ b/packages/core-llm-tools/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+});

--- a/packages/core-llm-tools/vitest.config.ts
+++ b/packages/core-llm-tools/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,18 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/core-llm-tools:
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.13)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
   packages/expo:
     dependencies:
       '@equationalapplications/core-llm-wiki':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "./packages/core" },
     { "path": "./packages/expo" },
     { "path": "./packages/react" },
-    { "path": "./packages/prisma-outbox" }
+    { "path": "./packages/prisma-outbox" },
+    { "path": "./packages/core-llm-tools" }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: [
       'packages/core/__tests__/**/*.test.ts',
       'packages/expo/__tests__/**/*.test.ts',
+      'packages/core-llm-tools/__tests__/**/*.test.ts',
     ],
     environment: 'node',
   },


### PR DESCRIPTION
## Summary

- New `@equationalapplications/core-llm-tools` workspace package — pure TypeScript, no Node/browser deps, runs in Expo Hermes and Cloud Run alike
- Exports `AgentScope` union + `AgentToolManifest`/`AgentToolSchema` interfaces, Core-tier manifests (`get_current_time`, `escalate_to_cloud_agent`), and `buildAuthorizedSchemaArray` injector
- Injector filters manifests by capability scope: `core`-scoped tools always injected; all others require explicit user grant

## Test Plan

- [ ] `pnpm --filter @equationalapplications/core-llm-tools exec vitest run` → 18 tests pass (3 files: types, manifests, injector)
- [ ] `pnpm test` → full suite passes with no regressions (616 tests across all packages)
- [ ] `pnpm --filter @equationalapplications/core-llm-tools build` → `dist/index.js`, `dist/index.mjs`, `dist/index.d.ts` emit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)