### PR TITLE
docs: README SEO/DX improvements — nav bars, ecosystem tables, absolute links, npm metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ flowchart TB
 
 ## Monorepo Packages
 
-`expo-llm-wiki` is organized as a monorepo with four packages:
+`expo-llm-wiki` is organized as a monorepo with five packages:
 
 | Package | Purpose | Platform |
 |---------|---------|----------|
@@ -103,6 +103,7 @@ flowchart TB
 | **`@equationalapplications/expo-llm-wiki`** | Persistent episodic memory | Expo, React Native |
 | **`@equationalapplications/react-llm-wiki`** | Persistent episodic memory | Web (React) |
 | **`@equationalapplications/core-llm-tools`** | Platform-agnostic Gemini tool schemas and capability-based scope injector | Node.js, browser, React Native |
+| **`@equationalapplications/prisma-outbox`** | Sync SQLite outbox events to Prisma-backed database (transactional outbox pattern) | Node.js |
 
 **Choose your package:**
 - **Expo/React Native app?** → `@equationalapplications/expo-llm-wiki`

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ flowchart TB
 
 The wiki packages share the same core API and database schema. The core library is **framework-agnostic**; `@equationalapplications/expo-llm-wiki` injects the Expo adapter, while `@equationalapplications/core-llm-wiki` and `@equationalapplications/react-llm-wiki` require your application to provide a SQLite adapter.
 
-`@equationalapplications/core-llm-tools` is a standalone, zero-dependency package — it has no SQLite or framework dependencies and can be used independently of the wiki packages. See [packages/core-llm-tools/README.md](packages/core-llm-tools/README.md) for full documentation.
+`@equationalapplications/core-llm-tools` is a standalone, zero-dependency package — it has no SQLite or framework dependencies and can be used independently of the wiki packages. See [packages/core-llm-tools/README.md](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) for full documentation.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 [![GitHub Tag](https://img.shields.io/github/v/tag/equationalapplications/expo-llm-wiki?label=github%20tag)](https://github.com/equationalapplications/expo-llm-wiki/tags)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/LICENSE)
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=@equationalapplications/expo-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)<br>
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=@equationalapplications/react-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)<br>
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=@equationalapplications/core-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)<br>
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-tools?label=@equationalapplications/core-llm-tools)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-tools?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 ## Persistent, episodic memory for AI Agents.
 

--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ expo-llm-wiki implements multiple security layers to protect against common vuln
 - **Timeout Configuration**: `deletionHookTimeoutMs` (default 30s) caps per-row deletion latency. Tune per deployment constraints.
 - **Force-Delete Escape Hatch**: `forceDeleteIgnoreRankerHook` bypasses hook failures (use ONLY when ANN backend permanently decommissioned).
 
-See [SECURITY.md](./SECURITY.md) for VectorRanker adapter security guidance (SQL injection, entity isolation, credential scrubbing, resource limits).
+See [SECURITY.md](https://github.com/equationalapplications/expo-llm-wiki/blob/main/SECURITY.md) for VectorRanker adapter security guidance (SQL injection, entity isolation, credential scrubbing, resource limits).
 
 ## React Component Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=expo)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)<br>
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)<br>
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=core)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=@equationalapplications/expo-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=@equationalapplications/react-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=@equationalapplications/core-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-tools?label=@equationalapplications/core-llm-tools)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-tools?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
 
 ## Persistent, episodic memory for AI Agents.
 
@@ -92,21 +93,25 @@ flowchart TB
 
 ## Monorepo Packages
 
-`expo-llm-wiki` is organized as a monorepo with three packages, each optimized for different platforms:
+`expo-llm-wiki` is organized as a monorepo with four packages:
 
-| Package | Platform | SQLite Adapter | Size (Minzipped) |
-|---------|----------|---|---|
-| **`@equationalapplications/core-llm-wiki`** | Node.js, any platform | User-provided (e.g., `better-sqlite3`) | ~23 kB |
-| **`@equationalapplications/expo-llm-wiki`** | Expo, React Native | `expo-sqlite` (built-in) | ~24 kB |
-| **`@equationalapplications/react-llm-wiki`** | Web (React) | User-provided (e.g., `sql.js`) | ~25 kB |
+| Package | Purpose | Platform |
+|---------|---------|----------|
+| **`@equationalapplications/core-llm-wiki`** | Persistent episodic memory | Node.js, any platform |
+| **`@equationalapplications/expo-llm-wiki`** | Persistent episodic memory | Expo, React Native |
+| **`@equationalapplications/react-llm-wiki`** | Persistent episodic memory | Web (React) |
+| **`@equationalapplications/core-llm-tools`** | Platform-agnostic Gemini tool schemas and capability-based scope injector | Node.js, browser, React Native |
 
 **Choose your package:**
 - **Expo/React Native app?** → `@equationalapplications/expo-llm-wiki`
 - **React web app (CRA, Vite + React, Next.js client)?** → `@equationalapplications/react-llm-wiki` + `sql.js`
 - **Vanilla JS or non-React framework?** → `@equationalapplications/core-llm-wiki` + `sql.js`
 - **Node.js backend?** → `@equationalapplications/core-llm-wiki` + `better-sqlite3`
+- **Gemini tool schemas + capability-scoped injection?** → `@equationalapplications/core-llm-tools`
 
-All packages share the same core API and database schema. The core library is **framework-agnostic**; `@equationalapplications/expo-llm-wiki` injects the Expo adapter, while `@equationalapplications/core-llm-wiki` and `@equationalapplications/react-llm-wiki` require your application to provide a SQLite adapter.
+The wiki packages share the same core API and database schema. The core library is **framework-agnostic**; `@equationalapplications/expo-llm-wiki` injects the Expo adapter, while `@equationalapplications/core-llm-wiki` and `@equationalapplications/react-llm-wiki` require your application to provide a SQLite adapter.
+
+`@equationalapplications/core-llm-tools` is a standalone, zero-dependency package — it has no SQLite or framework dependencies and can be used independently of the wiki packages. See [packages/core-llm-tools/README.md](packages/core-llm-tools/README.md) for full documentation.
 
 ## Installation
 

--- a/docs/superpowers/specs/2026-05-28-readme-seo-dx-improvements.md
+++ b/docs/superpowers/specs/2026-05-28-readme-seo-dx-improvements.md
@@ -1,0 +1,153 @@
+# README SEO & DX Improvements
+
+**Date:** 2026-05-28  
+**Scope:** All 6 READMEs (root + 5 packages) + all 5 `package.json` files
+
+---
+
+## Goals
+
+1. Fix broken relative links on the npm registry (no `repository.directory` set)
+2. Add nav bar links for GitHub, Playground, Changelog, Issues
+3. Improve `keywords` + `description` in `package.json` for npm search discoverability
+4. Add Monorepo Ecosystem cross-link table to each package README
+5. Improve opening taglines with key search terms (RAG, episodic memory, multi-agent, multi-tiered)
+6. Link external dependencies inline at first reference
+
+---
+
+## Section 1 — Nav Bar
+
+Added immediately after the badge block in each README:
+
+```markdown
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
+```
+
+- `core-llm-tools`: omit Playground link (playground uses `react-llm-wiki`, not tools)
+- All other packages: include all four links
+
+---
+
+## Section 2 — package.json Fields
+
+### Repository / bugs / homepage
+
+Add to all 5 package `package.json` files:
+
+```json
+"repository": {
+  "type": "git",
+  "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+  "directory": "packages/<name>"
+},
+"bugs": {
+  "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+},
+"homepage": "https://github.com/equationalapplications/expo-llm-wiki#readme"
+```
+
+`directory` values:
+- `core-llm-wiki` → `packages/core`
+- `expo-llm-wiki` → `packages/expo`
+- `react-llm-wiki` → `packages/react`
+- `prisma-outbox` → `packages/prisma-outbox`
+- `core-llm-tools` → `packages/core-llm-tools`
+
+### description improvements
+
+| Package | New description |
+|---------|----------------|
+| `core-llm-wiki` | "Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter." |
+| `expo-llm-wiki` | "Local-first LLM memory for Expo and React Native. Combines the core semantic search and extraction engine with expo-sqlite and ready-to-use React hooks." |
+| `react-llm-wiki` | "In-browser LLM memory for React web apps. Wraps the core engine with sql.js WebAssembly SQLite for a complete, zero-server RAG experience." |
+| `prisma-outbox` | "Sync core-llm-wiki SQLite outbox events to your Prisma-backed database using the transactional outbox pattern — at-least-once delivery with ordering guarantees." |
+| `core-llm-tools` | "Zero-dependency Gemini function-calling schemas and capability-scoped tool injection for edge AI agents. Works in Node.js, browser, and React Native (Hermes)." |
+
+### keywords
+
+| Package | Keywords |
+|---------|----------|
+| `core-llm-wiki` | `llm-memory`, `ai-memory`, `rag`, `sqlite`, `vector-search`, `episodic-memory`, `semantic-memory`, `multi-agent`, `typescript`, `gemini`, `openai` |
+| `expo-llm-wiki` | above + `expo`, `react-native`, `expo-sqlite`, `mobile-ai`, `local-first` |
+| `react-llm-wiki` | core set + `react`, `react-hooks`, `web-ai`, `sql.js`, `wasm`, `in-browser` |
+| `prisma-outbox` | `prisma`, `outbox-pattern`, `transactional-outbox`, `event-sync`, `sqlite-sync`, `at-least-once` |
+| `core-llm-tools` | `gemini`, `function-calling`, `tool-schemas`, `llm-tools`, `capability-scopes`, `react-native`, `edge-ai`, `typescript` |
+
+---
+
+## Section 3 — Absolute URL Fixes
+
+Relative links break on npm when `repository.directory` is not set (and even with it, some paths still resolve incorrectly for monorepos). All relative links replaced with absolute GitHub URLs.
+
+| Relative pattern | Absolute form |
+|-----------------|---------------|
+| `LICENSE` (badge target) | `https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/<pkg>/LICENSE` |
+| `SECURITY.md` | `https://github.com/equationalapplications/expo-llm-wiki/blob/main/SECURITY.md` |
+| `docs/superpowers/specs/<file>` | `https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/superpowers/specs/<file>` |
+| `packages/core/README.md#<anchor>` | `https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#<anchor>` |
+| `#<issue-number>` | `https://github.com/equationalapplications/expo-llm-wiki/issues/<number>` |
+
+---
+
+## Section 4 — Monorepo Ecosystem Section
+
+Added near the bottom of each package README (before footer line). Current package bolded + not linked. Siblings linked to npm.
+
+```markdown
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| **`@equationalapplications/core-llm-wiki`** | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| [`@equationalapplications/expo-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) | Expo / React Native adapter with `expo-sqlite` |
+| [`@equationalapplications/react-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) | React hooks + web adapter with `sql.js` |
+| [`@equationalapplications/prisma-outbox`](https://www.npmjs.com/package/@equationalapplications/prisma-outbox) | Sync SQLite outbox events to Prisma in a transaction |
+| [`@equationalapplications/core-llm-tools`](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) | Platform-agnostic Gemini tool schemas + capability scope injector |
+```
+
+Each README bolds its own row and links the other four.
+
+---
+
+## Section 5 — Taglines & External Dependency Links
+
+### Opening taglines
+
+| Package | Tagline |
+|---------|---------|
+| `core-llm-wiki` | "Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter." |
+| `expo-llm-wiki` | "Local-first LLM memory for Expo and React Native. Combines the core semantic search and extraction engine with expo-sqlite and ready-to-use React hooks." |
+| `react-llm-wiki` | "In-browser LLM memory for React web apps. Wraps the core engine with sql.js WebAssembly SQLite for a complete, zero-server RAG experience." |
+| `prisma-outbox` | "Sync `@equationalapplications/core-llm-wiki` SQLite outbox events to your Prisma-backed database using the transactional outbox pattern — at-least-once delivery with ordering guarantees." |
+| `core-llm-tools` | "Zero-dependency Gemini function-calling schemas and capability-scoped tool injection for edge AI agents. Works in Node.js, browser, and React Native (Hermes)." |
+
+### External dependency links (inline, first reference only)
+
+| Dependency | Link |
+|-----------|------|
+| `sql.js` | https://github.com/sql-js/sql.js |
+| `better-sqlite3` | https://github.com/WiseLibs/better-sqlite3 |
+| `sqlite-vec` | https://github.com/asg017/sqlite-vec |
+| `sqlite-vss` | https://github.com/asg017/sqlite-vss |
+| `expo-sqlite` | https://docs.expo.dev/versions/latest/sdk/sqlite/ |
+| `MiniSearch` | https://github.com/lucaong/minisearch |
+
+---
+
+## Files Changed
+
+### READMEs
+- `README.md` (root) — nav bar + badge label updates already done in kv/tools-docs
+- `packages/core/README.md`
+- `packages/expo/README.md`
+- `packages/react/README.md`
+- `packages/prisma-outbox/README.md`
+- `packages/core-llm-tools/README.md`
+
+### package.json
+- `packages/core/package.json`
+- `packages/expo/package.json`
+- `packages/react/package.json`
+- `packages/prisma-outbox/package.json`
+- `packages/core-llm-tools/package.json`

--- a/docs/superpowers/specs/2026-05-28-readme-seo-dx-improvements.md
+++ b/docs/superpowers/specs/2026-05-28-readme-seo-dx-improvements.md
@@ -44,15 +44,18 @@ Add to all 5 package `package.json` files:
 "bugs": {
   "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
 },
-"homepage": "https://github.com/equationalapplications/expo-llm-wiki#readme"
+"homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/<name>#readme"
 ```
 
-`directory` values:
-- `core-llm-wiki` → `packages/core`
-- `expo-llm-wiki` → `packages/expo`
-- `react-llm-wiki` → `packages/react`
-- `prisma-outbox` → `packages/prisma-outbox`
-- `core-llm-tools` → `packages/core-llm-tools`
+`directory` and `homepage` values per package:
+
+| Package | `directory` | `homepage` |
+|---------|------------|-----------|
+| `core-llm-wiki` | `packages/core` | `.../tree/main/packages/core#readme` |
+| `expo-llm-wiki` | `packages/expo` | `.../tree/main/packages/expo#readme` |
+| `react-llm-wiki` | `packages/react` | `.../tree/main/packages/react#readme` |
+| `prisma-outbox` | `packages/prisma-outbox` | `.../tree/main/packages/prisma-outbox#readme` |
+| `core-llm-tools` | `packages/core-llm-tools` | `.../tree/main/packages/core-llm-tools#readme` |
 
 ### description improvements
 

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -1,11 +1,13 @@
 # @equationalapplications/core-llm-tools
 
-Platform-agnostic Gemini tool schemas and a capability-based scope injector.
+Zero-dependency Gemini function-calling schemas and capability-scoped tool injection for edge AI agents. Works in Node.js, browser, and React Native (Hermes).
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-tools?label=core-llm-tools)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
 [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-tools?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 > A universal registry bridging the gap between Edge AI (Expo/React Native) and Cloud Agents (Cloud Run).
 
@@ -85,3 +87,17 @@ const response = await ai.models.generateContent({
 - [JSON Schema Specification](https://json-schema.org/understanding-json-schema/) — Structural foundation for `AgentToolSchema.parameters`.
 - [OAuth 2.0 Scope Concepts](https://oauth.net/2/scope/) — Inspiration behind the capability-based `AgentScope` permission hierarchy.
 - [@google/adk (Agent Development Kit)](https://github.com/google/adk-python) — Server-side framework used by Cloud Run backends to wrap and execute the schemas defined in this package.
+
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| [`@equationalapplications/core-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| [`@equationalapplications/expo-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) | Expo / React Native adapter with `expo-sqlite` |
+| [`@equationalapplications/react-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) | React hooks + web adapter with `sql.js` |
+| [`@equationalapplications/prisma-outbox`](https://www.npmjs.com/package/@equationalapplications/prisma-outbox) | Sync SQLite outbox events to Prisma in a transaction |
+| **`@equationalapplications/core-llm-tools`** | Platform-agnostic Gemini tool schemas + capability scope injector |
+
+---
+
+Made with ❤️ by Equational Applications LLC. [https://equationalapplications.com/](https://equationalapplications.com/)

--- a/packages/core-llm-tools/package.json
+++ b/packages/core-llm-tools/package.json
@@ -25,7 +25,16 @@
     "README.md"
   ],
   "license": "MIT",
-  "keywords": ["gemini", "function-calling", "tool-schemas", "llm-tools", "capability-scopes", "react-native", "edge-ai", "typescript"],
+  "keywords": [
+    "gemini",
+    "function-calling",
+    "tool-schemas",
+    "llm-tools",
+    "capability-scopes",
+    "react-native",
+    "edge-ai",
+    "typescript"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",

--- a/packages/core-llm-tools/package.json
+++ b/packages/core-llm-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/core-llm-tools",
   "version": "4.10.0",
-  "description": "Platform-agnostic Gemini tool schemas and capability-based scope injector.",
+  "description": "Zero-dependency Gemini function-calling schemas and capability-scoped tool injection for edge AI agents. Works in Node.js, browser, and React Native (Hermes).",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -25,6 +25,16 @@
     "README.md"
   ],
   "license": "MIT",
+  "keywords": ["gemini", "function-calling", "tool-schemas", "llm-tools", "capability-scopes", "react-native", "edge-ai", "typescript"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/core-llm-tools"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/core-llm-tools#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,10 +1,12 @@
 # @equationalapplications/core-llm-wiki
 
-Pure TypeScript business logic for LLM Wiki Memory.
+Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=core)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
@@ -12,7 +14,7 @@ Pure TypeScript business logic for LLM Wiki Memory.
 
 - **Platform-agnostic** — Zero runtime dependencies; works with any SQLite driver via the `SQLiteAdapter` interface
 - **Semantic search** — Vector embeddings via your LLM's `embed` function, ranked by cosine similarity
-- **Keyword fallback** — MiniSearch in-memory index for offline/degraded scenarios when embeddings unavailable
+- **Keyword fallback** — [MiniSearch](https://github.com/lucaong/minisearch) in-memory index for offline/degraded scenarios when embeddings unavailable
 - **Retrieval tuning** — Per-call overrides for `maxResults`, `preFilterLimit`, `hybridWeight`, `tierWeights`, and `includeZeroWeightEntities`
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with per-entity score multipliers (`tierWeights`); optional `factScores` and `metadata` for explainability
 - **Immutable vs mutable facts** — Use `WikiFact.source_type` to distinguish document-sourced facts (`immutable_document`) from derived or user-provided facts (`librarian_inferred`, `user_stated`, `user_confirmed`). Immutable document facts are not rewritten by `runLibrarian()` or `runHeal()` and can only be removed by `forget()` or re-ingesting.
@@ -240,7 +242,7 @@ When `preFilterLimit: 50` is set with 1000 facts, cosine similarity is computed 
 
 ## Pluggable Vector Retrieval
 
-When your entity corpus grows, in-process cosine similarity scoring becomes a bottleneck. The optional **`VectorRanker`** interface lets you delegate semantic ranking to **sqlite-vec**, **sqlite-vss**, or an external vector database while `WikiMemory` handles embedding validation, hybrid scoring, and tier-2 row hydration.
+When your entity corpus grows, in-process cosine similarity scoring becomes a bottleneck. The optional **`VectorRanker`** interface lets you delegate semantic ranking to [**sqlite-vec**](https://github.com/asg017/sqlite-vec), [**sqlite-vss**](https://github.com/asg017/sqlite-vss), or an external vector database while `WikiMemory` handles embedding validation, hybrid scoring, and tier-2 row hydration.
 
 ### `VectorRanker` purpose
 
@@ -455,7 +457,7 @@ If implementing a custom `VectorRanker`:
 - **Credential Scrubbing**: Strip API keys, tokens, connection strings from thrown errors before surfacing to host.
 - **Resource Limits**: Cap `limit` and `candidateIds.length` to prevent DoS. Do NOT retain `vector` references beyond callback scope — blocks GC.
 
-See [SECURITY.md](../../SECURITY.md) for complete adapter security guidance and code examples.
+See [SECURITY.md](https://github.com/equationalapplications/expo-llm-wiki/blob/main/SECURITY.md) for complete adapter security guidance and code examples.
 
 ### Host Application Security
 
@@ -585,7 +587,7 @@ export interface SQLiteAdapter {
 
 `@equationalapplications/expo-llm-wiki` provides a pre-built adapter for Expo/React Native. For web and Node.js, implement the interface yourself — examples below.
 
-**Browser (sql.js):**
+**Browser ([sql.js](https://github.com/sql-js/sql.js)):**
 
 ```typescript
 import initSqlJs from 'sql.js';
@@ -625,7 +627,7 @@ const adapter: SQLiteAdapter = {
 };
 ```
 
-**Node.js (better-sqlite3):**
+**Node.js ([better-sqlite3](https://github.com/WiseLibs/better-sqlite3)):**
 
 ```typescript
 import Database from 'better-sqlite3';
@@ -689,6 +691,16 @@ The flowchart shows:
 4. **Two-phase SELECT**: phase 1 scores all/filtered facts with minimal columns, phase 2 fetches full rows for winners
 5. **Hybrid scoring** to blend semantic and keyword rankings
 6. **Vector caching** on full scans only; reads with `preFilterLimit` active skip cache population
+
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| **`@equationalapplications/core-llm-wiki`** | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| [`@equationalapplications/expo-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) | Expo / React Native adapter with `expo-sqlite` |
+| [`@equationalapplications/react-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) | React hooks + web adapter with `sql.js` |
+| [`@equationalapplications/prisma-outbox`](https://www.npmjs.com/package/@equationalapplications/prisma-outbox) | Sync SQLite outbox events to Prisma in a transaction |
+| [`@equationalapplications/core-llm-tools`](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) | Platform-agnostic Gemini tool schemas + capability scope injector |
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,19 @@
     "README.md"
   ],
   "license": "MIT",
-  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai"],
+  "keywords": [
+    "llm-memory",
+    "ai-memory",
+    "rag",
+    "sqlite",
+    "vector-search",
+    "episodic-memory",
+    "semantic-memory",
+    "multi-agent",
+    "typescript",
+    "gemini",
+    "openai"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/core-llm-wiki",
   "version": "4.10.0",
-  "description": "DB-agnostic core logic for LLM Wiki Memory.",
+  "description": "Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -30,6 +30,16 @@
     "README.md"
   ],
   "license": "MIT",
+  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/core#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -1,10 +1,12 @@
 # @equationalapplications/expo-llm-wiki
 
-Expo/React Native adapter for @equationalapplications/core-llm-wiki, powered by `expo-sqlite`.
+Local-first LLM memory for Expo and React Native. Combines the core semantic search and extraction engine with [`expo-sqlite`](https://docs.expo.dev/versions/latest/sdk/sqlite/) and ready-to-use React hooks.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fexpo-llm-wiki?label=npm)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki)
 [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fexpo-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/expo/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
@@ -311,6 +313,16 @@ const memory = await wiki.read(
 ```
 
 For full details on `{{mustache}}` prompt templating and the strict distinction between global auto-runs and runtime overrides, see [Prompt Management & Overrides](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#prompt-management--overrides) in `@equationalapplications/core-llm-wiki`.
+
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| [`@equationalapplications/core-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| **`@equationalapplications/expo-llm-wiki`** | Expo / React Native adapter with `expo-sqlite` |
+| [`@equationalapplications/react-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) | React hooks + web adapter with `sql.js` |
+| [`@equationalapplications/prisma-outbox`](https://www.npmjs.com/package/@equationalapplications/prisma-outbox) | Sync SQLite outbox events to Prisma in a transaction |
+| [`@equationalapplications/core-llm-tools`](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) | Platform-agnostic Gemini tool schemas + capability scope injector |
 
 ## License
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/expo-llm-wiki",
   "version": "4.10.0",
-  "description": "Expo/React Native adapter for @equationalapplications/core-llm-wiki.",
+  "description": "Local-first LLM memory for Expo and React Native. Combines the core semantic search and extraction engine with expo-sqlite and ready-to-use React hooks.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -30,6 +30,16 @@
     "README.md"
   ],
   "license": "MIT",
+  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai", "expo", "react-native", "expo-sqlite", "mobile-ai", "local-first"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/expo"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/expo#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -30,7 +30,24 @@
     "README.md"
   ],
   "license": "MIT",
-  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai", "expo", "react-native", "expo-sqlite", "mobile-ai", "local-first"],
+  "keywords": [
+    "llm-memory",
+    "ai-memory",
+    "rag",
+    "sqlite",
+    "vector-search",
+    "episodic-memory",
+    "semantic-memory",
+    "multi-agent",
+    "typescript",
+    "gemini",
+    "openai",
+    "expo",
+    "react-native",
+    "expo-sqlite",
+    "mobile-ai",
+    "local-first"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -1,10 +1,12 @@
 # @equationalapplications/prisma-outbox
 
-Prisma adapter for the [expo-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki) transactional outbox pattern.
+Sync [`@equationalapplications/core-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) SQLite outbox events to your Prisma-backed database using the transactional outbox pattern — at-least-once delivery with ordering guarantees.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fprisma-outbox?label=prisma-outbox)](https://www.npmjs.com/package/@equationalapplications/prisma-outbox)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 Polls the SQLite outbox table written by `@equationalapplications/core-llm-wiki` and syncs events to your Prisma-backed system inside a Prisma transaction, with configurable batch size, poll interval, error handling, and a concurrency guard.
 
@@ -91,3 +93,17 @@ worker.stop();
 ## Limitations
 
 - **Single-instance only.** The worker does not use row-level locking or leases. Running two `PrismaOutboxWorker` instances against the same SQLite file will cause duplicate Prisma writes. Run exactly one worker per SQLite database. `mapEvent` must still be idempotent to tolerate at-least-once delivery (acknowledgement can fail after a successful Prisma commit).
+
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| [`@equationalapplications/core-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| [`@equationalapplications/expo-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) | Expo / React Native adapter with `expo-sqlite` |
+| [`@equationalapplications/react-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) | React hooks + web adapter with `sql.js` |
+| **`@equationalapplications/prisma-outbox`** | Sync SQLite outbox events to Prisma in a transaction |
+| [`@equationalapplications/core-llm-tools`](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) | Platform-agnostic Gemini tool schemas + capability scope injector |
+
+---
+
+Made with ❤️ by Equational Applications LLC. [https://equationalapplications.com/](https://equationalapplications.com/)

--- a/packages/prisma-outbox/package.json
+++ b/packages/prisma-outbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/prisma-outbox",
   "version": "4.10.0",
-  "description": "Prisma adapter for the expo-llm-wiki transactional outbox pattern.",
+  "description": "Sync core-llm-wiki SQLite outbox events to your Prisma-backed database using the transactional outbox pattern — at-least-once delivery with ordering guarantees.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -25,6 +25,16 @@
     "README.md"
   ],
   "license": "MIT",
+  "keywords": ["prisma", "outbox-pattern", "transactional-outbox", "event-sync", "sqlite-sync", "at-least-once"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/prisma-outbox"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/prisma-outbox#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/prisma-outbox/package.json
+++ b/packages/prisma-outbox/package.json
@@ -25,7 +25,14 @@
     "README.md"
   ],
   "license": "MIT",
-  "keywords": ["prisma", "outbox-pattern", "transactional-outbox", "event-sync", "sqlite-sync", "at-least-once"],
+  "keywords": [
+    "prisma",
+    "outbox-pattern",
+    "transactional-outbox",
+    "event-sync",
+    "sqlite-sync",
+    "at-least-once"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,10 +1,12 @@
 # @equationalapplications/react-llm-wiki
 
-React hooks and web utilities for @equationalapplications/core-llm-wiki, designed for web and Expo.
+In-browser LLM memory for React web apps. Wraps the core engine with [`sql.js`](https://github.com/sql-js/sql.js) WebAssembly SQLite for a complete, zero-server RAG experience.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[Playground](https://equationalapplications.github.io/expo-llm-wiki/playground/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
@@ -433,6 +435,16 @@ The flowchart shows:
 4. **Two-phase SELECT**: phase 1 scores all/filtered facts with minimal columns, phase 2 fetches full rows for winners
 5. **Hybrid scoring** to blend semantic and keyword rankings
 6. **Vector caching** on full scans only; reads with `preFilterLimit` active skip cache population
+
+## Monorepo Ecosystem
+
+| Package | Description |
+|---------|-------------|
+| [`@equationalapplications/core-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) | Pure TypeScript core — DB-agnostic, bring your own SQLite adapter |
+| [`@equationalapplications/expo-llm-wiki`](https://www.npmjs.com/package/@equationalapplications/expo-llm-wiki) | Expo / React Native adapter with `expo-sqlite` |
+| **`@equationalapplications/react-llm-wiki`** | React hooks + web adapter with `sql.js` |
+| [`@equationalapplications/prisma-outbox`](https://www.npmjs.com/package/@equationalapplications/prisma-outbox) | Sync SQLite outbox events to Prisma in a transaction |
+| [`@equationalapplications/core-llm-tools`](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) | Platform-agnostic Gemini tool schemas + capability scope injector |
 
 ## License
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 # @equationalapplications/react-llm-wiki
 
-In-browser LLM memory for React web apps. Wraps the core engine with [`sql.js`](https://github.com/sql-js/sql.js) WebAssembly SQLite for a complete, zero-server RAG experience.
+In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., [`sql.js`](https://github.com/sql-js/sql.js) WebAssembly) for a complete, zero-server RAG experience.
 
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=react)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/react-llm-wiki",
   "version": "4.10.0",
-  "description": "React hooks and web utilities for LLM Wiki Memory.",
+  "description": "In-browser LLM memory for React web apps. Wraps the core engine with sql.js WebAssembly SQLite for a complete, zero-server RAG experience.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -23,6 +23,16 @@
     "README.md"
   ],
   "license": "MIT",
+  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai", "react", "react-hooks", "web-ai", "sql.js", "wasm", "in-browser"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/react"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/react#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,25 @@
     "README.md"
   ],
   "license": "MIT",
-  "keywords": ["llm-memory", "ai-memory", "rag", "sqlite", "vector-search", "episodic-memory", "semantic-memory", "multi-agent", "typescript", "gemini", "openai", "react", "react-hooks", "web-ai", "sql.js", "wasm", "in-browser"],
+  "keywords": [
+    "llm-memory",
+    "ai-memory",
+    "rag",
+    "sqlite",
+    "vector-search",
+    "episodic-memory",
+    "semantic-memory",
+    "multi-agent",
+    "typescript",
+    "gemini",
+    "openai",
+    "react",
+    "react-hooks",
+    "web-ai",
+    "sql.js",
+    "wasm",
+    "in-browser"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equationalapplications/react-llm-wiki",
   "version": "4.10.0",
-  "description": "In-browser LLM memory for React web apps. Wraps the core engine with sql.js WebAssembly SQLite for a complete, zero-server RAG experience.",
+  "description": "In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., sql.js WebAssembly) for a complete, zero-server RAG experience.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Adds nav bar (GitHub · Playground · Changelog · Issues) to all 6 READMEs; `core-llm-tools` omits Playground (not in playground app)
- Adds `@equationalapplications/core-llm-tools` package to root README monorepo table and badges
- Fixes all relative links (LICENSE badges, SECURITY.md) to absolute GitHub URLs — prevents 404s on npm registry
- Adds `repository`, `bugs`, `homepage`, `keywords`, and improved `description` fields to all 5 package `package.json` files for npm search discoverability
- Adds Monorepo Ecosystem cross-link table to each package README (current package bolded, siblings linked to npm)
- Updates opening taglines with SEO-relevant terms (RAG, episodic memory, multi-agent, hybrid LLM memory)
- Links external dependencies (MiniSearch, sqlite-vec, sqlite-vss, sql.js, better-sqlite3, expo-sqlite) at first reference in relevant READMEs

## Test Plan

- [x] `pnpm test` — all 35 tests pass
- [x] `pnpm run build` — build success
- [ ] Verify nav bar renders correctly on npm registry after publish
- [ ] Verify LICENSE badge links resolve on GitHub and npm
- [ ] Verify ecosystem table links resolve on npm registry