### PR TITLE
feat(core-llm-tools): add google_search built-in tool support

### DIFF
--- a/docs/superpowers/specs/2026-06-18-google-search-tool-design.md
+++ b/docs/superpowers/specs/2026-06-18-google-search-tool-design.md
@@ -1,6 +1,6 @@
 # Design: `google_search` Built-In Tool Support in `core-llm-tools`
 
-**Status:** Approved (design phase) — implementation plan pending
+**Status:** Implemented
 **Package:** `@equationalapplications/core-llm-tools`
 **Date:** 2026-06-18
 

--- a/docs/superpowers/specs/2026-06-18-google-search-tool-design.md
+++ b/docs/superpowers/specs/2026-06-18-google-search-tool-design.md
@@ -1,0 +1,171 @@
+# Design: `google_search` Built-In Tool Support in `core-llm-tools`
+
+**Status:** Approved (design phase) — implementation plan pending
+**Package:** `@equationalapplications/core-llm-tools`
+**Date:** 2026-06-18
+
+## Problem
+
+`core-llm-tools` models tools as `AgentToolManifest { name, scope, schema }`, where `schema`
+is a Gemini function-declaration (`name`, `description`, `parameters`) that the *consumer*
+implements and executes. Gemini's `google_search` tool (Search grounding,
+https://ai.google.dev/gemini-api/docs/google-search) is a different kind of tool: it is
+declared in the `tools[]` array as `{ google_search: {} }`, has no parameters, and is executed
+server-side by Google — there is no client-side handler to write. The current manifest shape
+and `buildAuthorizedSchemaArray` injector have no way to represent or emit this.
+
+## Goals
+
+- Let `google_search` be declared as a manifest and flow through the existing
+  scope-authorization model (`buildAuthorizedSchemaArray`'s capability filtering), without
+  inventing a parallel system.
+- No breaking change to the current `AgentToolManifest` / `AgentToolSchema` /
+  `buildAuthorizedSchemaArray` contract — existing consumers (e.g. Clanker's `generateReply`)
+  must keep compiling and behaving identically.
+- Design the manifest shape so future built-in tools (e.g. `code_execution`) can be added later
+  without another breaking change.
+
+## Non-Goals
+
+- Parsing or typing Gemini's response-side `groundingMetadata` (`webSearchQueries`,
+  `groundingChunks`, `groundingSupports`, `searchEntryPoint`). That is response handling, lives
+  in the calling backend (Clanker's `generateReply`), and has no dependency on this package's
+  request-side tool declarations.
+- Backend wiring in Clanker. Out of scope for this repo/package.
+
+## Design
+
+### 1. Manifest types (`packages/core-llm-tools/src/types.ts`)
+
+Split `AgentToolManifest` into a discriminated union. The function-declaration variant's `kind`
+field is **optional** so every existing manifest literal (no `kind` field) still type-checks
+unchanged:
+
+```ts
+export type BuiltInToolName = 'google_search';
+
+export interface FunctionToolManifest {
+  name: string;
+  scope: AgentScope;
+  kind?: 'function';
+  schema: AgentToolSchema;
+}
+
+export interface BuiltInToolManifest {
+  name: string;
+  scope: AgentScope;
+  kind: 'built_in';
+  builtIn: BuiltInToolName;
+}
+
+export type AgentToolManifest = FunctionToolManifest | BuiltInToolManifest;
+```
+
+`AgentToolSchema` is unchanged.
+
+### 2. New manifest (`packages/core-llm-tools/src/manifests/core.ts`)
+
+```ts
+export const googleSearchManifest: BuiltInToolManifest = {
+  name: 'google_search',
+  scope: 'core',
+  kind: 'built_in',
+  builtIn: 'google_search',
+};
+```
+
+Scope is `'core'`: grounding/search isn't a sensitive personal-data capability like
+`calendar:read` or `messages:send`, and the draft guidance calls for a Core-tier manifest. It is
+always injected, matching `get_current_time` / `escalate_to_cloud_agent`.
+
+### 3. Injector (`packages/core-llm-tools/src/injector.ts`)
+
+`buildAuthorizedSchemaArray` is kept **exactly as-is** (still function-declarations only) but
+gets a `@deprecated` JSDoc pointing at the new function — non-breaking, IDE-visible migration
+hint.
+
+New function returns the full Gemini `tools[]` array, mixing one `functionDeclarations` group
+with one entry per authorized built-in tool:
+
+```ts
+export type GeminiToolEntry =
+  | { functionDeclarations: AgentToolSchema[] }
+  | { [K in BuiltInToolName]: Record<string, never> };
+
+export function buildAuthorizedToolsArray(
+  availableManifests: AgentToolManifest[],
+  userGrantedScopes: string[]
+): GeminiToolEntry[] {
+  const authorized = availableManifests.filter(
+    (m) => m.scope === 'core' || userGrantedScopes.includes(m.scope)
+  );
+
+  const entries: GeminiToolEntry[] = [];
+
+  const fnSchemas = authorized
+    .filter((m): m is FunctionToolManifest => m.kind !== 'built_in')
+    .map((m) => m.schema);
+  if (fnSchemas.length > 0) entries.push({ functionDeclarations: fnSchemas });
+
+  for (const m of authorized) {
+    if (m.kind === 'built_in') {
+      entries.push({ [m.builtIn]: {} } as GeminiToolEntry);
+    }
+  }
+
+  return entries;
+}
+```
+
+The `functionDeclarations` group is omitted entirely when no function manifests are authorized,
+keeping the payload minimal.
+
+### 4. Exports (`packages/core-llm-tools/src/index.ts`)
+
+Add: `FunctionToolManifest`, `BuiltInToolManifest`, `BuiltInToolName`, `GeminiToolEntry`,
+`buildAuthorizedToolsArray`, `googleSearchManifest`.
+
+### 5. Tests (`packages/core-llm-tools/__tests__/`)
+
+- Old function-only manifest literal (no `kind` field) still authorizes/filters correctly
+  through both `buildAuthorizedSchemaArray` and `buildAuthorizedToolsArray`.
+- `buildAuthorizedToolsArray` with a mix of function + built-in manifests produces a two-entry
+  array (`functionDeclarations` + `google_search`).
+- Zero authorized function manifests → `functionDeclarations` entry omitted.
+- Zero authorized built-in manifests → no built-in entries in output.
+- `googleSearchManifest` (scope `'core'`) is included regardless of `userGrantedScopes`.
+- A manifest passed with `kind: undefined` explicitly (rather than omitted) still routes to the
+  function-declarations branch (filter predicate is `m.kind !== 'built_in'`, not a truthiness
+  check) — confirms the fallback narrowing is robust either way the field is absent.
+
+### 6. Documentation (`packages/core-llm-tools/README.md`)
+
+Add a "Built-In Tools (Grounding)" section under Quick Start showing `googleSearchManifest` +
+`buildAuthorizedToolsArray` wired into a `generateContent` call, with a one-line note that
+parsing `groundingMetadata` for citations is the caller's responsibility.
+
+### 7. Versioning
+
+Semver-minor (no breaking changes): `4.11.0` → `4.12.0` for `core-llm-tools`.
+
+## Implementation Notes
+
+- **Dynamic key assertion:** `entries.push({ [m.builtIn]: {} } as GeminiToolEntry)` needs the
+  `as` cast because TS can't statically map a runtime string (`m.builtIn`) to a computed key in
+  a mapped union type. This is safe only because `m.builtIn` is typed as `BuiltInToolName`
+  (currently the single literal `'google_search'`) — never widen that field to `string` without
+  re-deriving the cast's safety.
+- **Future built-in parameters:** today every built-in tool's payload is `{}`. If Google ships a
+  built-in tool that takes config (e.g. a hypothetical `{ code_execution: { timeout: 5000 } }`),
+  extend `BuiltInToolManifest` with an optional `config?: Record<string, unknown>` and have the
+  injector spread it in (`{ [m.builtIn]: m.config ?? {} }`). Not needed now — YAGNI until a
+  second built-in tool with parameters actually exists.
+
+## Testing Strategy
+
+Unit tests only (`vitest run` in `packages/core-llm-tools`) — this package is pure, dependency-free
+schema/filtering logic with no I/O, consistent with its existing test suite.
+
+## Open Questions
+
+None — all resolved during brainstorming (manifest shape, injector API, scope assignment).

--- a/docs/superpowers/specs/2026-06-18-okf-export-design.md
+++ b/docs/superpowers/specs/2026-06-18-okf-export-design.md
@@ -1,0 +1,236 @@
+# Design: Open Knowledge Format (OKF) Export
+
+**Status:** Approved (design phase) — implementation plan pending
+**Packages:** new `@equationalapplications/core-okf` (`packages/okf`); `packages/core` adapter
+**Date:** 2026-06-18
+**Spec reference:** Open Knowledge Format v0.1, https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
+## Problem
+
+OKF v0.1 is a vendor-neutral spec for representing knowledge as a directory of markdown files
+with YAML frontmatter, where the file path is the concept's identity. `expo-llm-wiki`'s
+`WikiMemory` already models knowledge as facts/tasks/events per entity and already exports it
+(`exportDump()` → JSON `MemoryDump`, optionally rendered to human-readable markdown via
+`formatMemoryDump()`). Neither existing export is OKF-compliant: `formatMemoryDump()` produces
+one combined markdown file per entity with no frontmatter and no per-concept addressability.
+Producing a real OKF bundle would let users open their wiki memory in any OKF-aware tool,
+editor, or visualizer, and host it as a plain git repo.
+
+## Goals
+
+- Add an OKF-compliant export path: `MemoryDump` → a flat list of `{ path, content }` files
+  forming a valid OKF bundle (root `index.md`, per-entity `index.md`/`log.md`/concept files).
+- Build the OKF-generic parts (frontmatter serialization, concept/index/log builders) as a
+  standalone, zero-dependency package with no knowledge of this wiki's data model, so other
+  projects in (or outside) this monorepo can produce/consume OKF bundles without depending on
+  `core-llm-wiki`.
+- Conform to the v0.1 normative rules: `type` is the only required frontmatter key; `index.md`
+  files carry no frontmatter except the bundle root, which may declare `okf_version: "0.1"`;
+  `log.md` uses ISO 8601 `YYYY-MM-DD` date headings, newest first; reserved filenames `index.md`
+  and `log.md` are never used as concept files.
+
+## Non-Goals
+
+- **No import.** Reading a foreign OKF bundle back into `WikiMemory` requires deciding how
+  arbitrary third-party `type` values map to facts/tasks/events — a separate, larger problem.
+  This spec is export-only.
+- **No archiving.** Output is a flat file list, same shape as `formatMemoryDump`'s existing
+  `files[]`. No tar/zip dependency is introduced — no current consumer of `formatMemoryDump`
+  archives its output either (`ExportTab.tsx` renders it directly); packaging into an archive is
+  a UI-layer concern left to callers.
+- **No changes to `exportDump()` / `importDump()` / `ImportExportService`.** The OKF export is
+  an additional, alternate formatting function alongside `formatMemoryDump`, not a replacement.
+
+## Design
+
+### 1. `packages/okf` (`@equationalapplications/core-okf`) — generic OKF primitives
+
+New zero-dependency package, structured like `core-llm-tools`. No knowledge of `WikiFact`,
+`WikiTask`, or `WikiEvent`.
+
+**`src/types.ts`**
+
+```ts
+export interface OkfFrontmatter {
+  type: string;
+  title?: string;
+  description?: string;
+  resource?: string;
+  tags?: string[];
+  timestamp?: string; // ISO 8601
+  [key: string]: unknown; // producers may add custom keys; consumers must preserve them
+}
+
+export interface OkfIndexEntry {
+  path: string; // bundle-relative, e.g. 'entities/alice/facts/fact_123.md'
+  title: string;
+  description?: string;
+}
+
+export interface OkfIndexSection {
+  heading: string; // e.g. 'Facts'
+  entries: OkfIndexEntry[];
+}
+
+export interface OkfLogEntry {
+  date: string; // ISO 8601 YYYY-MM-DD, used for grouping/heading
+  text: string; // rendered line content; may include a markdown link
+}
+
+export interface OkfFile {
+  path: string;
+  content: string;
+}
+```
+
+**`src/frontmatter.ts`**
+
+```ts
+export function serializeFrontmatter(fm: OkfFrontmatter): string;
+```
+
+Emits a `---\n...\n---\n` YAML block. Supports the value shapes frontmatter actually needs:
+string, number, boolean, null scalars, and `string[]` (rendered as a block list). Quotes a
+string value when it contains `:`, `#`, leading/trailing whitespace, or would otherwise parse
+as a YAML bool/null/number literal (e.g. a tag literally named `"true"`).
+
+**`src/concept.ts`**
+
+```ts
+export function buildConceptDocument(fm: OkfFrontmatter, body: string): string;
+```
+
+Concatenates the serialized frontmatter block and the body. `type` is the only field this
+function requires to be present (enforced by `OkfFrontmatter.type` being non-optional) — matches
+the spec's "minimally opinionated" requirement.
+
+**`src/index-md.ts`**
+
+```ts
+export function buildIndexMd(sections: OkfIndexSection[]): string;
+export function buildRootIndexMd(okfVersion: string, sections: OkfIndexSection[]): string;
+```
+
+`buildIndexMd` renders `## <heading>` per section and `* [title](path) - description` (or
+`* [title](path)` when `description` is absent) per entry, no frontmatter. `buildRootIndexMd`
+wraps the same body in a frontmatter block containing only `okf_version` — the one normative
+exception where an `index.md` may carry frontmatter.
+
+**`src/log-md.ts`**
+
+```ts
+export function buildLogMd(entries: OkfLogEntry[]): string;
+```
+
+Groups entries by `date`, sorts groups descending (newest first), renders `## YYYY-MM-DD` per
+group and `- <text>` per entry underneath, in the order given within each group.
+
+**`src/index.ts`** — barrel export of all of the above.
+
+### 2. `packages/core/src/utils/formatOkfBundle.ts` — wiki adapter
+
+Maps a `MemoryDump` to an OKF bundle using `core-okf`'s primitives. New file, parallel to the
+existing `formatMemoryDump.ts`.
+
+**Shared sanitizer:** `formatMemoryDump.ts`'s entity-directory-name sanitization
+(`formatEntityFileName`'s internal logic, currently inlined) is extracted to a shared
+`sanitizeForFilename(value: string): string` helper (new file
+`packages/core/src/utils/sanitizeForFilename.ts`) and reused by both formatters — same
+collision-hash/length-limit behavior as today, no behavior change to `formatMemoryDump`'s
+existing output.
+
+**Layout per entity** (`<dir>` = `sanitizeForFilename(entityId)`):
+
+```
+entities/<dir>/facts/<fact.id>.md
+entities/<dir>/tasks/<task.id>.md
+entities/<dir>/log.md
+entities/<dir>/index.md
+index.md                              (bundle root)
+```
+
+Fact/task `id` values (`fact_<24hex>` / `task_<24hex>`, from `generateId()`) are already
+filesystem-safe and used directly as filenames — no sanitization needed there.
+
+**Fact → concept doc** (`entities/<dir>/facts/<fact.id>.md`, `type: 'fact'`):
+- `title`: `fact.title`
+- `tags`: `fact.tags`
+- `timestamp`: `new Date(fact.updated_at).toISOString()`
+- `resource`: `fact.source_ref ?? undefined` (key omitted when `null`)
+- custom keys: `id`, `entity_id`, `confidence`, `source_type`, `source_hash`, `created_at`,
+  `access_count`, `last_accessed_at`, `deleted_at`
+- **excluded:** `embedding_blob` (binary; stripped the same way `formatMemoryDump` already
+  strips it from its manifest)
+- body: `fact.body`
+
+**Task → concept doc** (`entities/<dir>/tasks/<task.id>.md`, `type: 'task'`):
+- `title`: `task.description`
+- `timestamp`: `new Date(task.updated_at).toISOString()`
+- custom keys: `id`, `entity_id`, `status`, `priority`, `created_at`, `resolved_at`, `deleted_at`
+- body: `''` (a task's only content is its description, already used as `title`)
+
+**Events → `entities/<dir>/log.md`:** one `OkfLogEntry` per event — `date` is `event.created_at`
+formatted as `YYYY-MM-DD`; `text` is `` (event.event_type) <summary> ``, where `<summary>` is
+`event.summary` unless `event.related_entry_id` matches an exported fact's `id` for that entity,
+in which case it's wrapped as a markdown link to that fact's relative path
+(`[summary](../facts/<id>.md)`) — this is what realizes OKF's "a link asserts a relationship"
+convention for this bundle.
+
+**Entity `index.md`** (`entities/<dir>/index.md`): two sections, "Facts" and "Tasks", each entry
+linking to its concept file (`title` = the doc's `title`, `description` omitted — neither facts
+nor tasks have a dedicated description field distinct from their title/body). A plain line below
+the sections links to `./log.md` for the event timeline.
+
+**Root `index.md`**: `buildRootIndexMd('0.1', ...)` with one section "Entities", one entry per
+exported entity linking to `entities/<dir>/index.md`.
+
+**Function signature:**
+
+```ts
+export function formatOkfBundle(dump: MemoryDump): { files: OkfFile[] };
+```
+
+### 3. Exports
+
+- `packages/okf/src/index.ts`: all types + `serializeFrontmatter`, `buildConceptDocument`,
+  `buildIndexMd`, `buildRootIndexMd`, `buildLogMd`.
+- `packages/core/src/index.ts`: add `formatOkfBundle` to the existing barrel export (alongside
+  `formatMemoryDump`).
+- `packages/core/package.json`: add `@equationalapplications/core-okf` as a `workspace:*`
+  dependency.
+
+### 4. Testing Strategy
+
+Unit tests only, `vitest run`, no I/O — same style as `core-llm-tools`.
+
+`packages/okf/__tests__/`:
+- `frontmatter.test.ts` — scalar types, string-array tags, quoting rules (colon, `#`, leading/
+  trailing whitespace, boolean/null/number-literal-shaped strings), key ordering, omission of
+  `undefined` values.
+- `concept.test.ts` — frontmatter + body concatenation, minimal case (`type` only).
+- `index-md.test.ts` — multiple sections, entries with/without `description`, empty sections
+  list, `buildRootIndexMd`'s `okf_version` frontmatter.
+- `log-md.test.ts` — date grouping/descending sort, multiple entries per date, ISO heading
+  format, empty entries list.
+
+`packages/core/__tests__/`:
+- `formatOkfBundle.test.ts` — full bundle shape for a multi-entity, multi-fact/task/event dump:
+  correct file paths, frontmatter field mapping per fact/task, `embedding_blob` exclusion,
+  `related_entry_id` → markdown-link resolution in `log.md` (including the case where the
+  referenced fact isn't in the export and the link is omitted), root + entity `index.md` link
+  correctness, reserved-filename collision (an entity/fact/task whose sanitized id would be
+  `index` or `log` — confirm the existing hash-suffix collision logic in
+  `sanitizeForFilename` still produces a non-colliding name).
+- `sanitizeForFilename.test.ts` — extracted from the existing inline logic; same assertions
+  `formatMemoryDump.test.ts` already implicitly relies on, now testable directly.
+
+### 5. Versioning
+
+New package starts in the monorepo's lockstep version scheme (currently `4.11.0`, matching
+every other published package's `package.json`). `packages/core`'s change is additive
+(semver-minor).
+
+## Open Questions
+
+None — all resolved during brainstorming (package boundary, export-only scope, concept mapping,
+directory layout).

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -81,6 +81,38 @@ const response = await ai.models.generateContent({
 });
 ```
 
+### 3. Built-In Tools (Grounding)
+
+Some Gemini capabilities, like [Google Search grounding](https://ai.google.dev/gemini-api/docs/google-search),
+are built-in tools executed server-side by Google rather than function declarations your code
+implements. These are declared with `kind: 'built_in'` and flow through the same
+capability-scope model as function tools, via `buildAuthorizedToolsArray`:
+
+```typescript
+import { buildAuthorizedToolsArray, googleSearchManifest, escalateToCloudManifest } from '@equationalapplications/core-llm-tools';
+
+const allAppTools = [escalateToCloudManifest, googleSearchManifest];
+const userGrantedScopes: string[] = [];
+
+// Returns the full Gemini tools[] array: a functionDeclarations group (if any
+// function tools are authorized) plus one entry per authorized built-in tool.
+const tools = buildAuthorizedToolsArray(allAppTools, userGrantedScopes);
+// => [{ functionDeclarations: [...] }, { google_search: {} }]
+
+const response = await ai.models.generateContent({
+  model: 'gemini-2.5-flash',
+  contents: userInput,
+  tools,
+});
+```
+
+> **Note:** When the model uses `google_search`, Gemini returns a `groundingMetadata` object
+> (search queries, source citations, etc.) on the response. Parsing that metadata is the
+> caller's responsibility — this package only handles the request-side tool declaration.
+
+`buildAuthorizedSchemaArray` is still available for callers that only ever use function tools,
+but is deprecated in favor of `buildAuthorizedToolsArray`.
+
 ## Helpful Resources & Links
 
 - [Google Gen AI: Function Calling Tutorial](https://ai.google.dev/gemini-api/docs/function-calling) — Official docs on how the JSON schemas in this package interact with Gemini models.

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -86,12 +86,15 @@ const response = await ai.models.generateContent({
 Some Gemini capabilities, like [Google Search grounding](https://ai.google.dev/gemini-api/docs/google-search),
 are built-in tools executed server-side by Google rather than function declarations your code
 implements. These are declared with `kind: 'built_in'` and flow through the same
-capability-scope model as function tools, via `buildAuthorizedToolsArray`:
+capability-scope model as function tools, via `buildAuthorizedToolsArray`.
+Use `AnyAgentToolManifest` when mixing function and built-in manifests;
+`AgentToolManifest` remains the function-only type for existing callers:
 
 ```typescript
+import type { AnyAgentToolManifest } from '@equationalapplications/core-llm-tools';
 import { buildAuthorizedToolsArray, googleSearchManifest, escalateToCloudManifest } from '@equationalapplications/core-llm-tools';
 
-const allAppTools = [escalateToCloudManifest, googleSearchManifest];
+const allAppTools: AnyAgentToolManifest[] = [escalateToCloudManifest, googleSearchManifest];
 const userGrantedScopes: string[] = [];
 
 // Returns the full Gemini tools[] array: a functionDeclarations group (if any

--- a/packages/core-llm-tools/__tests__/index.test.ts
+++ b/packages/core-llm-tools/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import * as CoreLlmTools from '../src/index';
+
+describe('package public API', () => {
+  it('exports buildAuthorizedSchemaArray and buildAuthorizedToolsArray', () => {
+    expect(typeof CoreLlmTools.buildAuthorizedSchemaArray).toBe('function');
+    expect(typeof CoreLlmTools.buildAuthorizedToolsArray).toBe('function');
+  });
+
+  it('exports googleSearchManifest alongside existing core manifests', () => {
+    expect(CoreLlmTools.googleSearchManifest.name).toBe('google_search');
+    expect(CoreLlmTools.getCurrentTimeManifest.name).toBe('get_current_time');
+    expect(CoreLlmTools.escalateToCloudManifest.name).toBe('escalate_to_cloud_agent');
+  });
+});

--- a/packages/core-llm-tools/__tests__/injector.test.ts
+++ b/packages/core-llm-tools/__tests__/injector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildAuthorizedSchemaArray, buildAuthorizedToolsArray } from '../src/injector';
-import type { AgentToolManifest, BuiltInToolManifest } from '../src/types';
+import type { AgentToolManifest, AnyAgentToolManifest, BuiltInToolManifest } from '../src/types';
 
 const coreTool: AgentToolManifest = {
   name: 'get_current_time',
@@ -79,16 +79,19 @@ describe('buildAuthorizedSchemaArray', () => {
     expect(result).toHaveLength(3);
   });
 
-  it('ignores built-in manifests (deprecated — use buildAuthorizedToolsArray)', () => {
-    const result = buildAuthorizedSchemaArray([coreTool, googleSearchTool], []);
+  it('ignores built-in manifests at runtime when callers bypass types', () => {
+    const mixedTools = [coreTool, googleSearchTool] as unknown as AgentToolManifest[];
+    const result = buildAuthorizedSchemaArray(mixedTools, []);
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(coreTool.schema);
   });
 });
 
 describe('buildAuthorizedToolsArray', () => {
+  const mixedTools: AnyAgentToolManifest[] = [coreTool, googleSearchTool];
+
   it('returns a functionDeclarations entry plus one entry per authorized built-in tool', () => {
-    const result = buildAuthorizedToolsArray([coreTool, googleSearchTool], []);
+    const result = buildAuthorizedToolsArray(mixedTools, []);
     expect(result).toHaveLength(2);
     expect(result).toContainEqual({ functionDeclarations: [coreTool.schema] });
     expect(result).toContainEqual({ google_search: {} });
@@ -113,7 +116,7 @@ describe('buildAuthorizedToolsArray', () => {
 
   it('excludes a non-core built-in tool scope mismatch and a non-core function tool together', () => {
     const result = buildAuthorizedToolsArray(
-      [calendarReadTool, googleSearchTool],
+      [calendarReadTool, googleSearchTool] satisfies AnyAgentToolManifest[],
       []
     );
     expect(result).toHaveLength(1);

--- a/packages/core-llm-tools/__tests__/injector.test.ts
+++ b/packages/core-llm-tools/__tests__/injector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildAuthorizedSchemaArray } from '../src/injector';
-import type { AgentToolManifest } from '../src/types';
+import { buildAuthorizedSchemaArray, buildAuthorizedToolsArray } from '../src/injector';
+import type { AgentToolManifest, BuiltInToolManifest } from '../src/types';
 
 const coreTool: AgentToolManifest = {
   name: 'get_current_time',
@@ -18,6 +18,20 @@ const messagesSendTool: AgentToolManifest = {
   name: 'send_message',
   scope: 'messages:send',
   schema: { name: 'send_message', description: 'Send a message' },
+};
+
+const explicitUndefinedKindTool: AgentToolManifest = {
+  name: 'explicit_undefined_kind',
+  scope: 'core',
+  kind: undefined,
+  schema: { name: 'explicit_undefined_kind', description: 'explicit undefined kind' },
+};
+
+const googleSearchTool: BuiltInToolManifest = {
+  name: 'google_search',
+  scope: 'core',
+  kind: 'built_in',
+  builtIn: 'google_search',
 };
 
 describe('buildAuthorizedSchemaArray', () => {
@@ -63,5 +77,58 @@ describe('buildAuthorizedSchemaArray', () => {
       ['calendar:read', 'messages:send']
     );
     expect(result).toHaveLength(3);
+  });
+
+  it('ignores built-in manifests (deprecated — use buildAuthorizedToolsArray)', () => {
+    const result = buildAuthorizedSchemaArray([coreTool, googleSearchTool], []);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(coreTool.schema);
+  });
+});
+
+describe('buildAuthorizedToolsArray', () => {
+  it('returns a functionDeclarations entry plus one entry per authorized built-in tool', () => {
+    const result = buildAuthorizedToolsArray([coreTool, googleSearchTool], []);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ functionDeclarations: [coreTool.schema] });
+    expect(result).toContainEqual({ google_search: {} });
+  });
+
+  it('omits the functionDeclarations entry when no function manifests are authorized', () => {
+    const result = buildAuthorizedToolsArray([googleSearchTool], []);
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual({ google_search: {} });
+  });
+
+  it('omits built-in entries when none are authorized', () => {
+    const result = buildAuthorizedToolsArray([coreTool], []);
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual({ functionDeclarations: [coreTool.schema] });
+  });
+
+  it('always includes core-scoped built-in tools regardless of granted scopes', () => {
+    const result = buildAuthorizedToolsArray([googleSearchTool], []);
+    expect(result).toContainEqual({ google_search: {} });
+  });
+
+  it('excludes a non-core built-in tool scope mismatch and a non-core function tool together', () => {
+    const result = buildAuthorizedToolsArray(
+      [calendarReadTool, googleSearchTool],
+      []
+    );
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual({ google_search: {} });
+  });
+
+  it('treats an explicit kind: undefined manifest as a function manifest', () => {
+    const result = buildAuthorizedToolsArray([explicitUndefinedKindTool], []);
+    expect(result).toContainEqual({
+      functionDeclarations: [explicitUndefinedKindTool.schema],
+    });
+  });
+
+  it('returns an empty array when manifests list is empty', () => {
+    const result = buildAuthorizedToolsArray([], ['calendar:read']);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/core-llm-tools/__tests__/manifests.test.ts
+++ b/packages/core-llm-tools/__tests__/manifests.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCurrentTimeManifest, escalateToCloudManifest } from '../src/manifests/core';
+import { getCurrentTimeManifest, escalateToCloudManifest, googleSearchManifest } from '../src/manifests/core';
 
 describe('getCurrentTimeManifest', () => {
   it('has name get_current_time', () => {
@@ -38,5 +38,23 @@ describe('escalateToCloudManifest', () => {
 
   it('schema has a description', () => {
     expect(escalateToCloudManifest.schema.description.length).toBeGreaterThan(0);
+  });
+});
+
+describe('googleSearchManifest', () => {
+  it('has name google_search', () => {
+    expect(googleSearchManifest.name).toBe('google_search');
+  });
+
+  it('scope is core', () => {
+    expect(googleSearchManifest.scope).toBe('core');
+  });
+
+  it('kind is built_in', () => {
+    expect(googleSearchManifest.kind).toBe('built_in');
+  });
+
+  it('builtIn is google_search', () => {
+    expect(googleSearchManifest.builtIn).toBe('google_search');
   });
 });

--- a/packages/core-llm-tools/__tests__/types.test.ts
+++ b/packages/core-llm-tools/__tests__/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { AgentScope, AgentToolManifest } from '../src/types';
+import type {
+  AgentScope,
+  AgentToolManifest,
+  FunctionToolManifest,
+  BuiltInToolManifest,
+  BuiltInToolName,
+} from '../src/types';
 
 describe('AgentScope', () => {
   it('accepts all valid scope literals', () => {
@@ -16,16 +22,58 @@ describe('AgentScope', () => {
   });
 });
 
-describe('AgentToolManifest', () => {
+describe('FunctionToolManifest', () => {
   it('requires name, scope, and schema fields', () => {
-    expectTypeOf<AgentToolManifest>().toHaveProperty('name');
-    expectTypeOf<AgentToolManifest>().toHaveProperty('scope');
-    expectTypeOf<AgentToolManifest>().toHaveProperty('schema');
+    expectTypeOf<FunctionToolManifest>().toHaveProperty('name');
+    expectTypeOf<FunctionToolManifest>().toHaveProperty('scope');
+    expectTypeOf<FunctionToolManifest>().toHaveProperty('schema');
   });
 
   it('schema requires name and description', () => {
-    type Schema = AgentToolManifest['schema'];
+    type Schema = FunctionToolManifest['schema'];
     expectTypeOf<Schema>().toHaveProperty('name');
     expectTypeOf<Schema>().toHaveProperty('description');
+  });
+
+  it('kind is optional and, when present, is the literal "function"', () => {
+    expectTypeOf<FunctionToolManifest['kind']>().toEqualTypeOf<'function' | undefined>();
+  });
+
+  it('a manifest literal without a kind field type-checks as FunctionToolManifest', () => {
+    const manifest: FunctionToolManifest = {
+      name: 'legacy_tool',
+      scope: 'core',
+      schema: { name: 'legacy_tool', description: 'no kind field' },
+    };
+    expectTypeOf(manifest).toMatchTypeOf<FunctionToolManifest>();
+  });
+});
+
+describe('BuiltInToolManifest', () => {
+  it('requires name, scope, kind, and builtIn fields', () => {
+    expectTypeOf<BuiltInToolManifest>().toHaveProperty('name');
+    expectTypeOf<BuiltInToolManifest>().toHaveProperty('scope');
+    expectTypeOf<BuiltInToolManifest>().toHaveProperty('kind');
+    expectTypeOf<BuiltInToolManifest>().toHaveProperty('builtIn');
+  });
+
+  it('kind is the literal "built_in"', () => {
+    expectTypeOf<BuiltInToolManifest['kind']>().toEqualTypeOf<'built_in'>();
+  });
+
+  it('builtIn is constrained to BuiltInToolName', () => {
+    expectTypeOf<BuiltInToolManifest['builtIn']>().toEqualTypeOf<BuiltInToolName>();
+  });
+});
+
+describe('AgentToolManifest', () => {
+  it('is the union of FunctionToolManifest and BuiltInToolManifest', () => {
+    expectTypeOf<AgentToolManifest>().toEqualTypeOf<FunctionToolManifest | BuiltInToolManifest>();
+  });
+});
+
+describe('BuiltInToolName', () => {
+  it('includes "google_search"', () => {
+    expectTypeOf<'google_search'>().toMatchTypeOf<BuiltInToolName>();
   });
 });

--- a/packages/core-llm-tools/__tests__/types.test.ts
+++ b/packages/core-llm-tools/__tests__/types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expectTypeOf } from 'vitest';
 import type {
   AgentScope,
   AgentToolManifest,
+  AnyAgentToolManifest,
   FunctionToolManifest,
   BuiltInToolManifest,
   BuiltInToolName,
@@ -64,11 +65,32 @@ describe('BuiltInToolManifest', () => {
   it('builtIn is constrained to BuiltInToolName', () => {
     expectTypeOf<BuiltInToolManifest['builtIn']>().toEqualTypeOf<BuiltInToolName>();
   });
+
+  it('name matches builtIn (both BuiltInToolName)', () => {
+    expectTypeOf<BuiltInToolManifest['name']>().toEqualTypeOf<BuiltInToolName>();
+  });
 });
 
 describe('AgentToolManifest', () => {
+  it('is an alias for FunctionToolManifest', () => {
+    expectTypeOf<AgentToolManifest>().toEqualTypeOf<FunctionToolManifest>();
+  });
+
+  it('allows direct schema access without narrowing', () => {
+    const manifest: AgentToolManifest = {
+      name: 'legacy_tool',
+      scope: 'core',
+      schema: { name: 'legacy_tool', description: 'stable contract' },
+    };
+    expectTypeOf(manifest.schema).toMatchTypeOf<FunctionToolManifest['schema']>();
+  });
+});
+
+describe('AnyAgentToolManifest', () => {
   it('is the union of FunctionToolManifest and BuiltInToolManifest', () => {
-    expectTypeOf<AgentToolManifest>().toEqualTypeOf<FunctionToolManifest | BuiltInToolManifest>();
+    expectTypeOf<AnyAgentToolManifest>().toEqualTypeOf<
+      FunctionToolManifest | BuiltInToolManifest
+    >();
   });
 });
 

--- a/packages/core-llm-tools/src/index.ts
+++ b/packages/core-llm-tools/src/index.ts
@@ -2,6 +2,7 @@ export type {
   AgentScope,
   AgentToolManifest,
   AgentToolSchema,
+  AnyAgentToolManifest,
   FunctionToolManifest,
   BuiltInToolManifest,
   BuiltInToolName,

--- a/packages/core-llm-tools/src/index.ts
+++ b/packages/core-llm-tools/src/index.ts
@@ -1,3 +1,18 @@
-export type { AgentScope, AgentToolManifest, AgentToolSchema } from './types';
-export { buildAuthorizedSchemaArray } from './injector';
-export { getCurrentTimeManifest, escalateToCloudManifest } from './manifests/core';
+export type {
+  AgentScope,
+  AgentToolManifest,
+  AgentToolSchema,
+  FunctionToolManifest,
+  BuiltInToolManifest,
+  BuiltInToolName,
+} from './types';
+export {
+  buildAuthorizedSchemaArray,
+  buildAuthorizedToolsArray,
+} from './injector';
+export type { GeminiToolEntry } from './injector';
+export {
+  getCurrentTimeManifest,
+  escalateToCloudManifest,
+  googleSearchManifest,
+} from './manifests/core';

--- a/packages/core-llm-tools/src/injector.ts
+++ b/packages/core-llm-tools/src/injector.ts
@@ -1,6 +1,7 @@
 import type {
   AgentToolManifest,
   AgentToolSchema,
+  AnyAgentToolManifest,
   BuiltInToolName,
   FunctionToolManifest,
 } from './types';
@@ -20,7 +21,7 @@ export function buildAuthorizedSchemaArray(
         manifest.scope === 'core' || userGrantedScopes.includes(manifest.scope)
     )
     .filter(
-      (manifest): manifest is FunctionToolManifest => manifest.kind !== 'built_in'
+      (manifest): manifest is FunctionToolManifest => 'schema' in manifest
     )
     .map((manifest) => manifest.schema);
 }
@@ -36,7 +37,7 @@ export type GeminiToolEntry =
  * group, plus one entry per authorized built-in tool.
  */
 export function buildAuthorizedToolsArray(
-  availableManifests: AgentToolManifest[],
+  availableManifests: AnyAgentToolManifest[],
   userGrantedScopes: string[]
 ): GeminiToolEntry[] {
   const authorized = availableManifests.filter(

--- a/packages/core-llm-tools/src/injector.ts
+++ b/packages/core-llm-tools/src/injector.ts
@@ -1,5 +1,15 @@
-import type { AgentToolManifest, AgentToolSchema } from './types';
+import type {
+  AgentToolManifest,
+  AgentToolSchema,
+  BuiltInToolName,
+  FunctionToolManifest,
+} from './types';
 
+/**
+ * @deprecated Use buildAuthorizedToolsArray instead — it returns the full Gemini
+ * tools[] array, including built-in tools like google_search. This function only
+ * ever returns function-declaration schemas; built-in manifests are ignored.
+ */
 export function buildAuthorizedSchemaArray(
   availableManifests: AgentToolManifest[],
   userGrantedScopes: string[]
@@ -9,5 +19,45 @@ export function buildAuthorizedSchemaArray(
       (manifest) =>
         manifest.scope === 'core' || userGrantedScopes.includes(manifest.scope)
     )
+    .filter(
+      (manifest): manifest is FunctionToolManifest => manifest.kind !== 'built_in'
+    )
     .map((manifest) => manifest.schema);
+}
+
+/** One entry of a Gemini `tools[]` array: a function-declarations group, or a built-in tool. */
+export type GeminiToolEntry =
+  | { functionDeclarations: AgentToolSchema[] }
+  | { [K in BuiltInToolName]: Record<string, never> };
+
+/**
+ * Filters manifests by granted scope (core-scoped manifests always pass) and
+ * returns the full Gemini tools[] array: at most one functionDeclarations
+ * group, plus one entry per authorized built-in tool.
+ */
+export function buildAuthorizedToolsArray(
+  availableManifests: AgentToolManifest[],
+  userGrantedScopes: string[]
+): GeminiToolEntry[] {
+  const authorized = availableManifests.filter(
+    (manifest) =>
+      manifest.scope === 'core' || userGrantedScopes.includes(manifest.scope)
+  );
+
+  const entries: GeminiToolEntry[] = [];
+
+  const fnSchemas = authorized
+    .filter(
+      (manifest): manifest is FunctionToolManifest => manifest.kind !== 'built_in'
+    )
+    .map((manifest) => manifest.schema);
+  if (fnSchemas.length > 0) entries.push({ functionDeclarations: fnSchemas });
+
+  for (const manifest of authorized) {
+    if (manifest.kind === 'built_in') {
+      entries.push({ [manifest.builtIn]: {} } as GeminiToolEntry);
+    }
+  }
+
+  return entries;
 }

--- a/packages/core-llm-tools/src/manifests/core.ts
+++ b/packages/core-llm-tools/src/manifests/core.ts
@@ -1,4 +1,4 @@
-import type { AgentToolManifest } from '../types';
+import type { AgentToolManifest, BuiltInToolManifest } from '../types';
 
 export const getCurrentTimeManifest: AgentToolManifest = {
   name: 'get_current_time',
@@ -20,4 +20,11 @@ export const escalateToCloudManifest: AgentToolManifest = {
       'Use this tool when the user asks to schedule a reminder, perform deep memory searches, or execute a complex workflow that requires cloud resources.',
     parameters: { type: 'object', properties: {} },
   },
+};
+
+export const googleSearchManifest: BuiltInToolManifest = {
+  name: 'google_search',
+  scope: 'core',
+  kind: 'built_in',
+  builtIn: 'google_search',
 };

--- a/packages/core-llm-tools/src/types.ts
+++ b/packages/core-llm-tools/src/types.ts
@@ -31,10 +31,14 @@ export interface FunctionToolManifest {
 
 /** A Gemini built-in tool (e.g. google_search) — no client handler, no parameters. */
 export interface BuiltInToolManifest {
-  name: string;
+  name: BuiltInToolName;
   scope: AgentScope;
   kind: 'built_in';
   builtIn: BuiltInToolName;
 }
 
-export type AgentToolManifest = FunctionToolManifest | BuiltInToolManifest;
+/** Function-calling tool manifest (stable public contract for downstream callers). */
+export type AgentToolManifest = FunctionToolManifest;
+
+/** Union of function and built-in manifests for mixed tool arrays. */
+export type AnyAgentToolManifest = FunctionToolManifest | BuiltInToolManifest;

--- a/packages/core-llm-tools/src/types.ts
+++ b/packages/core-llm-tools/src/types.ts
@@ -17,8 +17,24 @@ export interface AgentToolSchema {
   };
 }
 
-export interface AgentToolManifest {
+/** Names of Gemini built-in tools (executed server-side, no client handler). */
+export type BuiltInToolName = 'google_search';
+
+/** A tool backed by a client-implemented function-calling schema. */
+export interface FunctionToolManifest {
   name: string;
   scope: AgentScope;
+  /** Optional for backward compatibility — manifests without this field are function tools. */
+  kind?: 'function';
   schema: AgentToolSchema;
 }
+
+/** A Gemini built-in tool (e.g. google_search) — no client handler, no parameters. */
+export interface BuiltInToolManifest {
+  name: string;
+  scope: AgentScope;
+  kind: 'built_in';
+  builtIn: BuiltInToolName;
+}
+
+export type AgentToolManifest = FunctionToolManifest | BuiltInToolManifest;


### PR DESCRIPTION
## Summary

- Split `AgentToolManifest` into a discriminated union (`FunctionToolManifest` | `BuiltInToolManifest`) with backward-compatible optional `kind` field
- Add `buildAuthorizedToolsArray` to return the full Gemini `tools[]` array (mixed `functionDeclarations` + built-in entries like `{ google_search: {} }`)
- Export `googleSearchManifest` as a core-tier built-in tool; deprecate `buildAuthorizedSchemaArray` via JSDoc (behavior unchanged for function-only callers)

## Test plan

- [x] `pnpm --filter @equationalapplications/core-llm-tools typecheck` passes
- [x] `pnpm --filter @equationalapplications/core-llm-tools test` — 39/39 tests pass
- [x] `pnpm --filter @equationalapplications/core-llm-tools build` — tsup emits dist without type errors
- [ ] Verify downstream callers can switch from `buildAuthorizedSchemaArray` to `buildAuthorizedToolsArray` when adopting `google_search`


Made with [Cursor](https://cursor.com)