### PR TITLE
feat: add OKF v0.1 export via core-okf package

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,11 +11,11 @@
       "npmPublish": false
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox','core-llm-tools'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
+      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox','core-llm-tools','okf'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
     }],
     "@semantic-release/github",
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json", "packages/core-llm-tools/package.json"],
+      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json", "packages/core-llm-tools/package.json", "packages/okf/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }]
   ]

--- a/docs/superpowers/specs/2026-06-18-okf-export-design.md
+++ b/docs/superpowers/specs/2026-06-18-okf-export-design.md
@@ -1,6 +1,6 @@
 # Design: Open Knowledge Format (OKF) Export
 
-**Status:** Approved (design phase) — implementation plan pending
+**Status:** Implemented
 **Packages:** new `@equationalapplications/core-okf` (`packages/okf`); `packages/core` adapter
 **Date:** 2026-06-18
 **Spec reference:** Open Knowledge Format v0.1, https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md

--- a/docs/superpowers/specs/2026-06-18-okf-export-design.md
+++ b/docs/superpowers/specs/2026-06-18-okf-export-design.md
@@ -149,8 +149,10 @@ entities/<dir>/index.md
 index.md                              (bundle root)
 ```
 
-Fact/task `id` values (`fact_<24hex>` / `task_<24hex>`, from `generateId()`) are already
-filesystem-safe and used directly as filenames — no sanitization needed there.
+Fact/task `id` values are passed through `sanitizeConceptId()` before use as filenames. This
+reuses the same character/length sanitization as entity directories and additionally remaps OKF-
+reserved concept names (`index`, `log`) to a hash-suffixed variant so concept files never
+collide with structural `index.md` / `log.md` files.
 
 **Fact → concept doc** (`entities/<dir>/facts/<fact.id>.md`, `type: 'fact'`):
 - `title`: `fact.title`
@@ -173,7 +175,7 @@ filesystem-safe and used directly as filenames — no sanitization needed there.
 formatted as `YYYY-MM-DD`; `text` is `` (event.event_type) <summary> ``, where `<summary>` is
 `event.summary` unless `event.related_entry_id` matches an exported fact's `id` for that entity,
 in which case it's wrapped as a markdown link to that fact's relative path
-(`[summary](../facts/<id>.md)`) — this is what realizes OKF's "a link asserts a relationship"
+(`[summary](./facts/<id>.md)`) — this is what realizes OKF's "a link asserts a relationship"
 convention for this bundle.
 
 **Entity `index.md`** (`entities/<dir>/index.md`): two sections, "Facts" and "Tasks", each entry
@@ -218,9 +220,8 @@ Unit tests only, `vitest run`, no I/O — same style as `core-llm-tools`.
   correct file paths, frontmatter field mapping per fact/task, `embedding_blob` exclusion,
   `related_entry_id` → markdown-link resolution in `log.md` (including the case where the
   referenced fact isn't in the export and the link is omitted), root + entity `index.md` link
-  correctness, reserved-filename collision (an entity/fact/task whose sanitized id would be
-  `index` or `log` — confirm the existing hash-suffix collision logic in
-  `sanitizeForFilename` still produces a non-colliding name).
+  correctness, reserved-filename avoidance (fact/task ids `index` or `log` must not produce
+  concept files named `index.md` or `log.md`; unsafe ids with path separators are sanitized).
 - `sanitizeForFilename.test.ts` — extracted from the existing inline logic; same assertions
   `formatMemoryDump.test.ts` already implicitly relies on, now testable directly.
 

--- a/packages/core/__tests__/formatOkfBundle.test.ts
+++ b/packages/core/__tests__/formatOkfBundle.test.ts
@@ -163,7 +163,7 @@ describe('formatOkfBundle', () => {
     expect(rootIndex.content).toContain('* [bob](entities/bob/index.md)');
   });
 
-  it('does not collide when an entity, fact, or task id sanitizes to a reserved name', () => {
+  it('avoids reserved concept filenames and sanitizes unsafe fact/task ids', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
       entities: {
@@ -176,11 +176,30 @@ describe('formatOkfBundle', () => {
     };
     const { files } = formatOkfBundle(dump);
     const paths = files.map(f => f.path);
-    expect(paths).toContain('entities/index/facts/index.md');
-    expect(paths).toContain('entities/index/tasks/log.md');
+    const conceptPaths = paths.filter(p => p.includes('/facts/') || p.includes('/tasks/'));
+    expect(conceptPaths.every(p => !p.endsWith('/facts/index.md') && !p.endsWith('/tasks/log.md'))).toBe(true);
+    expect(conceptPaths.some(p => /\/facts\/index-[0-9a-f]{16}\.md$/.test(p))).toBe(true);
+    expect(conceptPaths.some(p => /\/tasks\/log-[0-9a-f]{16}\.md$/.test(p))).toBe(true);
     expect(paths).toContain('entities/index/index.md');
     expect(paths).toContain('entities/index/log.md');
     expect(paths).toContain('index.md');
     expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('sanitizes fact ids containing path separators', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: {
+          facts: [makeFact({ id: '../escape', entity_id: 'alice' })],
+          tasks: [],
+          events: [],
+        },
+      },
+    };
+    const { files } = formatOkfBundle(dump);
+    const factFile = files.find(f => f.path.startsWith('entities/alice/facts/'))!;
+    expect(factFile.path).toMatch(/^entities\/alice\/facts\/escape-[0-9a-f]{16}\.md$/);
+    expect(factFile.path).not.toContain('..');
   });
 });

--- a/packages/core/__tests__/formatOkfBundle.test.ts
+++ b/packages/core/__tests__/formatOkfBundle.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { formatOkfBundle } from '../src/utils/formatOkfBundle';
+import type { MemoryDump, WikiFact, WikiTask, WikiEvent } from '../src/types';
+
+function makeFact(overrides: Partial<WikiFact> = {}): WikiFact {
+  return {
+    id: 'fact_aaa',
+    entity_id: 'alice',
+    title: 'Likes coffee',
+    body: 'Alice drinks coffee every morning.',
+    tags: ['preference', 'drink'],
+    confidence: 'certain',
+    source_type: 'user_stated',
+    source_hash: null,
+    source_ref: 'chat-2026-01-01',
+    created_at: 1700000000000,
+    updated_at: 1700000100000,
+    embedding_blob: new Uint8Array([0, 0, 128, 63]),
+    last_accessed_at: 1700000200000,
+    access_count: 3,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<WikiTask> = {}): WikiTask {
+  return {
+    id: 'task_bbb',
+    entity_id: 'alice',
+    description: 'Order more coffee beans',
+    status: 'pending',
+    priority: 2,
+    created_at: 1700000300000,
+    updated_at: 1700000400000,
+    resolved_at: null,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<WikiEvent> = {}): WikiEvent {
+  return {
+    id: 'evt_ccc',
+    entity_id: 'alice',
+    event_type: 'observation',
+    summary: 'Alice mentioned coffee',
+    related_entry_id: null,
+    created_at: 1700000500000,
+    ...overrides,
+  };
+}
+
+describe('formatOkfBundle', () => {
+  it('produces no files for an empty dump except the root index.md', () => {
+    const { files } = formatOkfBundle({ generatedAt: 0, entities: {} });
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe('index.md');
+    expect(files[0].content).toBe('---\nokf_version: "0.1"\n---\n\n');
+  });
+
+  it('writes one concept file per fact with correct path and excludes embedding_blob', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [makeFact()], tasks: [], events: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md');
+    expect(factFile).toBeDefined();
+    expect(factFile!.content).not.toContain('embedding_blob');
+    expect(factFile!.content).toContain('type: fact');
+    expect(factFile!.content).toContain('title: Likes coffee');
+    expect(factFile!.content).toContain('timestamp: 2023-11-14T22:15:00.000Z');
+    expect(factFile!.content).toContain('resource: chat-2026-01-01');
+    expect(factFile!.content).toContain('id: fact_aaa');
+    expect(factFile!.content).toContain('entity_id: alice');
+    expect(factFile!.content).toContain('confidence: certain');
+    expect(factFile!.content).toContain('source_type: user_stated');
+    expect(factFile!.content).toContain('access_count: 3');
+    expect(factFile!.content).toContain('Alice drinks coffee every morning.');
+  });
+
+  it('omits the resource key when source_ref is null', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [makeFact({ source_ref: null })], tasks: [], events: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md')!;
+    expect(factFile.content).not.toContain('resource:');
+  });
+
+  it('writes one concept file per task with description as title and empty body', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [], tasks: [makeTask()], events: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const taskFile = files.find(f => f.path === 'entities/alice/tasks/task_bbb.md');
+    expect(taskFile).toBeDefined();
+    expect(taskFile!.content).toBe(
+      '---\ntype: task\ntitle: Order more coffee beans\ntimestamp: 2023-11-14T22:20:00.000Z\nid: task_bbb\nentity_id: alice\nstatus: pending\npriority: 2\ncreated_at: 1700000300000\nresolved_at: null\ndeleted_at: null\n---\n\n'
+    );
+  });
+
+  it('links a log entry to its referenced fact when related_entry_id matches an exported fact', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: {
+          facts: [makeFact()],
+          tasks: [],
+          events: [makeEvent({ related_entry_id: 'fact_aaa', summary: 'Confirmed coffee preference' })],
+        },
+      },
+    };
+    const { files } = formatOkfBundle(dump);
+    const logFile = files.find(f => f.path === 'entities/alice/log.md')!;
+    expect(logFile.content).toContain('[Confirmed coffee preference](../facts/fact_aaa.md)');
+  });
+
+  it('renders a plain summary when related_entry_id does not match an exported fact', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: {
+          facts: [],
+          tasks: [],
+          events: [makeEvent({ related_entry_id: 'fact_missing', summary: 'Unlinked event' })],
+        },
+      },
+    };
+    const { files } = formatOkfBundle(dump);
+    const logFile = files.find(f => f.path === 'entities/alice/log.md')!;
+    expect(logFile.content).toContain('(observation) Unlinked event');
+    expect(logFile.content).not.toContain('[Unlinked event]');
+  });
+
+  it('builds an entity index.md linking to facts, tasks, and the log', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [makeFact()], tasks: [makeTask()], events: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const entityIndex = files.find(f => f.path === 'entities/alice/index.md')!;
+    expect(entityIndex.content).toContain('## Facts');
+    expect(entityIndex.content).toContain('* [Likes coffee](facts/fact_aaa.md)');
+    expect(entityIndex.content).toContain('## Tasks');
+    expect(entityIndex.content).toContain('* [Order more coffee beans](tasks/task_bbb.md)');
+    expect(entityIndex.content).toContain('[Event log](./log.md)');
+  });
+
+  it('builds a root index.md linking to every entity index', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: { facts: [], tasks: [], events: [] },
+        bob: { facts: [], tasks: [], events: [] },
+      },
+    };
+    const { files } = formatOkfBundle(dump);
+    const rootIndex = files.find(f => f.path === 'index.md')!;
+    expect(rootIndex.content).toContain('* [alice](entities/alice/index.md)');
+    expect(rootIndex.content).toContain('* [bob](entities/bob/index.md)');
+  });
+
+  it('does not collide when an entity, fact, or task id sanitizes to a reserved name', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        index: {
+          facts: [makeFact({ id: 'index', entity_id: 'index' })],
+          tasks: [makeTask({ id: 'log', entity_id: 'index' })],
+          events: [],
+        },
+      },
+    };
+    const { files } = formatOkfBundle(dump);
+    const paths = files.map(f => f.path);
+    expect(paths).toContain('entities/index/facts/index.md');
+    expect(paths).toContain('entities/index/tasks/log.md');
+    expect(paths).toContain('entities/index/index.md');
+    expect(paths).toContain('entities/index/log.md');
+    expect(paths).toContain('index.md');
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/packages/core/__tests__/formatOkfBundle.test.ts
+++ b/packages/core/__tests__/formatOkfBundle.test.ts
@@ -115,7 +115,7 @@ describe('formatOkfBundle', () => {
     };
     const { files } = formatOkfBundle(dump);
     const logFile = files.find(f => f.path === 'entities/alice/log.md')!;
-    expect(logFile.content).toContain('[Confirmed coffee preference](../facts/fact_aaa.md)');
+    expect(logFile.content).toContain('[Confirmed coffee preference](./facts/fact_aaa.md)');
   });
 
   it('renders a plain summary when related_entry_id does not match an exported fact', () => {

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -39,7 +39,7 @@ describe('sanitizeForFilename', () => {
 
   it('remaps Windows reserved device names with a hash suffix', () => {
     expect(sanitizeForFilename('con')).toMatch(/^con-[0-9a-f]{16}$/);
-    expect(sanitizeForFilename('con.txt')).toMatch(/^con\.txt-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('con.txt')).toMatch(/^con-[0-9a-f]{16}\.txt$/);
     expect(sanitizeForFilename('PRN')).toMatch(/^PRN-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('com1')).toMatch(/^com1-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('LPT9')).toMatch(/^LPT9-[0-9a-f]{16}$/);

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForFilename } from '../src/utils/sanitizeForFilename';
+
+describe('sanitizeForFilename', () => {
+  it('returns an already-safe value unchanged', () => {
+    expect(sanitizeForFilename('alice')).toBe('alice');
+  });
+
+  it('replaces unsafe characters and appends a hash suffix when the value changes', () => {
+    const result = sanitizeForFilename('alice/bob');
+    expect(result).toMatch(/^alice_bob-[0-9a-f]{16}$/);
+  });
+
+  it('falls back to "entity" plus a hash suffix for an empty value', () => {
+    const result = sanitizeForFilename('');
+    expect(result).toMatch(/^entity-[0-9a-f]{16}$/);
+  });
+
+  it('truncates values longer than 200 chars and appends a hash suffix', () => {
+    const longValue = 'a'.repeat(250);
+    const result = sanitizeForFilename(longValue);
+    const match = result.match(/^(a+)-([0-9a-f]{16})$/);
+    expect(match).not.toBeNull();
+    expect(match![1].length).toBe(200);
+  });
+
+  it('produces the same output for the same input (deterministic)', () => {
+    expect(sanitizeForFilename('a/b/c')).toBe(sanitizeForFilename('a/b/c'));
+  });
+});

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { sanitizeForFilename } from '../src/utils/sanitizeForFilename';
 
 describe('sanitizeForFilename', () => {
+  it('guards dot-only inputs', () => {
+    expect(sanitizeForFilename('.')).toMatch(/^entity-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('..')).toMatch(/^entity-[0-9a-f]{16}$/);
+  });
+
+  it('rewrites leading-dot names', () => {
+    expect(sanitizeForFilename('.git')).toMatch(/^git-[0-9a-f]{16}$/);
+  });
+
   it('returns an already-safe value unchanged', () => {
     expect(sanitizeForFilename('alice')).toBe('alice');
   });

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -39,7 +39,7 @@ describe('sanitizeForFilename', () => {
 
   it('remaps Windows reserved device names with a hash suffix', () => {
     expect(sanitizeForFilename('con')).toMatch(/^con-[0-9a-f]{16}$/);
-    expect(sanitizeForFilename('con.txt')).toMatch(/^con-[0-9a-f]{16}\.txt$/);
+    expect(sanitizeForFilename('con.txt')).toMatch(/^con\.txt-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('PRN')).toMatch(/^PRN-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('com1')).toMatch(/^com1-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('LPT9')).toMatch(/^LPT9-[0-9a-f]{16}$/);

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -39,6 +39,7 @@ describe('sanitizeForFilename', () => {
 
   it('remaps Windows reserved device names with a hash suffix', () => {
     expect(sanitizeForFilename('con')).toMatch(/^con-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('con.txt')).toMatch(/^con\.txt-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('PRN')).toMatch(/^PRN-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('com1')).toMatch(/^com1-[0-9a-f]{16}$/);
     expect(sanitizeForFilename('LPT9')).toMatch(/^LPT9-[0-9a-f]{16}$/);

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -36,6 +36,18 @@ describe('sanitizeForFilename', () => {
   it('produces the same output for the same input (deterministic)', () => {
     expect(sanitizeForFilename('a/b/c')).toBe(sanitizeForFilename('a/b/c'));
   });
+
+  it('remaps Windows reserved device names with a hash suffix', () => {
+    expect(sanitizeForFilename('con')).toMatch(/^con-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('PRN')).toMatch(/^PRN-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('com1')).toMatch(/^com1-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('LPT9')).toMatch(/^LPT9-[0-9a-f]{16}$/);
+  });
+
+  it('strips trailing dots and spaces and appends a hash suffix', () => {
+    expect(sanitizeForFilename('alice.')).toMatch(/^alice-[0-9a-f]{16}$/);
+    expect(sanitizeForFilename('bob ')).toMatch(/^bob-[0-9a-f]{16}$/);
+  });
 });
 
 describe('sanitizeConceptId', () => {

--- a/packages/core/__tests__/sanitizeForFilename.test.ts
+++ b/packages/core/__tests__/sanitizeForFilename.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeForFilename } from '../src/utils/sanitizeForFilename';
+import { sanitizeConceptId, sanitizeForFilename } from '../src/utils/sanitizeForFilename';
 
 describe('sanitizeForFilename', () => {
   it('guards dot-only inputs', () => {
@@ -35,5 +35,20 @@ describe('sanitizeForFilename', () => {
 
   it('produces the same output for the same input (deterministic)', () => {
     expect(sanitizeForFilename('a/b/c')).toBe(sanitizeForFilename('a/b/c'));
+  });
+});
+
+describe('sanitizeConceptId', () => {
+  it('remaps OKF-reserved concept names with a hash suffix', () => {
+    expect(sanitizeConceptId('index')).toMatch(/^index-[0-9a-f]{16}$/);
+    expect(sanitizeConceptId('log')).toMatch(/^log-[0-9a-f]{16}$/);
+  });
+
+  it('returns an already-safe value unchanged', () => {
+    expect(sanitizeConceptId('fact_aaa')).toBe('fact_aaa');
+  });
+
+  it('sanitizes path separators like sanitizeForFilename', () => {
+    expect(sanitizeConceptId('../escape')).toMatch(/^escape-[0-9a-f]{16}$/);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export { WikiMemory } from './WikiMemory';
 export type { WikiMemoryTestAccess } from './WikiMemory';
 export { formatContext } from './utils/formatContext';
 export { formatMemoryDump } from './utils/formatMemoryDump';
+export { formatOkfBundle } from './utils/formatOkfBundle';
 export { parseEmbedding } from './utils/embedding';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';

--- a/packages/core/src/utils/formatMemoryDump.ts
+++ b/packages/core/src/utils/formatMemoryDump.ts
@@ -1,4 +1,5 @@
 import type { MemoryDump, FormattedMemoryDump, MemoryBundle, WikiFact, WikiTask, WikiEvent } from '../types';
+import { sanitizeForFilename } from './sanitizeForFilename';
 
 function renderFact(f: WikiFact): string {
   const tags = (f.tags || []).join(', ');
@@ -58,37 +59,8 @@ function renderEntity(entityId: string, bundle: MemoryBundle, generatedAt: numbe
   return lines.join('\n');
 }
 
-function shortHash(value: string): string {
-  let h1 = 5381;
-  let h2 = 52711;
-  for (let i = 0; i < value.length; i += 1) {
-    const c = value.charCodeAt(i);
-    h1 = Math.imul(h1, 33) ^ c;
-    h2 = Math.imul(h2, 31) ^ c;
-  }
-  return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
-}
-
 function formatEntityFileName(entityId: string): string {
-  const normalized = entityId.normalize('NFKC');
-  const sanitized = normalized
-    .replace(/[^A-Za-z0-9._-]+/g, '_')
-    .replace(/^\.+/, '_')
-    .replace(/_+/g, '_')
-    .replace(/^[_-]+|[_-]+$/g, '');
-
-  // Enforce a max base-name length so the final filename stays within typical
-  // filesystem limits (~255 bytes). Reserve ~20 chars for `-<16hexchars>.md`.
-  const MAX_BASE = 200;
-  const trimmed = sanitized.length > MAX_BASE ? sanitized.slice(0, MAX_BASE) : sanitized;
-
-  const baseName = trimmed && trimmed !== '.' && trimmed !== '..'
-    ? trimmed
-    : 'entity';
-  const needsSuffix = baseName !== entityId || sanitized.length > MAX_BASE;
-  const uniqueBaseName = needsSuffix ? `${baseName}-${shortHash(entityId)}` : baseName;
-
-  return `${uniqueBaseName}.md`;
+  return `${sanitizeForFilename(entityId)}.md`;
 }
 
 export function formatMemoryDump(dump: MemoryDump): FormattedMemoryDump {

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -106,7 +106,7 @@ export function formatOkfBundle(dump: MemoryDump): { files: OkfFile[] } {
     ];
     files.push({
       path: `entities/${dir}/index.md`,
-      content: `${buildIndexMd(entityIndexSections)}\n[Event log](./log.md)\n`,
+      content: `${buildIndexMd(entityIndexSections)}[Event log](./log.md)\n`,
     });
 
     rootEntries.push({ path: `entities/${dir}/index.md`, title: entityId });

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -53,7 +53,7 @@ function formatLogDate(timestampMs: number): string {
 function buildEventLogEntries(events: WikiEvent[], factIds: Set<string>): OkfLogEntry[] {
   return events.map(e => {
     const text = e.related_entry_id && factIds.has(e.related_entry_id)
-      ? `(${e.event_type}) [${e.summary}](../facts/${e.related_entry_id}.md)`
+      ? `(${e.event_type}) [${e.summary}](./facts/${e.related_entry_id}.md)`
       : `(${e.event_type}) ${e.summary}`;
     return { date: formatLogDate(e.created_at), text };
   });

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -56,9 +56,15 @@ function buildEventLogEntries(
 ): OkfLogEntry[] {
   return events.map(e => {
     const factFilename = e.related_entry_id ? factIdToFilename.get(e.related_entry_id) : undefined;
+    const summary = e.summary
+      .replace(/\\/g, '\\\\')
+      .replace(/\[/g, '\\[')
+      .replace(/\]/g, '\\]')
+      .replace(/\r?\n/g, ' ');
+
     const text = factFilename
-      ? `(${e.event_type}) [${e.summary}](./facts/${factFilename}.md)`
-      : `(${e.event_type}) ${e.summary}`;
+      ? `(${e.event_type}) [${summary}](./facts/${factFilename}.md)`
+      : `(${e.event_type}) ${summary}`;
     return { date: formatLogDate(e.created_at), text };
   });
 }

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -10,7 +10,7 @@ import {
   type OkfIndexSection,
   type OkfLogEntry,
 } from '@equationalapplications/core-okf';
-import { sanitizeForFilename } from './sanitizeForFilename';
+import { sanitizeConceptId, sanitizeForFilename } from './sanitizeForFilename';
 
 function factFrontmatter(f: WikiFact): OkfFrontmatter {
   return {
@@ -50,10 +50,14 @@ function formatLogDate(timestampMs: number): string {
   return new Date(timestampMs).toISOString().slice(0, 10);
 }
 
-function buildEventLogEntries(events: WikiEvent[], factIds: Set<string>): OkfLogEntry[] {
+function buildEventLogEntries(
+  events: WikiEvent[],
+  factIdToFilename: Map<string, string>,
+): OkfLogEntry[] {
   return events.map(e => {
-    const text = e.related_entry_id && factIds.has(e.related_entry_id)
-      ? `(${e.event_type}) [${e.summary}](./facts/${e.related_entry_id}.md)`
+    const factFilename = e.related_entry_id ? factIdToFilename.get(e.related_entry_id) : undefined;
+    const text = factFilename
+      ? `(${e.event_type}) [${e.summary}](./facts/${factFilename}.md)`
       : `(${e.event_type}) ${e.summary}`;
     return { date: formatLogDate(e.created_at), text };
   });
@@ -65,33 +69,35 @@ export function formatOkfBundle(dump: MemoryDump): { files: OkfFile[] } {
 
   for (const [entityId, bundle] of Object.entries(dump.entities)) {
     const dir = sanitizeForFilename(entityId);
-    const factIds = new Set(bundle.facts.map(f => f.id));
+    const factIdToFilename = new Map(
+      bundle.facts.map(f => [f.id, sanitizeConceptId(f.id)] as const),
+    );
 
     const factEntries: OkfIndexEntry[] = bundle.facts.map(f => ({
-      path: `facts/${f.id}.md`,
+      path: `facts/${factIdToFilename.get(f.id)!}.md`,
       title: f.title,
     }));
     for (const f of bundle.facts) {
       files.push({
-        path: `entities/${dir}/facts/${f.id}.md`,
+        path: `entities/${dir}/facts/${factIdToFilename.get(f.id)!}.md`,
         content: buildConceptDocument(factFrontmatter(f), f.body),
       });
     }
 
     const taskEntries: OkfIndexEntry[] = bundle.tasks.map(t => ({
-      path: `tasks/${t.id}.md`,
+      path: `tasks/${sanitizeConceptId(t.id)}.md`,
       title: t.description,
     }));
     for (const t of bundle.tasks) {
       files.push({
-        path: `entities/${dir}/tasks/${t.id}.md`,
+        path: `entities/${dir}/tasks/${sanitizeConceptId(t.id)}.md`,
         content: buildConceptDocument(taskFrontmatter(t), ''),
       });
     }
 
     files.push({
       path: `entities/${dir}/log.md`,
-      content: buildLogMd(buildEventLogEntries(bundle.events, factIds)),
+      content: buildLogMd(buildEventLogEntries(bundle.events, factIdToFilename)),
     });
 
     const entityIndexSections: OkfIndexSection[] = [

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -1,0 +1,118 @@
+import type { MemoryDump, WikiFact, WikiTask, WikiEvent } from '../types';
+import {
+  buildConceptDocument,
+  buildIndexMd,
+  buildRootIndexMd,
+  buildLogMd,
+  type OkfFile,
+  type OkfFrontmatter,
+  type OkfIndexEntry,
+  type OkfIndexSection,
+  type OkfLogEntry,
+} from '@equationalapplications/core-okf';
+import { sanitizeForFilename } from './sanitizeForFilename';
+
+function factFrontmatter(f: WikiFact): OkfFrontmatter {
+  return {
+    type: 'fact',
+    title: f.title,
+    tags: f.tags,
+    timestamp: new Date(f.updated_at).toISOString(),
+    resource: f.source_ref ?? undefined,
+    id: f.id,
+    entity_id: f.entity_id,
+    confidence: f.confidence,
+    source_type: f.source_type,
+    source_hash: f.source_hash,
+    created_at: f.created_at,
+    access_count: f.access_count,
+    last_accessed_at: f.last_accessed_at,
+    deleted_at: f.deleted_at,
+  };
+}
+
+function taskFrontmatter(t: WikiTask): OkfFrontmatter {
+  return {
+    type: 'task',
+    title: t.description,
+    timestamp: new Date(t.updated_at).toISOString(),
+    id: t.id,
+    entity_id: t.entity_id,
+    status: t.status,
+    priority: t.priority,
+    created_at: t.created_at,
+    resolved_at: t.resolved_at,
+    deleted_at: t.deleted_at,
+  };
+}
+
+function formatLogDate(timestampMs: number): string {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function buildEventLogEntries(events: WikiEvent[], factIds: Set<string>): OkfLogEntry[] {
+  return events.map(e => {
+    const text = e.related_entry_id && factIds.has(e.related_entry_id)
+      ? `(${e.event_type}) [${e.summary}](../facts/${e.related_entry_id}.md)`
+      : `(${e.event_type}) ${e.summary}`;
+    return { date: formatLogDate(e.created_at), text };
+  });
+}
+
+export function formatOkfBundle(dump: MemoryDump): { files: OkfFile[] } {
+  const files: OkfFile[] = [];
+  const rootEntries: OkfIndexEntry[] = [];
+
+  for (const [entityId, bundle] of Object.entries(dump.entities)) {
+    const dir = sanitizeForFilename(entityId);
+    const factIds = new Set(bundle.facts.map(f => f.id));
+
+    const factEntries: OkfIndexEntry[] = bundle.facts.map(f => ({
+      path: `facts/${f.id}.md`,
+      title: f.title,
+    }));
+    for (const f of bundle.facts) {
+      files.push({
+        path: `entities/${dir}/facts/${f.id}.md`,
+        content: buildConceptDocument(factFrontmatter(f), f.body),
+      });
+    }
+
+    const taskEntries: OkfIndexEntry[] = bundle.tasks.map(t => ({
+      path: `tasks/${t.id}.md`,
+      title: t.description,
+    }));
+    for (const t of bundle.tasks) {
+      files.push({
+        path: `entities/${dir}/tasks/${t.id}.md`,
+        content: buildConceptDocument(taskFrontmatter(t), ''),
+      });
+    }
+
+    files.push({
+      path: `entities/${dir}/log.md`,
+      content: buildLogMd(buildEventLogEntries(bundle.events, factIds)),
+    });
+
+    const entityIndexSections: OkfIndexSection[] = [
+      { heading: 'Facts', entries: factEntries },
+      { heading: 'Tasks', entries: taskEntries },
+    ];
+    files.push({
+      path: `entities/${dir}/index.md`,
+      content: `${buildIndexMd(entityIndexSections)}\n[Event log](./log.md)\n`,
+    });
+
+    rootEntries.push({ path: `entities/${dir}/index.md`, title: entityId });
+  }
+
+  files.push({
+    path: 'index.md',
+    content: buildRootIndexMd(
+      '0.1',
+      rootEntries.length > 0 ? [{ heading: 'Entities', entries: rootEntries }] : [],
+    ),
+  });
+
+  return { files };
+}

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -37,7 +37,8 @@ const WINDOWS_RESERVED_NAMES = new Set([
 ]);
 
 function isWindowsReservedName(name: string): boolean {
-  return WINDOWS_RESERVED_NAMES.has(name.toLowerCase());
+  const base = name.split('.')[0];
+  return WINDOWS_RESERVED_NAMES.has(base.toLowerCase());
 }
 
 export function sanitizeForFilename(value: string): string {

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -70,10 +70,7 @@ export function sanitizeForFilename(value: string): string {
   if (!needsSuffix) return baseName;
 
   const suffix = `-${shortHash(value)}`;
-  const dotIndex = baseName.indexOf('.');
-  return dotIndex === -1
-    ? `${baseName}${suffix}`
-    : `${baseName.slice(0, dotIndex)}${suffix}${baseName.slice(dotIndex)}`;
+  return `${baseName}${suffix}`;
 }
 
 /** Sanitize a fact/task id for use as a concept filename (without .md). */

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -11,6 +11,35 @@ function shortHash(value: string): string {
 
 const OKF_RESERVED_CONCEPT_NAMES = new Set(['index', 'log']);
 
+const WINDOWS_RESERVED_NAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+]);
+
+function isWindowsReservedName(name: string): boolean {
+  return WINDOWS_RESERVED_NAMES.has(name.toLowerCase());
+}
+
 export function sanitizeForFilename(value: string): string {
   const normalized = value.normalize('NFKC');
   const sanitized = normalized
@@ -24,8 +53,18 @@ export function sanitizeForFilename(value: string): string {
   const MAX_BASE = 200;
   const trimmed = sanitized.length > MAX_BASE ? sanitized.slice(0, MAX_BASE) : sanitized;
 
-  const baseName = trimmed && trimmed !== '.' && trimmed !== '..' ? trimmed : 'entity';
-  const needsSuffix = baseName !== value || sanitized.length > MAX_BASE;
+  let baseName = trimmed && trimmed !== '.' && trimmed !== '..' ? trimmed : 'entity';
+
+  // Windows disallows trailing dots and spaces in filenames.
+  const withoutTrailingDotSpace = baseName.replace(/[. ]+$/, '');
+  const hadTrailingDotSpace = withoutTrailingDotSpace !== baseName;
+  if (hadTrailingDotSpace) {
+    baseName = withoutTrailingDotSpace || 'entity';
+  }
+
+  const windowsReserved = isWindowsReservedName(baseName);
+  const needsSuffix =
+    baseName !== value || sanitized.length > MAX_BASE || hadTrailingDotSpace || windowsReserved;
   return needsSuffix ? `${baseName}-${shortHash(value)}` : baseName;
 }
 

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -9,6 +9,8 @@ function shortHash(value: string): string {
   return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
 }
 
+const OKF_RESERVED_CONCEPT_NAMES = new Set(['index', 'log']);
+
 export function sanitizeForFilename(value: string): string {
   const normalized = value.normalize('NFKC');
   const sanitized = normalized
@@ -25,4 +27,13 @@ export function sanitizeForFilename(value: string): string {
   const baseName = trimmed && trimmed !== '.' && trimmed !== '..' ? trimmed : 'entity';
   const needsSuffix = baseName !== value || sanitized.length > MAX_BASE;
   return needsSuffix ? `${baseName}-${shortHash(value)}` : baseName;
+}
+
+/** Sanitize a fact/task id for use as a concept filename (without .md). */
+export function sanitizeConceptId(id: string): string {
+  const sanitized = sanitizeForFilename(id);
+  if (OKF_RESERVED_CONCEPT_NAMES.has(sanitized.toLowerCase())) {
+    return `${sanitized}-${shortHash(id)}`;
+  }
+  return sanitized;
 }

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -66,7 +66,14 @@ export function sanitizeForFilename(value: string): string {
   const windowsReserved = isWindowsReservedName(baseName);
   const needsSuffix =
     baseName !== value || sanitized.length > MAX_BASE || hadTrailingDotSpace || windowsReserved;
-  return needsSuffix ? `${baseName}-${shortHash(value)}` : baseName;
+
+  if (!needsSuffix) return baseName;
+
+  const suffix = `-${shortHash(value)}`;
+  const dotIndex = baseName.indexOf('.');
+  return dotIndex === -1
+    ? `${baseName}${suffix}`
+    : `${baseName.slice(0, dotIndex)}${suffix}${baseName.slice(dotIndex)}`;
 }
 
 /** Sanitize a fact/task id for use as a concept filename (without .md). */

--- a/packages/core/src/utils/sanitizeForFilename.ts
+++ b/packages/core/src/utils/sanitizeForFilename.ts
@@ -1,0 +1,28 @@
+function shortHash(value: string): string {
+  let h1 = 5381;
+  let h2 = 52711;
+  for (let i = 0; i < value.length; i += 1) {
+    const c = value.charCodeAt(i);
+    h1 = Math.imul(h1, 33) ^ c;
+    h2 = Math.imul(h2, 31) ^ c;
+  }
+  return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
+}
+
+export function sanitizeForFilename(value: string): string {
+  const normalized = value.normalize('NFKC');
+  const sanitized = normalized
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^\.+/, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[_-]+|[_-]+$/g, '');
+
+  // Enforce a max base-name length so the final filename stays within typical
+  // filesystem limits (~255 bytes). Reserve ~20 chars for `-<16hexchars>`.
+  const MAX_BASE = 200;
+  const trimmed = sanitized.length > MAX_BASE ? sanitized.slice(0, MAX_BASE) : sanitized;
+
+  const baseName = trimmed && trimmed !== '.' && trimmed !== '..' ? trimmed : 'entity';
+  const needsSuffix = baseName !== value || sanitized.length > MAX_BASE;
+  return needsSuffix ? `${baseName}-${shortHash(value)}` : baseName;
+}

--- a/packages/okf/LICENSE
+++ b/packages/okf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Equational Applications LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/okf/README.md
+++ b/packages/okf/README.md
@@ -1,0 +1,3 @@
+# @equationalapplications/core-okf
+
+Zero-dependency primitives for producing [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) (OKF v0.1) bundles: YAML frontmatter serialization, concept document assembly, and `index.md`/`log.md` builders. No knowledge of any specific data model — bring your own mapping from your domain objects to `OkfFrontmatter` + body strings.

--- a/packages/okf/__tests__/concept.test.ts
+++ b/packages/okf/__tests__/concept.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { buildConceptDocument } from '../src/concept';
+
+describe('buildConceptDocument', () => {
+  it('concatenates frontmatter and body with a blank line between', () => {
+    const result = buildConceptDocument({ type: 'fact', title: 'T' }, 'Body text');
+    expect(result).toBe('---\ntype: fact\ntitle: T\n---\n\nBody text');
+  });
+
+  it('supports the minimal case where only type is present', () => {
+    const result = buildConceptDocument({ type: 'task' }, '');
+    expect(result).toBe('---\ntype: task\n---\n\n');
+  });
+});

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -21,6 +21,22 @@ describe('serializeFrontmatter', () => {
     expect(result).toBe('---\ntype: fact\ntags:\n  - a\n  - b\n---\n');
   });
 
+  it('serializes an array with mixed scalar types', () => {
+    const result = serializeFrontmatter({
+      type: 'fact',
+      values: [1, true, null, 'text'],
+    } as any);
+    expect(result).toBe('---\ntype: fact\nvalues:\n  - 1\n  - true\n  - null\n  - text\n---\n');
+  });
+
+  it('does not quote ISO 8601 timestamps with timezone offsets', () => {
+    const result = serializeFrontmatter({
+      type: 'fact',
+      timestamp: '2026-05-28T14:30:00+05:00',
+    });
+    expect(result).toBe('---\ntype: fact\ntimestamp: 2026-05-28T14:30:00+05:00\n---\n');
+  });
+
   it('renders an empty array as []', () => {
     const result = serializeFrontmatter({ type: 'fact', tags: [] });
     expect(result).toBe('---\ntype: fact\ntags: []\n---\n');

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -92,6 +92,11 @@ describe('serializeFrontmatter', () => {
     expect(result).toBe('---\ntype: fact\ntitle: "a\\tb"\n---\n');
   });
 
+  it('quotes a string value containing a carriage return', () => {
+    const result = serializeFrontmatter({ type: 'fact', description: 'line one\rline two' });
+    expect(result).toBe('---\ntype: fact\ndescription: "line one\\rline two"\n---\n');
+  });
+
   it('quotes custom keys containing spaces or colons', () => {
     const result = serializeFrontmatter({
       type: 'fact',

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -81,4 +81,28 @@ describe('serializeFrontmatter', () => {
     const result = serializeFrontmatter({ type: 'fact', resource: undefined, title: 'T' });
     expect(result).toBe('---\ntype: fact\ntitle: T\n---\n');
   });
+
+  it('quotes a string value containing a newline', () => {
+    const result = serializeFrontmatter({ type: 'fact', description: 'line one\nline two' });
+    expect(result).toBe('---\ntype: fact\ndescription: "line one\\nline two"\n---\n');
+  });
+
+  it('quotes a string value containing a tab', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: 'a\tb' });
+    expect(result).toBe('---\ntype: fact\ntitle: "a\\tb"\n---\n');
+  });
+
+  it('quotes custom keys containing spaces or colons', () => {
+    const result = serializeFrontmatter({
+      type: 'fact',
+      'custom key': 'v',
+      'meta:field': 'w',
+    } as any);
+    expect(result).toBe('---\ntype: fact\n"custom key": v\n"meta:field": w\n---\n');
+  });
+
+  it('quotes custom keys that would parse as YAML literals', () => {
+    const result = serializeFrontmatter({ '123': 'n', type: 'fact', true: 'b' } as any);
+    expect(result).toBe('---\n"123": n\ntype: fact\n"true": b\n---\n');
+  });
 });

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { serializeFrontmatter } from '../src/frontmatter';
+
+describe('serializeFrontmatter', () => {
+  it('serializes a minimal type-only frontmatter block', () => {
+    expect(serializeFrontmatter({ type: 'fact' })).toBe('---\ntype: fact\n---\n');
+  });
+
+  it('serializes string, number, boolean, and null scalars', () => {
+    const result = serializeFrontmatter({
+      type: 'fact',
+      priority: 5,
+      active: true,
+      resolved_at: null,
+    } as any);
+    expect(result).toBe('---\ntype: fact\npriority: 5\nactive: true\nresolved_at: null\n---\n');
+  });
+
+  it('serializes a string array as a YAML block list', () => {
+    const result = serializeFrontmatter({ type: 'fact', tags: ['a', 'b'] });
+    expect(result).toBe('---\ntype: fact\ntags:\n  - a\n  - b\n---\n');
+  });
+
+  it('renders an empty array as []', () => {
+    const result = serializeFrontmatter({ type: 'fact', tags: [] });
+    expect(result).toBe('---\ntype: fact\ntags: []\n---\n');
+  });
+
+  it('quotes a string value containing a colon', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: 'Note: important' });
+    expect(result).toBe('---\ntype: fact\ntitle: "Note: important"\n---\n');
+  });
+
+  it('quotes a string value containing a hash', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: 'foo # bar' });
+    expect(result).toBe('---\ntype: fact\ntitle: "foo # bar"\n---\n');
+  });
+
+  it('quotes a string value with leading or trailing whitespace', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: ' foo' });
+    expect(result).toBe('---\ntype: fact\ntitle: " foo"\n---\n');
+  });
+
+  it('quotes a tag that would otherwise parse as a YAML boolean literal', () => {
+    const result = serializeFrontmatter({ type: 'fact', tags: ['true'] });
+    expect(result).toBe('---\ntype: fact\ntags:\n  - "true"\n---\n');
+  });
+
+  it('quotes a string value that would otherwise parse as a YAML null literal', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: 'null' });
+    expect(result).toBe('---\ntype: fact\ntitle: "null"\n---\n');
+  });
+
+  it('quotes a string value that would otherwise parse as a YAML number literal', () => {
+    const result = serializeFrontmatter({ type: 'fact', title: '123' });
+    expect(result).toBe('---\ntype: fact\ntitle: "123"\n---\n');
+  });
+
+  it('preserves key insertion order rather than sorting', () => {
+    const result = serializeFrontmatter({ type: 'fact', b: 'x', a: 'y' } as any);
+    expect(result).toBe('---\ntype: fact\nb: x\na: y\n---\n');
+  });
+
+  it('omits keys with an undefined value', () => {
+    const result = serializeFrontmatter({ type: 'fact', resource: undefined, title: 'T' });
+    expect(result).toBe('---\ntype: fact\ntitle: T\n---\n');
+  });
+});

--- a/packages/okf/__tests__/index-md.test.ts
+++ b/packages/okf/__tests__/index-md.test.ts
@@ -32,4 +32,9 @@ describe('buildRootIndexMd', () => {
       '---\nokf_version: "0.1"\n---\n\n## Entities\n\n* [alice](entities/alice/index.md)\n'
     );
   });
+
+  it('escapes special characters in okf_version for valid YAML', () => {
+    const result = buildRootIndexMd('0.1"\\evil\n', []);
+    expect(result).toBe('---\nokf_version: "0.1\\"\\\\evil\\n"\n---\n\n');
+  });
 });

--- a/packages/okf/__tests__/index-md.test.ts
+++ b/packages/okf/__tests__/index-md.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buildIndexMd, buildRootIndexMd } from '../src/index-md';
+
+describe('buildIndexMd', () => {
+  it('renders multiple sections with entries with and without description', () => {
+    const result = buildIndexMd([
+      {
+        heading: 'Facts',
+        entries: [
+          { path: 'facts/a.md', title: 'A', description: 'desc A' },
+          { path: 'facts/b.md', title: 'B' },
+        ],
+      },
+      { heading: 'Tasks', entries: [] },
+    ]);
+    expect(result).toBe(
+      '## Facts\n\n* [A](facts/a.md) - desc A\n* [B](facts/b.md)\n\n## Tasks\n'
+    );
+  });
+
+  it('renders an empty string for an empty sections list', () => {
+    expect(buildIndexMd([])).toBe('');
+  });
+});
+
+describe('buildRootIndexMd', () => {
+  it('wraps the body in a frontmatter block containing only okf_version', () => {
+    const result = buildRootIndexMd('0.1', [
+      { heading: 'Entities', entries: [{ path: 'entities/alice/index.md', title: 'alice' }] },
+    ]);
+    expect(result).toBe(
+      '---\nokf_version: "0.1"\n---\n\n## Entities\n\n* [alice](entities/alice/index.md)\n'
+    );
+  });
+});

--- a/packages/okf/__tests__/log-md.test.ts
+++ b/packages/okf/__tests__/log-md.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { buildLogMd } from '../src/log-md';
+
+describe('buildLogMd', () => {
+  it('groups entries by date, sorts groups descending, preserves entry order within a group', () => {
+    const result = buildLogMd([
+      { date: '2026-01-01', text: 'A' },
+      { date: '2026-01-02', text: 'B' },
+      { date: '2026-01-01', text: 'C' },
+    ]);
+    expect(result).toBe('## 2026-01-02\n\n- B\n\n## 2026-01-01\n\n- A\n- C\n');
+  });
+
+  it('renders an ISO YYYY-MM-DD heading for a single entry', () => {
+    const result = buildLogMd([{ date: '2026-06-18', text: 'X' }]);
+    expect(result).toBe('## 2026-06-18\n\n- X\n');
+  });
+
+  it('renders an empty string for an empty entries list', () => {
+    expect(buildLogMd([])).toBe('');
+  });
+});

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/core-okf",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "Zero-dependency Open Knowledge Format (OKF) v0.1 primitives: frontmatter serialization, concept documents, index.md and log.md builders.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@equationalapplications/core-llm-wiki",
-  "version": "4.12.0",
-  "description": "Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter.",
+  "name": "@equationalapplications/core-okf",
+  "version": "4.11.0",
+  "description": "Zero-dependency Open Knowledge Format (OKF) v0.1 primitives: frontmatter serialization, concept documents, index.md and log.md builders.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -10,11 +10,6 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
-    },
-    "./testing": {
-      "types": "./dist/testing.d.ts",
-      "require": "./dist/testing.js",
-      "import": "./dist/testing.mjs"
     }
   },
   "scripts": {
@@ -31,27 +26,22 @@
   ],
   "license": "MIT",
   "keywords": [
-    "llm-memory",
-    "ai-memory",
-    "rag",
-    "sqlite",
-    "vector-search",
-    "episodic-memory",
-    "semantic-memory",
-    "multi-agent",
-    "typescript",
-    "gemini",
-    "openai"
+    "okf",
+    "open-knowledge-format",
+    "markdown",
+    "frontmatter",
+    "knowledge-graph",
+    "typescript"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
-    "directory": "packages/core"
+    "directory": "packages/okf"
   },
   "bugs": {
     "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
   },
-  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/core#readme",
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/okf#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
@@ -59,13 +49,7 @@
   "engines": {
     "node": ">=20"
   },
-  "dependencies": {
-    "minisearch": "^7.0.0",
-    "@equationalapplications/core-okf": "workspace:*"
-  },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "^12.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
     "vitest": "4.1.5"

--- a/packages/okf/src/concept.ts
+++ b/packages/okf/src/concept.ts
@@ -1,0 +1,6 @@
+import type { OkfFrontmatter } from './types';
+import { serializeFrontmatter } from './frontmatter';
+
+export function buildConceptDocument(fm: OkfFrontmatter, body: string): string {
+  return `${serializeFrontmatter(fm)}\n${body}`;
+}

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -14,6 +14,11 @@ function needsQuoting(value: string): boolean {
   if (value !== value.trim()) return true;
   if (/[\n\r\t]/.test(value)) return true;
   if (isIso8601Timestamp(value)) return false;
+
+  // Quote strings that YAML could otherwise parse as collections/indicators.
+  if (/^[-?:]\s/.test(value)) return true;
+  if (/^[\[\]{}&,*%!|>'"@`]/.test(value)) return true;
+
   if (value.includes(':') || value.includes('#')) return true;
   if (RESERVED_LITERALS.has(value.toLowerCase())) return true;
   if (looksLikeNumber(value)) return true;

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -12,6 +12,7 @@ function isIso8601Timestamp(value: string): boolean {
 
 function needsQuoting(value: string): boolean {
   if (value !== value.trim()) return true;
+  if (/[\n\r\t]/.test(value)) return true;
   if (isIso8601Timestamp(value)) return false;
   if (value.includes(':') || value.includes('#')) return true;
   if (RESERVED_LITERALS.has(value.toLowerCase())) return true;
@@ -20,12 +21,24 @@ function needsQuoting(value: string): boolean {
 }
 
 function quoteString(value: string): string {
-  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
   return `"${escaped}"`;
 }
 
 function serializeScalarString(value: string): string {
   return needsQuoting(value) ? quoteString(value) : value;
+}
+
+function serializeKey(key: string): string {
+  if (/\s/.test(key) || needsQuoting(key)) {
+    return quoteString(key);
+  }
+  return key;
 }
 
 function serializeValue(value: unknown): string {
@@ -42,9 +55,9 @@ export function serializeFrontmatter(fm: OkfFrontmatter): string {
     if (value === undefined) continue;
     if (Array.isArray(value)) {
       if (value.length === 0) {
-        lines.push(`${key}: []`);
+        lines.push(`${serializeKey(key)}: []`);
       } else {
-        lines.push(`${key}:`);
+        lines.push(`${serializeKey(key)}:`);
         for (const item of value as unknown[]) {
           if (typeof item === 'string') {
             lines.push(`  - ${serializeScalarString(item)}`);
@@ -54,7 +67,7 @@ export function serializeFrontmatter(fm: OkfFrontmatter): string {
         }
       }
     } else {
-      lines.push(`${key}: ${serializeValue(value)}`);
+      lines.push(`${serializeKey(key)}: ${serializeValue(value)}`);
     }
   }
   lines.push('---');

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -40,7 +40,9 @@ export function serializeScalarString(value: string): string {
 }
 
 function serializeKey(key: string): string {
-  if (/\s/.test(key) || needsQuoting(key)) {
+  // needsQuoting() intentionally exempts ISO 8601 timestamps for *values*.
+  // For keys, quote timestamp-like scalars to avoid YAML timestamp coercion in some parsers.
+  if (/\s/.test(key) || needsQuoting(key) || isIso8601Timestamp(key)) {
     return quoteString(key);
   }
   return key;

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -1,0 +1,58 @@
+import type { OkfFrontmatter } from './types';
+
+const RESERVED_LITERALS = new Set(['true', 'false', 'yes', 'no', 'on', 'off', 'null', '~', '']);
+
+function looksLikeNumber(value: string): boolean {
+  return /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(value);
+}
+
+function isIso8601Timestamp(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value);
+}
+
+function needsQuoting(value: string): boolean {
+  if (value !== value.trim()) return true;
+  if (isIso8601Timestamp(value)) return false;
+  if (value.includes(':') || value.includes('#')) return true;
+  if (RESERVED_LITERALS.has(value.toLowerCase())) return true;
+  if (looksLikeNumber(value)) return true;
+  return false;
+}
+
+function quoteString(value: string): string {
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function serializeScalarString(value: string): string {
+  return needsQuoting(value) ? quoteString(value) : value;
+}
+
+function serializeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'boolean') return String(value);
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'string') return serializeScalarString(value);
+  throw new Error(`Unsupported frontmatter value type: ${typeof value}`);
+}
+
+export function serializeFrontmatter(fm: OkfFrontmatter): string {
+  const lines: string[] = ['---'];
+  for (const [key, value] of Object.entries(fm)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        lines.push(`${key}: []`);
+      } else {
+        lines.push(`${key}:`);
+        for (const item of value as unknown[]) {
+          lines.push(`  - ${serializeScalarString(item as string)}`);
+        }
+      }
+    } else {
+      lines.push(`${key}: ${serializeValue(value)}`);
+    }
+  }
+  lines.push('---');
+  return lines.join('\n') + '\n';
+}

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -7,7 +7,7 @@ function looksLikeNumber(value: string): boolean {
 }
 
 function isIso8601Timestamp(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value);
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2}|[+-]\d{4}|[+-]\d{2})$/.test(value);
 }
 
 function needsQuoting(value: string): boolean {
@@ -46,7 +46,11 @@ export function serializeFrontmatter(fm: OkfFrontmatter): string {
       } else {
         lines.push(`${key}:`);
         for (const item of value as unknown[]) {
-          lines.push(`  - ${serializeScalarString(item as string)}`);
+          if (typeof item === 'string') {
+            lines.push(`  - ${serializeScalarString(item)}`);
+          } else {
+            lines.push(`  - ${serializeValue(item)}`);
+          }
         }
       }
     } else {

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -30,7 +30,7 @@ function quoteString(value: string): string {
   return `"${escaped}"`;
 }
 
-function serializeScalarString(value: string): string {
+export function serializeScalarString(value: string): string {
   return needsQuoting(value) ? quoteString(value) : value;
 }
 

--- a/packages/okf/src/index-md.ts
+++ b/packages/okf/src/index-md.ts
@@ -2,9 +2,19 @@ import { serializeScalarString } from './frontmatter';
 import type { OkfIndexEntry, OkfIndexSection } from './types';
 
 function renderEntry(entry: OkfIndexEntry): string {
-  return entry.description
-    ? `* [${entry.title}](${entry.path}) - ${entry.description}`
-    : `* [${entry.title}](${entry.path})`;
+  const esc = (s: string) =>
+    s
+      .replace(/\\/g, '\\\\')
+      .replace(/\[/g, '\\[')
+      .replace(/\]/g, '\\]')
+      .replace(/\r?\n/g, ' ');
+
+  const title = esc(entry.title);
+  const description = entry.description ? esc(entry.description) : undefined;
+
+  return description
+    ? `* [${title}](${entry.path}) - ${description}`
+    : `* [${title}](${entry.path})`;
 }
 
 function renderSections(sections: OkfIndexSection[]): string {

--- a/packages/okf/src/index-md.ts
+++ b/packages/okf/src/index-md.ts
@@ -1,0 +1,30 @@
+import type { OkfIndexEntry, OkfIndexSection } from './types';
+
+function renderEntry(entry: OkfIndexEntry): string {
+  return entry.description
+    ? `* [${entry.title}](${entry.path}) - ${entry.description}`
+    : `* [${entry.title}](${entry.path})`;
+}
+
+function renderSections(sections: OkfIndexSection[]): string {
+  const lines: string[] = [];
+  for (const section of sections) {
+    lines.push(`## ${section.heading}`);
+    lines.push('');
+    for (const entry of section.entries) {
+      lines.push(renderEntry(entry));
+    }
+    lines.push('');
+  }
+  if (lines.length === 0) return '';
+  return lines.join('\n').trimEnd() + '\n';
+}
+
+export function buildIndexMd(sections: OkfIndexSection[]): string {
+  return renderSections(sections);
+}
+
+export function buildRootIndexMd(okfVersion: string, sections: OkfIndexSection[]): string {
+  const frontmatter = `---\nokf_version: "${okfVersion}"\n---\n`;
+  return `${frontmatter}\n${renderSections(sections)}`;
+}

--- a/packages/okf/src/index-md.ts
+++ b/packages/okf/src/index-md.ts
@@ -1,3 +1,4 @@
+import { serializeScalarString } from './frontmatter';
 import type { OkfIndexEntry, OkfIndexSection } from './types';
 
 function renderEntry(entry: OkfIndexEntry): string {
@@ -25,6 +26,6 @@ export function buildIndexMd(sections: OkfIndexSection[]): string {
 }
 
 export function buildRootIndexMd(okfVersion: string, sections: OkfIndexSection[]): string {
-  const frontmatter = `---\nokf_version: "${okfVersion}"\n---\n`;
+  const frontmatter = `---\nokf_version: ${serializeScalarString(okfVersion)}\n---\n`;
   return `${frontmatter}\n${renderSections(sections)}`;
 }

--- a/packages/okf/src/index.ts
+++ b/packages/okf/src/index.ts
@@ -1,0 +1,5 @@
+export type { OkfFrontmatter, OkfIndexEntry, OkfIndexSection, OkfLogEntry, OkfFile } from './types';
+export { serializeFrontmatter } from './frontmatter';
+export { buildConceptDocument } from './concept';
+export { buildIndexMd, buildRootIndexMd } from './index-md';
+export { buildLogMd } from './log-md';

--- a/packages/okf/src/log-md.ts
+++ b/packages/okf/src/log-md.ts
@@ -1,0 +1,25 @@
+import type { OkfLogEntry } from './types';
+
+export function buildLogMd(entries: OkfLogEntry[]): string {
+  const groups = new Map<string, OkfLogEntry[]>();
+  for (const entry of entries) {
+    const group = groups.get(entry.date) ?? [];
+    group.push(entry);
+    groups.set(entry.date, group);
+  }
+
+  const dates = Array.from(groups.keys()).sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+
+  const lines: string[] = [];
+  for (const date of dates) {
+    lines.push(`## ${date}`);
+    lines.push('');
+    for (const entry of groups.get(date)!) {
+      lines.push(`- ${entry.text}`);
+    }
+    lines.push('');
+  }
+
+  if (lines.length === 0) return '';
+  return lines.join('\n').trimEnd() + '\n';
+}

--- a/packages/okf/src/types.ts
+++ b/packages/okf/src/types.ts
@@ -1,3 +1,6 @@
+export type OkfFrontmatterScalar = string | number | boolean | null;
+export type OkfFrontmatterValue = OkfFrontmatterScalar | OkfFrontmatterScalar[];
+
 export interface OkfFrontmatter {
   type: string;
   title?: string;
@@ -5,11 +8,11 @@ export interface OkfFrontmatter {
   resource?: string;
   tags?: string[];
   timestamp?: string; // ISO 8601
-  [key: string]: unknown; // producers may add custom keys; consumers must preserve them
+  [key: string]: OkfFrontmatterValue | undefined; // custom keys; values must be serializable scalars or scalar arrays
 }
 
 export interface OkfIndexEntry {
-  path: string; // bundle-relative, e.g. 'entities/alice/facts/fact_123.md'
+  path: string; // relative to the index.md that contains the link, e.g. 'facts/fact_123.md'
   title: string;
   description?: string;
 }

--- a/packages/okf/src/types.ts
+++ b/packages/okf/src/types.ts
@@ -1,0 +1,30 @@
+export interface OkfFrontmatter {
+  type: string;
+  title?: string;
+  description?: string;
+  resource?: string;
+  tags?: string[];
+  timestamp?: string; // ISO 8601
+  [key: string]: unknown; // producers may add custom keys; consumers must preserve them
+}
+
+export interface OkfIndexEntry {
+  path: string; // bundle-relative, e.g. 'entities/alice/facts/fact_123.md'
+  title: string;
+  description?: string;
+}
+
+export interface OkfIndexSection {
+  heading: string; // e.g. 'Facts'
+  entries: OkfIndexEntry[];
+}
+
+export interface OkfLogEntry {
+  date: string; // ISO 8601 YYYY-MM-DD, used for grouping/heading
+  text: string; // rendered line content; may include a markdown link
+}
+
+export interface OkfFile {
+  path: string;
+  content: string;
+}

--- a/packages/okf/tsconfig.json
+++ b/packages/okf/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/okf/tsup.config.ts
+++ b/packages/okf/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+});

--- a/packages/okf/vitest.config.ts
+++ b/packages/okf/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@equationalapplications/core-okf':
+        specifier: workspace:*
+        version: link:../okf
       minisearch:
         specifier: ^7.0.0
         version: 7.2.0
@@ -239,6 +242,18 @@ importers:
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/okf:
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       typescript:
         specifier: ^5.4.0
         version: 5.9.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "./packages/expo" },
     { "path": "./packages/react" },
     { "path": "./packages/prisma-outbox" },
-    { "path": "./packages/core-llm-tools" }
+    { "path": "./packages/core-llm-tools" },
+    { "path": "./packages/okf" }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       'packages/core/__tests__/**/*.test.ts',
       'packages/expo/__tests__/**/*.test.ts',
       'packages/core-llm-tools/__tests__/**/*.test.ts',
+      'packages/okf/__tests__/**/*.test.ts',
     ],
     environment: 'node',
   },


### PR DESCRIPTION
## Summary

Specification: docs/superpowers/specs/2026-06-18-okf-export-design.md

- Add `@equationalapplications/core-okf` (`packages/okf`), a zero-dependency package with OKF v0.1 primitives: YAML frontmatter serialization, concept document assembly, and `index.md`/`log.md` builders.
- Add `formatOkfBundle` in `packages/core` to map `MemoryDump` → a flat `{ path, content }[]` OKF bundle (root `index.md`, per-entity concept files, entity indexes, and event logs).
- Extract `sanitizeForFilename` from `formatMemoryDump` so both export paths share identical entity-directory naming.

## Test plan

- [x] `pnpm --filter @equationalapplications/core-okf test` — 20 tests pass
- [x] `pnpm --filter @equationalapplications/core-llm-wiki test` — includes 5 `sanitizeForFilename` and 9 `formatOkfBundle` tests
- [x] `pnpm -r typecheck` — all packages pass
- [x] `pnpm -r build` — all packages build
- [x] `pnpm test` — full monorepo suite passes


Made with [Cursor](https://cursor.com)