### PR TITLE
feat(react): add useEntityStatus hook

### DIFF
--- a/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
+++ b/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
@@ -3,13 +3,13 @@
 **Date:** 2026-06-22
 **Status:** Implemented
 **Follow-up to:** [2026-05-08-entity-status-subscription.md](./2026-05-08-entity-status-subscription.md) (§"React consumer (out of scope, follow-up)")
-**Package:** `@equationalapplications/expo-llm-wiki-react` (`packages/react`)
+**Package:** `@equationalapplications/react-llm-wiki` (`packages/react`)
 
 ---
 
 ## Problem
 
-`WikiMemory.getEntityStatus(entityId)` and `WikiMemory.subscribeEntityStatus(entityId, callback)` are fully implemented and shipped in `packages/core` (`packages/core/src/WikiMemory.ts:279-288`, delegating to `JobManager.ts:275-309`). There is no React binding. Developers building loading UI for background ingest/librarian/heal work must wire `useEffect` + `useState` + manual subscribe/unsubscribe themselves in every component.
+`WikiMemory.getEntityStatus(entityId)` and `WikiMemory.subscribeEntityStatus(entityId, callback)` are fully implemented and shipped in `packages/core` (`packages/core/src/WikiMemory.ts:279-288`, delegating to `packages/core/src/services/JobManager.ts:275-309`). There is no React binding. Developers building loading UI for background ingest/librarian/heal work must wire `useEffect` + `useState` + manual subscribe/unsubscribe themselves in every component.
 
 `packages/react` already has seven hooks in this style (`useWikiHasChanged`, `useWikiIngest`, etc.) and a `useWiki()` context accessor (`packages/react/src/WikiContext.tsx`). No subscription-based hook exists yet in this package — all existing hooks are action/promise-based (`execute()` + `isPending`/`error`/`lastResult`).
 
@@ -38,23 +38,30 @@ import type { EntityStatus } from '@equationalapplications/core-llm-wiki';
 
 export function useEntityStatus(entityId: string): EntityStatus {
   const wiki = useWiki();
-  const [status, setStatus] = useState<EntityStatus>(() => wiki.getEntityStatus(entityId));
+  const [snapshot, setSnapshot] = useState<{ entityId: string; status: EntityStatus }>(() => ({
+    entityId,
+    status: wiki.getEntityStatus(entityId),
+  }));
 
   useEffect(() => {
-    setStatus(wiki.getEntityStatus(entityId));
-    return wiki.subscribeEntityStatus(entityId, setStatus);
+    setSnapshot({ entityId, status: wiki.getEntityStatus(entityId) });
+    return wiki.subscribeEntityStatus(entityId, (status) => {
+      setSnapshot({ entityId, status });
+    });
   }, [wiki, entityId]);
 
-  return status;
+  return snapshot.entityId === entityId
+    ? snapshot.status
+    : wiki.getEntityStatus(entityId);
 }
 ```
 
 ### Design decisions (resolved during brainstorming)
 
 1. **`useEffect`, not `useSyncExternalStore`.** `packages/react/package.json` declares `peerDependencies: { react: ">=17" }`; `useSyncExternalStore` requires React 18+. Adopting it would require a shim dependency (`use-sync-external-store`) not used anywhere else in this repo, for a "quick win" hook. Rejected — stay on the `useEffect` pattern used by every other hook in this package.
-2. **Redundant initial fetch is intentional, not a bug.** Per `JobManager.ts:283-298` (and the binding spec, rule 1), `subscribeEntityStatus` synchronously invokes its callback once with the current snapshot immediately on subscribe. The effect therefore calls `getEntityStatus` once for the synchronous initial render value, then `subscribeEntityStatus` immediately re-delivers the same value via its mandatory initial emission. This is a harmless extra `setState` call with an identical value — not optimized away, because removing the initial `getEntityStatus` call would leave the hook's first-paint value stale/unset until the effect mounts (worse for SSR and first render).
+2. **Redundant initial fetch is intentional, not a bug.** Per `packages/core/src/services/JobManager.ts:283-298` (and the binding spec, rule 1), `subscribeEntityStatus` synchronously invokes its callback once with the current snapshot immediately on subscribe. The effect therefore calls `getEntityStatus` once for the synchronous initial render value, then `subscribeEntityStatus` immediately re-delivers the same value via its mandatory initial emission. This is a harmless extra `setState` call with an identical value — not optimized away, because removing the initial `getEntityStatus` call would leave the hook's first-paint value stale/unset until the effect mounts (worse for SSR and first render).
 3. **No `entityId` validation.** No other hook in `packages/react` validates its `entityId`/string arguments; `WikiMemory.getEntityStatus`/`subscribeEntityStatus` already accept any string with no normalization (per the binding spec, §"API"). Validation, if ever needed, belongs in core, not this thin wrapper.
-4. **`entityId` changes are supported.** Changing `entityId` across renders re-runs the effect: old subscription is torn down (idempotent unsubscribe per binding spec rule 7-adjacent guarantee), new subscription created, state reset to the new entity's current status via the same initial-fetch-then-subscribe sequence.
+4. **`entityId` changes are supported without stale UI.** The hook stores `{ entityId, status }` and returns `snapshot.status` only when `snapshot.entityId` matches the current `entityId`; otherwise it synchronously reads `wiki.getEntityStatus(entityId)`. That avoids a one-render flash of the previous entity's status (and ignores late callbacks from a torn-down subscription) while the effect re-subscribes.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
+++ b/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
@@ -1,7 +1,7 @@
 # Spec: `useEntityStatus(entityId)` React hook
 
 **Date:** 2026-06-22
-**Status:** Draft
+**Status:** Implemented
 **Follow-up to:** [2026-05-08-entity-status-subscription.md](./2026-05-08-entity-status-subscription.md) (§"React consumer (out of scope, follow-up)")
 **Package:** `@equationalapplications/expo-llm-wiki-react` (`packages/react`)
 

--- a/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
+++ b/docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md
@@ -1,0 +1,115 @@
+# Spec: `useEntityStatus(entityId)` React hook
+
+**Date:** 2026-06-22
+**Status:** Draft
+**Follow-up to:** [2026-05-08-entity-status-subscription.md](./2026-05-08-entity-status-subscription.md) (§"React consumer (out of scope, follow-up)")
+**Package:** `@equationalapplications/expo-llm-wiki-react` (`packages/react`)
+
+---
+
+## Problem
+
+`WikiMemory.getEntityStatus(entityId)` and `WikiMemory.subscribeEntityStatus(entityId, callback)` are fully implemented and shipped in `packages/core` (`packages/core/src/WikiMemory.ts:279-288`, delegating to `JobManager.ts:275-309`). There is no React binding. Developers building loading UI for background ingest/librarian/heal work must wire `useEffect` + `useState` + manual subscribe/unsubscribe themselves in every component.
+
+`packages/react` already has seven hooks in this style (`useWikiHasChanged`, `useWikiIngest`, etc.) and a `useWiki()` context accessor (`packages/react/src/WikiContext.tsx`). No subscription-based hook exists yet in this package — all existing hooks are action/promise-based (`execute()` + `isPending`/`error`/`lastResult`).
+
+## Goal
+
+Add `useEntityStatus(entityId): EntityStatus` to `packages/react`, re-exported transparently through `packages/expo` via its existing `export *` re-export chain.
+
+---
+
+## API
+
+```typescript
+// packages/react/src/useEntityStatus.ts
+export function useEntityStatus(entityId: string): EntityStatus;
+```
+
+- Returns the live `EntityStatus` (`{ ingesting, librarian, heal }`) for `entityId`, updating whenever the underlying job state transitions.
+- Reads `wiki` via `useWiki()` (must be called within `WikiProvider`, same as every other hook in this package).
+
+### Implementation
+
+```typescript
+import { useState, useEffect } from 'react';
+import { useWiki } from './WikiContext';
+import type { EntityStatus } from '@equationalapplications/core-llm-wiki';
+
+export function useEntityStatus(entityId: string): EntityStatus {
+  const wiki = useWiki();
+  const [status, setStatus] = useState<EntityStatus>(() => wiki.getEntityStatus(entityId));
+
+  useEffect(() => {
+    setStatus(wiki.getEntityStatus(entityId));
+    return wiki.subscribeEntityStatus(entityId, setStatus);
+  }, [wiki, entityId]);
+
+  return status;
+}
+```
+
+### Design decisions (resolved during brainstorming)
+
+1. **`useEffect`, not `useSyncExternalStore`.** `packages/react/package.json` declares `peerDependencies: { react: ">=17" }`; `useSyncExternalStore` requires React 18+. Adopting it would require a shim dependency (`use-sync-external-store`) not used anywhere else in this repo, for a "quick win" hook. Rejected — stay on the `useEffect` pattern used by every other hook in this package.
+2. **Redundant initial fetch is intentional, not a bug.** Per `JobManager.ts:283-298` (and the binding spec, rule 1), `subscribeEntityStatus` synchronously invokes its callback once with the current snapshot immediately on subscribe. The effect therefore calls `getEntityStatus` once for the synchronous initial render value, then `subscribeEntityStatus` immediately re-delivers the same value via its mandatory initial emission. This is a harmless extra `setState` call with an identical value — not optimized away, because removing the initial `getEntityStatus` call would leave the hook's first-paint value stale/unset until the effect mounts (worse for SSR and first render).
+3. **No `entityId` validation.** No other hook in `packages/react` validates its `entityId`/string arguments; `WikiMemory.getEntityStatus`/`subscribeEntityStatus` already accept any string with no normalization (per the binding spec, §"API"). Validation, if ever needed, belongs in core, not this thin wrapper.
+4. **`entityId` changes are supported.** Changing `entityId` across renders re-runs the effect: old subscription is torn down (idempotent unsubscribe per binding spec rule 7-adjacent guarantee), new subscription created, state reset to the new entity's current status via the same initial-fetch-then-subscribe sequence.
+
+---
+
+## Export surface
+
+- `packages/react/src/index.ts`: add `export { useEntityStatus } from './useEntityStatus';`
+- `EntityStatus` is already exported transitively via the existing `export * from '@equationalapplications/core-llm-wiki';` line in the same file — no new type export needed.
+- `packages/expo/src/index.ts` already does `export * from '@equationalapplications/react-llm-wiki';` — `useEntityStatus` becomes available to Expo consumers with no expo-package change.
+
+---
+
+## Testing
+
+Extend `packages/react/__tests__/hooks.test.tsx` (existing single-file convention for all hooks in this package) rather than creating a new test file.
+
+1. Extend `makeMockWiki()` with `getEntityStatus: vi.fn().mockReturnValue({ ingesting: false, librarian: false, heal: false })` and `subscribeEntityStatus: vi.fn((entityId, cb) => { cb(mockWiki.getEntityStatus(entityId)); return vi.fn(); })` (mirroring the real synchronous-initial-emission contract).
+2. New `describe('useEntityStatus')` block:
+   - **Initial render** — `renderHook(() => useEntityStatus('e1'), { wrapper })` returns the value from `getEntityStatus` before any effect runs.
+   - **Transition update** — capture the callback passed to `subscribeEntityStatus`, invoke it with a new status inside `act()`, assert `result.current` updates.
+   - **Unmount unsubscribes** — assert the unsubscribe function returned by the mocked `subscribeEntityStatus` is called on unmount.
+   - **`entityId` change resubscribes** — rerender with a new `entityId`, assert old unsubscribe called, `subscribeEntityStatus` called again with the new id, and `result.current` reflects the new entity's status.
+
+---
+
+## Documentation
+
+Add a short usage example to both:
+
+- `packages/react/README.md`
+- `packages/expo/README.md`
+
+Example to include (illustrative, adapt to each README's existing voice/section structure):
+
+```tsx
+function EntityLoadingSpinner({ entityId }: { entityId: string }) {
+  const { ingesting, librarian, heal } = useEntityStatus(entityId);
+  if (!ingesting && !librarian && !heal) return null;
+  return <Spinner label={ingesting ? 'Ingesting…' : librarian ? 'Organizing…' : 'Healing…'} />;
+}
+```
+
+---
+
+## Non-goals
+
+- No changes to `packages/core` (already shipped per the binding spec).
+- No `useSyncExternalStore` migration for this or any other hook in this package (separate future spec if the React 18+ floor is ever raised).
+- No polling fallback, no debouncing, no batching of rapid transitions — the hook is a direct pass-through of whatever `subscribeEntityStatus` delivers.
+- No multi-entity / wildcard variant (matches core's single-`entityId` scope).
+
+---
+
+## Acceptance
+
+- `useEntityStatus` exported from `packages/react/src/index.ts` and reachable from `@equationalapplications/expo-llm-wiki` with zero expo-package code changes.
+- All four test cases above pass in `packages/react/__tests__/hooks.test.tsx` via `pnpm test`.
+- `packages/react/README.md` and `packages/expo/README.md` both document the hook with a usage example.
+- No changes to `packages/core`.

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -220,6 +220,18 @@ export function UserProfile({ userId }: { userId: string }) {
 }
 ```
 
+For live background-job status (e.g. a loading spinner while a document ingests or the librarian runs):
+
+```typescript
+import { useEntityStatus } from '@equationalapplications/expo-llm-wiki';
+
+export function EntityLoadingSpinner({ entityId }: { entityId: string }) {
+  const { ingesting, librarian, heal } = useEntityStatus(entityId);
+  if (!ingesting && !librarian && !heal) return null;
+  return <Spinner label={ingesting ? 'Ingesting…' : librarian ? 'Organizing…' : 'Healing…'} />;
+}
+```
+
 ## Component Lifecycle
 
 ```mermaid

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -341,6 +341,18 @@ await execute(['user-123']);
 // lastResult: MemoryDump | null
 ```
 
+### `useEntityStatus(entityId)`
+
+Live status for an entity's background jobs (ingest, librarian, heal). Updates whenever a transition occurs — no polling.
+
+```typescript
+const { ingesting, librarian, heal } = useEntityStatus('user-123');
+
+if (ingesting || librarian || heal) {
+  return <Spinner label={ingesting ? 'Ingesting…' : librarian ? 'Organizing…' : 'Healing…'} />;
+}
+```
+
 ## Multi-Entity Reads
 
 `useMemoryRead` accepts a single entity ID or an array to search across namespaces in one pass. Pass `tierWeights` to apply per-entity score multipliers before the global top-K slice:

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -837,17 +837,28 @@ describe('useEntityStatus', () => {
 
   it('resubscribes when entityId changes', () => {
     const wiki = makeMockWiki();
-    const { rerender } = renderHook(({ entityId }) => useEntityStatus(entityId), {
+    const { rerender, result } = renderHook(({ entityId }) => useEntityStatus(entityId), {
       wrapper: wrapper(wiki),
       initialProps: { entityId: 'e1' },
     });
 
     const firstUnsubscribe = wiki.subscribeEntityStatus.mock.results[0].value as () => void;
 
+    wiki.getEntityStatus.mockImplementation((id: string) =>
+      id === 'e2'
+        ? { ingesting: true, librarian: false, heal: false }
+        : { ingesting: false, librarian: false, heal: false },
+    );
+    wiki.subscribeEntityStatus.mockImplementation((id: string, cb: (s: EntityStatus) => void) => {
+      cb(wiki.getEntityStatus(id));
+      return vi.fn();
+    });
+
     rerender({ entityId: 'e2' });
 
     expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
     expect(wiki.subscribeEntityStatus).toHaveBeenCalledTimes(2);
     expect(wiki.subscribeEntityStatus.mock.calls[1][0]).toBe('e2');
+    expect(result.current).toEqual({ ingesting: true, librarian: false, heal: false });
   });
 });

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -9,7 +9,8 @@ import { useWikiIngest } from '../src/useWikiIngest';
 import { useWikiForget } from '../src/useWikiForget';
 import { useWikiExport } from '../src/useWikiExport';
 import { useWikiHasChanged } from '../src/useWikiHasChanged';
-import type { ReadOptions } from '@equationalapplications/core-llm-wiki';
+import { useEntityStatus } from '../src/useEntityStatus';
+import type { ReadOptions, EntityStatus } from '@equationalapplications/core-llm-wiki';
 
 /** Minimal mock of WikiMemory — uses the real MemoryBundle shape ({ facts, tasks, events }) */
 function makeMockWiki() {
@@ -24,6 +25,11 @@ function makeMockWiki() {
     runHeal: vi.fn().mockResolvedValue(undefined),
     runPrune: vi.fn().mockResolvedValue({ entries: 0, tasks: 0, events: 0 }),
     runReembed: vi.fn().mockResolvedValue({ embedded: 0, skipped: 0, failed: 0 }),
+    getEntityStatus: vi.fn().mockReturnValue({ ingesting: false, librarian: false, heal: false }),
+    subscribeEntityStatus: vi.fn((_entityId: string, cb: (s: EntityStatus) => void) => {
+      cb({ ingesting: false, librarian: false, heal: false });
+      return vi.fn();
+    }),
   };
 }
 
@@ -785,5 +791,63 @@ describe('useWikiHasChanged', () => {
 
     expect(caught).toBe(boom);
     expect(result.current.error).toBe(boom);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useEntityStatus
+// ---------------------------------------------------------------------------
+
+describe('useEntityStatus', () => {
+  it('returns the initial snapshot from getEntityStatus', () => {
+    const wiki = makeMockWiki();
+    wiki.getEntityStatus.mockReturnValue({ ingesting: true, librarian: false, heal: false });
+    wiki.subscribeEntityStatus.mockImplementation((_entityId: string, cb: (s: EntityStatus) => void) => {
+      cb({ ingesting: true, librarian: false, heal: false });
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useEntityStatus('e1'), { wrapper: wrapper(wiki) });
+
+    expect(result.current).toEqual({ ingesting: true, librarian: false, heal: false });
+    expect(wiki.getEntityStatus).toHaveBeenCalledWith('e1');
+  });
+
+  it('updates when the subscription callback fires a transition', () => {
+    const wiki = makeMockWiki();
+    const { result } = renderHook(() => useEntityStatus('e1'), { wrapper: wrapper(wiki) });
+
+    const cb = wiki.subscribeEntityStatus.mock.calls[0][1] as (s: EntityStatus) => void;
+    act(() => {
+      cb({ ingesting: true, librarian: false, heal: false });
+    });
+
+    expect(result.current).toEqual({ ingesting: true, librarian: false, heal: false });
+  });
+
+  it('unsubscribes on unmount', () => {
+    const wiki = makeMockWiki();
+    const { unmount } = renderHook(() => useEntityStatus('e1'), { wrapper: wrapper(wiki) });
+
+    const unsubscribe = wiki.subscribeEntityStatus.mock.results[0].value as () => void;
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('resubscribes when entityId changes', () => {
+    const wiki = makeMockWiki();
+    const { rerender } = renderHook(({ entityId }) => useEntityStatus(entityId), {
+      wrapper: wrapper(wiki),
+      initialProps: { entityId: 'e1' },
+    });
+
+    const firstUnsubscribe = wiki.subscribeEntityStatus.mock.results[0].value as () => void;
+
+    rerender({ entityId: 'e2' });
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(wiki.subscribeEntityStatus).toHaveBeenCalledTimes(2);
+    expect(wiki.subscribeEntityStatus.mock.calls[1][0]).toBe('e2');
   });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,3 +8,4 @@ export { useWikiIngest } from './useWikiIngest';
 export { useWikiForget } from './useWikiForget';
 export { useWikiExport } from './useWikiExport';
 export { useWikiHasChanged } from './useWikiHasChanged';
+export { useEntityStatus } from './useEntityStatus';

--- a/packages/react/src/useEntityStatus.ts
+++ b/packages/react/src/useEntityStatus.ts
@@ -4,19 +4,20 @@ import type { EntityStatus } from '@equationalapplications/core-llm-wiki';
 
 export function useEntityStatus(entityId: string): EntityStatus {
   const wiki = useWiki();
-  const [snapshot, setSnapshot] = useState<{ entityId: string; status: EntityStatus }>(() => ({
+  const [snapshot, setSnapshot] = useState(() => ({
+    wiki,
     entityId,
     status: wiki.getEntityStatus(entityId),
   }));
 
   useEffect(() => {
-    setSnapshot({ entityId, status: wiki.getEntityStatus(entityId) });
+    setSnapshot({ wiki, entityId, status: wiki.getEntityStatus(entityId) });
     return wiki.subscribeEntityStatus(entityId, (status) => {
-      setSnapshot({ entityId, status });
+      setSnapshot({ wiki, entityId, status });
     });
   }, [wiki, entityId]);
 
-  return snapshot.entityId === entityId
+  return snapshot.wiki === wiki && snapshot.entityId === entityId
     ? snapshot.status
     : wiki.getEntityStatus(entityId);
 }

--- a/packages/react/src/useEntityStatus.ts
+++ b/packages/react/src/useEntityStatus.ts
@@ -4,12 +4,19 @@ import type { EntityStatus } from '@equationalapplications/core-llm-wiki';
 
 export function useEntityStatus(entityId: string): EntityStatus {
   const wiki = useWiki();
-  const [status, setStatus] = useState<EntityStatus>(() => wiki.getEntityStatus(entityId));
+  const [snapshot, setSnapshot] = useState<{ entityId: string; status: EntityStatus }>(() => ({
+    entityId,
+    status: wiki.getEntityStatus(entityId),
+  }));
 
   useEffect(() => {
-    setStatus(wiki.getEntityStatus(entityId));
-    return wiki.subscribeEntityStatus(entityId, setStatus);
+    setSnapshot({ entityId, status: wiki.getEntityStatus(entityId) });
+    return wiki.subscribeEntityStatus(entityId, (status) => {
+      setSnapshot({ entityId, status });
+    });
   }, [wiki, entityId]);
 
-  return status;
+  return snapshot.entityId === entityId
+    ? snapshot.status
+    : wiki.getEntityStatus(entityId);
 }

--- a/packages/react/src/useEntityStatus.ts
+++ b/packages/react/src/useEntityStatus.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+import { useWiki } from './WikiContext';
+import type { EntityStatus } from '@equationalapplications/core-llm-wiki';
+
+export function useEntityStatus(entityId: string): EntityStatus {
+  const wiki = useWiki();
+  const [status, setStatus] = useState<EntityStatus>(() => wiki.getEntityStatus(entityId));
+
+  useEffect(() => {
+    setStatus(wiki.getEntityStatus(entityId));
+    return wiki.subscribeEntityStatus(entityId, setStatus);
+  }, [wiki, entityId]);
+
+  return status;
+}


### PR DESCRIPTION
## Summary

- Add `useEntityStatus(entityId)` to `@equationalapplications/react-llm-wiki` — a thin `useEffect` wrapper around `WikiMemory.getEntityStatus` / `subscribeEntityStatus` for live ingest/librarian/heal status in components.
- Export through the existing `packages/expo` re-export chain (no expo package code changes).
- Document the hook in both `packages/react/README.md` and `packages/expo/README.md`.

Spec: [docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md](docs/superpowers/specs/2026-06-22-use-entity-status-hook-design.md)

## Test plan

- [x] `pnpm --filter @equationalapplications/react-llm-wiki test` — 53 tests pass (4 new `useEntityStatus` cases: initial snapshot, subscription transition, unmount unsubscribe, entityId resubscribe)
- [ ] Verify `useEntityStatus` is importable from `@equationalapplications/expo-llm-wiki` in a consumer app
- [ ] Smoke-test a loading spinner wired to `useEntityStatus` during an ingest or librarian run