### PR TITLE
feat: add OKF import path with parseOkfBundle and graph edges

### DIFF
--- a/docs/superpowers/specs/2026-06-22-okf-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-okf-import-design.md
@@ -1,6 +1,6 @@
 # Design: Open Knowledge Format (OKF) Import
 
-**Status:** Draft
+**Status:** Implemented
 **Packages:** `@equationalapplications/core-okf` (`packages/okf`); `packages/core` adapter + schema
 **Date:** 2026-06-22
 **Depends on:** `2026-06-18-okf-export-design.md` (export-only; explicitly deferred import)

--- a/docs/superpowers/specs/2026-06-22-okf-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-okf-import-design.md
@@ -133,19 +133,22 @@ A result of `'ignore'` at any step skips the file.
    for both our own exports (which always set the `id` custom key) and foreign bundles (which
    likely don't, per OKF's "only `type` is required" rule).
 2. **Per concept file:** `parseConcept` → frontmatter + body.
-   - Missing `id` → `generateId()`. Missing `created_at`/`updated_at` → `Date.now()`.
+   - Missing `id` → `basename(path)` (filename without `.md`), matching the path map from step 1 so
+     edges and `related_entry_id` resolve consistently. Missing `created_at`/`updated_at` →
+     `Date.now()`.
    - Remaining known frontmatter keys map back onto `WikiFact`/`WikiTask` fields, reversing
      `factFrontmatter`/`taskFrontmatter` from `formatOkfBundle.ts` (`title`, `tags`, `confidence`,
      `source_type`, `source_hash`, `source_ref`, `status`, `priority`, `resolved_at`,
      `deleted_at`, etc., per destination table).
    - `okf_type` field on the resulting `WikiFact`/`WikiTask` = `frontmatter.type` verbatim.
-   - `extractMarkdownLinks(body)`, resolve each `path` via the map from step 1; skip links that
-     don't resolve, or that resolve to `index.md`/`log.md` (structural navigation, not a
+   - `extractMarkdownLinks(body)`, resolve each `path` (after stripping `#…` / `?…` suffixes) via the
+     map from step 1; skip links that don't resolve, or that resolve to `index.md`/`log.md` (structural navigation, not a
      relationship). Emit `WikiEdge { id: generateId(), entity_id, source_id: <this concept's
      resolved id>, target_id: <resolved>, edge_type: text, created_at: Date.now() }`.
 3. **`log.md`** (if present): `parseLogMd` → events. Relative-link targets inside log entries
-   resolve via the same map to hydrate `related_entry_id` — this is the existing event-to-fact
-   relationship, unchanged in kind, just now read instead of only written.
+   resolve via the same map to hydrate `related_entry_id`, but only for paths under `/facts/`
+   (events link to facts on export; task targets are ignored). Fragment (`#…`) and query (`?…`)
+   suffixes are stripped before lookup.
 
 Output: `{ generatedAt: Date.now(), entities: { [entityId]: { facts, tasks, events, edges } } }`.
 

--- a/docs/superpowers/specs/2026-06-22-okf-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-okf-import-design.md
@@ -175,7 +175,7 @@ Output: `{ generatedAt: Date.now(), entities: { [entityId]: { facts, tasks, even
         target_id TEXT NOT NULL,
         edge_type TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        UNIQUE(source_id, target_id, edge_type)
+        UNIQUE(entity_id, source_id, target_id, edge_type)
       );
       CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
     `);
@@ -184,7 +184,7 @@ Output: `{ generatedAt: Date.now(), entities: { [entityId]: { facts, tasks, even
 ```
 
 `okf_type` is nullable; existing rows (pre-migration, or never touched by OKF import) stay
-`NULL`. The `UNIQUE(source_id, target_id, edge_type)` constraint makes re-importing the same
+`NULL`. The `UNIQUE(entity_id, source_id, target_id, edge_type)` constraint makes re-importing the same
 bundle idempotent without needing LWW semantics for edges — there's no "edit an edge", only
 presence/absence.
 

--- a/docs/superpowers/specs/2026-06-22-okf-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-okf-import-design.md
@@ -66,8 +66,8 @@ export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter
 Reads the `---\n...\n---\n` block. Supports scalar string/number/boolean/null, quoted strings
 (matching `serializeFrontmatter`'s quoting rules in reverse), and block string-lists (`  - item`
 lines under a `key:` line). Constructs it doesn't recognize (flow collections `[...]`/`{...}`,
-multi-line block scalars `|`/`>`, anchors/aliases, nested maps) are kept as the raw string value
-rather than causing a parse failure — this is a deliberate narrow subset, not a YAML 1.2 parser.
+multi-line block scalars `|`/`>`, anchors/aliases, nested maps) are silently skipped rather than
+causing a parse failure — this is a deliberate narrow subset, not a YAML 1.2 parser.
 
 **`src/concept.ts`** (add)
 
@@ -174,7 +174,7 @@ Output: `{ generatedAt: Date.now(), entities: { [entityId]: { facts, tasks, even
         created_at INTEGER NOT NULL,
         UNIQUE(source_id, target_id, edge_type)
       );
-      CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_id ON ${prefix}edges (entity_id);
+      CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
     `);
   },
 },

--- a/docs/superpowers/specs/2026-06-22-okf-import-design.md
+++ b/docs/superpowers/specs/2026-06-22-okf-import-design.md
@@ -1,0 +1,284 @@
+# Design: Open Knowledge Format (OKF) Import
+
+**Status:** Draft
+**Packages:** `@equationalapplications/core-okf` (`packages/okf`); `packages/core` adapter + schema
+**Date:** 2026-06-22
+**Depends on:** `2026-06-18-okf-export-design.md` (export-only; explicitly deferred import)
+
+## Problem
+
+The export spec produces a compliant OKF v0.1 bundle from a `MemoryDump` via `formatOkfBundle`,
+but there is no path back: reading a foreign or modified OKF bundle into `WikiMemory` requires
+parsing YAML frontmatter, interpreting `log.md` chronologies, and deciding how arbitrary
+third-party `type` values and markdown cross-links map onto the engine's facts/tasks/events.
+
+This matters now because of the planned **Per-Entity Seeded Ontology** direction (Strict /
+Emergent / Off `OntologyConfig` modes, not yet implemented): OKF's `type` frontmatter field and
+markdown cross-links are exactly the node-type and edge primitives that future ontology graph
+will need. Import should preserve them losslessly today, even though the consumer
+(`OntologyConfig`) doesn't exist yet, rather than discarding them via a forced fact/task
+downcast.
+
+## Goals
+
+- Zero-dependency parsing primitives in `@equationalapplications/core-okf`: extract frontmatter,
+  concept body, `log.md` chronology, and inline markdown links from OKF bundle files.
+- A `parseOkfBundle` adapter in `packages/core` that turns a flat `OkfFile[]` (one entity's
+  subtree) into a `MemoryDump`, fed straight into the existing `wiki.importDump(dump, { merge:
+  true })` pipeline — no changes to `ImportExportService`'s write-path safety (LWW, transactions,
+  embedding-blob handling).
+- Preserve the literal OKF `type` string per concept (no forced downcast to `'fact'`/`'task'`)
+  via a new nullable `okf_type` column, while still routing each concept into the existing
+  `entries`/`tasks` tables (routing is a separate decision from type fidelity).
+- Persist typed relationship edges extracted from markdown cross-links in a concept's body, via a
+  new `edges` table, so the bundle's graph structure survives a round trip.
+
+## Non-Goals
+
+- **No `ontology_manifest` / `OntologyConfig` handling.** `OntologyConfig` doesn't exist in code
+  yet (no type, no storage). Parsing or hydrating it now would be opaque metadata with no
+  consumer. Deferred to a future Per-Entity Seeded Ontology spec.
+- **No graph traversal/query API.** This spec adds enough to persist and round-trip edges
+  (`EdgeRepository.getByEntityId`). Multi-hop queries, path search, or any graph-read surface is
+  future work.
+- **No general YAML or CommonMark parsing.** `parseFrontmatter` supports the exact subset
+  `serializeFrontmatter` produces (scalars, quoted strings, block string-lists). `extractMarkdownLinks`
+  is a single-line inline-link regex, not a markdown AST. Unsupported constructs degrade
+  gracefully (raw-string fallback, or the link/entry is skipped) rather than throwing.
+- **No filesystem/archive I/O.** Same boundary as the export spec — the host application reads
+  files (or a zip) and passes `OkfFile[]` in.
+- **No cross-entity edge integrity guarantees.** An edge's `target_id` may reference a concept in
+  an entity that wasn't included in a given import/export call. Accepted, same class of limitation
+  as today's event `related_entry_id` handling.
+
+## Design
+
+### 1. `packages/okf` — generic parsing primitives
+
+No knowledge of `WikiFact`/`WikiTask`/`WikiEvent`. Mirrors the existing serializer files.
+
+**`src/frontmatter.ts`** (add to existing file)
+
+```ts
+export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter; rest: string };
+```
+
+Reads the `---\n...\n---\n` block. Supports scalar string/number/boolean/null, quoted strings
+(matching `serializeFrontmatter`'s quoting rules in reverse), and block string-lists (`  - item`
+lines under a `key:` line). Constructs it doesn't recognize (flow collections `[...]`/`{...}`,
+multi-line block scalars `|`/`>`, anchors/aliases, nested maps) are kept as the raw string value
+rather than causing a parse failure — this is a deliberate narrow subset, not a YAML 1.2 parser.
+
+**`src/concept.ts`** (add)
+
+```ts
+export function parseConcept(content: string): { frontmatter: OkfFrontmatter; body: string };
+```
+
+**`src/log-md.ts`** (add)
+
+```ts
+export function parseLogMd(content: string): OkfLogEntry[];
+```
+
+Regex over `## YYYY-MM-DD` headings and `- text` bullets underneath, the exact shape
+`buildLogMd` emits. Bundles with differently-formatted `log.md` files are best-effort (entries
+that don't match the pattern are skipped, not thrown).
+
+**`src/markdown-links.ts`** (new)
+
+```ts
+export function extractMarkdownLinks(body: string): Array<{ text: string; path: string }>;
+```
+
+Single-line inline link regex (`[text](path)`). Skips `http://`, `https://`, and `mailto:`
+targets — only relative/local paths are candidate edges.
+
+**`src/index.ts`**: export the four new functions alongside existing exports.
+
+### 2. `packages/core/src/utils/parseOkfBundle.ts` — wiki adapter
+
+```ts
+export interface OkfImportOptions {
+  /**
+   * Routes a concept's OKF `type` to a destination table. This does NOT discard the
+   * original type string — see okf_type below. Any type mapped to 'ignore' is skipped
+   * entirely (no row, no edges from it).
+   */
+  typeMapping?: Record<string, 'fact' | 'task' | 'ignore'>;
+  /** Fallback when typeMapping has no entry and directory convention doesn't apply. Default 'fact'. */
+  defaultSchema?: 'fact' | 'task' | 'ignore';
+}
+
+export function parseOkfBundle(
+  entityId: string,
+  files: OkfFile[],
+  options?: OkfImportOptions,
+): MemoryDump;
+```
+
+**Routing precedence** (decides `entries` vs `tasks` table; independent of type fidelity):
+
+1. `options.typeMapping[frontmatter.type]`, if present.
+2. Else, directory convention: path contains `/facts/` → fact, path contains `/tasks/` → task.
+3. Else, `options.defaultSchema` (default `'fact'`).
+
+A result of `'ignore'` at any step skips the file.
+
+**Two-pass parse per call** (`files` is one entity's subtree, e.g. everything under
+`entities/<dir>/`):
+
+1. **Build `path → resolvedId` map.** For every file other than `index.md`/`log.md`:
+   `frontmatter.id ?? basename(path)` (filename without `.md`). This lets links resolve to ids
+   for both our own exports (which always set the `id` custom key) and foreign bundles (which
+   likely don't, per OKF's "only `type` is required" rule).
+2. **Per concept file:** `parseConcept` → frontmatter + body.
+   - Missing `id` → `generateId()`. Missing `created_at`/`updated_at` → `Date.now()`.
+   - Remaining known frontmatter keys map back onto `WikiFact`/`WikiTask` fields, reversing
+     `factFrontmatter`/`taskFrontmatter` from `formatOkfBundle.ts` (`title`, `tags`, `confidence`,
+     `source_type`, `source_hash`, `source_ref`, `status`, `priority`, `resolved_at`,
+     `deleted_at`, etc., per destination table).
+   - `okf_type` field on the resulting `WikiFact`/`WikiTask` = `frontmatter.type` verbatim.
+   - `extractMarkdownLinks(body)`, resolve each `path` via the map from step 1; skip links that
+     don't resolve, or that resolve to `index.md`/`log.md` (structural navigation, not a
+     relationship). Emit `WikiEdge { id: generateId(), entity_id, source_id: <this concept's
+     resolved id>, target_id: <resolved>, edge_type: text, created_at: Date.now() }`.
+3. **`log.md`** (if present): `parseLogMd` → events. Relative-link targets inside log entries
+   resolve via the same map to hydrate `related_entry_id` — this is the existing event-to-fact
+   relationship, unchanged in kind, just now read instead of only written.
+
+Output: `{ generatedAt: Date.now(), entities: { [entityId]: { facts, tasks, events, edges } } }`.
+
+### 3. `packages/core` schema + service wiring
+
+**Migration v5** (`src/db/migrations.ts`):
+
+```ts
+{
+  version: 5,
+  description: 'Add okf_type to entries/tasks; create edges table for OKF graph import',
+  run: async (db, prefix) => {
+    for (const table of ['entries', 'tasks']) {
+      const cols = await db.getAllAsync<{ name: string }>(`PRAGMA table_info(${prefix}${table})`);
+      if (!cols.some(c => c.name === 'okf_type')) {
+        await db.execAsync(`ALTER TABLE ${prefix}${table} ADD COLUMN okf_type TEXT`);
+      }
+    }
+    await db.execAsync(`
+      CREATE TABLE IF NOT EXISTS ${prefix}edges (
+        id TEXT PRIMARY KEY,
+        entity_id TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        edge_type TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE(source_id, target_id, edge_type)
+      );
+      CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_id ON ${prefix}edges (entity_id);
+    `);
+  },
+},
+```
+
+`okf_type` is nullable; existing rows (pre-migration, or never touched by OKF import) stay
+`NULL`. The `UNIQUE(source_id, target_id, edge_type)` constraint makes re-importing the same
+bundle idempotent without needing LWW semantics for edges — there's no "edit an edge", only
+presence/absence.
+
+**`types.ts`**: add
+
+```ts
+export interface WikiEdge {
+  id: string;
+  entity_id: string;
+  source_id: string;
+  target_id: string;
+  edge_type: string;
+  created_at: number;
+}
+```
+
+Add `edges: WikiEdge[]` to `MemoryBundle`. Add `okf_type?: string | null` to `WikiFact` and
+`WikiTask`.
+
+**New `repositories/EdgeRepository.ts`** (mirrors `EventRepository`):
+
+- `addIgnoreDuplicate(edge: WikiEdge, tx?): Promise<void>` — `INSERT OR IGNORE`.
+- `getByEntityId(entityId: string, tx?): Promise<WikiEdge[]>`.
+- `bulkDeleteByEntityId(entityId: string, tx): Promise<void>` — hard delete (no soft-delete
+  concept for edges); used on non-merge import, mirroring `bulkSoftDeleteByEntityId` for
+  facts/tasks.
+
+**`WikiMemory.ts`**: instantiate `EdgeRepository`, pass it into `ImportExportService`'s
+constructor as a new argument (alongside the existing repos).
+
+**`ImportExportService.ts`**:
+
+- `getFullBundle`: fetch `edges` via `edgeRepo.getByEntityId(entityId, ...)`, include in the
+  returned `MemoryBundle`.
+- `doImportEntity`: in the non-merge branch, call `edgeRepo.bulkDeleteByEntityId(entityId, tx)`
+  alongside the existing fact/task wipe. After the events loop, iterate `bundle.edges` and
+  `edgeRepo.addIgnoreDuplicate(edge, tx)` each — runs in both merge and non-merge modes (the
+  UNIQUE constraint already prevents duplication on repeat import).
+
+**`formatOkfBundle.ts`**: one-line change in each of `factFrontmatter`/`taskFrontmatter` —
+`type: f.okf_type ?? 'fact'` / `type: t.okf_type ?? 'task'` instead of the hardcoded literal. No
+other changes: a concept's body already contains the markdown links that produced its edges, so
+OKF export round-trips the graph "for free" through existing body serialization — re-running
+`parseOkfBundle` on an exported bundle re-derives the same edges.
+
+**`index.ts`**: export `parseOkfBundle`, `OkfImportOptions`, `WikiEdge`.
+
+### 4. File Map
+
+| Package | Action | Path | Responsibility |
+| :--- | :--- | :--- | :--- |
+| `core-okf` | Modify | `src/frontmatter.ts` | Add `parseFrontmatter` |
+| `core-okf` | Create | `src/concept.ts` parse half / modify existing | Add `parseConcept` |
+| `core-okf` | Modify | `src/log-md.ts` | Add `parseLogMd` |
+| `core-okf` | Create | `src/markdown-links.ts` | `extractMarkdownLinks` |
+| `core-okf` | Modify | `src/index.ts` | Export new parse utilities |
+| `core` | Modify | `src/types.ts` | `WikiEdge`, `MemoryBundle.edges`, `okf_type` fields |
+| `core` | Modify | `src/db/migrations.ts` | v5: `okf_type` columns + `edges` table |
+| `core` | Create | `src/repositories/EdgeRepository.ts` | Edge persistence |
+| `core` | Modify | `src/WikiMemory.ts` | Wire `EdgeRepository` into `ImportExportService` |
+| `core` | Modify | `src/services/ImportExportService.ts` | Fetch/wipe/insert edges in bundle lifecycle |
+| `core` | Modify | `src/utils/formatOkfBundle.ts` | `okf_type` fallback (1 line × 2) |
+| `core` | Create | `src/utils/parseOkfBundle.ts` | `OkfFile[]` → `MemoryDump` adapter |
+| `core` | Modify | `src/index.ts` | Export `parseOkfBundle`, `OkfImportOptions`, `WikiEdge` |
+
+### 5. Testing Strategy
+
+`packages/okf/__tests__/`:
+
+- `frontmatter.test.ts` (extend): scalar/quoted-string parsing, block string-lists, unsupported
+  construct → raw-string fallback (round-trips against existing `serializeFrontmatter` fixtures).
+- `concept.test.ts` (extend): split frontmatter/body, minimal `type`-only case.
+- `log-md.test.ts` (extend): heading/bullet extraction, malformed-line skipping, empty content.
+- `markdown-links.test.ts` (new): inline link extraction, `http(s)://`/`mailto:` exclusion,
+  multiple links per line, no-link body.
+
+`packages/core/__tests__/`:
+
+- `migrations.test.ts` (extend): v5 adds `okf_type` columns and `edges` table idempotently
+  (running it twice is a no-op).
+- `EdgeRepository.test.ts` (new): `addIgnoreDuplicate` dedup behavior, `getByEntityId`,
+  `bulkDeleteByEntityId`.
+- `ImportExportService.test.ts` (extend): `getFullBundle` includes edges; `doImportEntity` wipes
+  edges on non-merge, inserts on both modes, re-import doesn't duplicate.
+- `parseOkfBundle.test.ts` (new): all three routing-precedence levels, `'ignore'` skip,
+  `okf_type` preservation for arbitrary third-party type strings, edge extraction + resolution
+  (including unresolved and structural-link skipping), missing-metadata fallback
+  (`generateId()`/`Date.now()`), and a **full round-trip test**: `formatOkfBundle` →
+  `parseOkfBundle` → structurally equivalent `MemoryDump` (facts, tasks, events, and edges).
+
+### 6. Versioning
+
+Additive (semver-minor): new nullable column, new table, new exported functions/types. No
+existing behavior changes except the `okf_type ?? 'fact'/'task'` fallback in `formatOkfBundle`,
+which preserves current output for all pre-existing data.
+
+## Open Questions
+
+None — resolved during brainstorming: schema-now vs. defer (chose minimal schema now), manifest
+handling (deferred), edge source (markdown link text, not frontmatter arrays).

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -38,7 +38,7 @@ describe('WikiMemory (Facade Layer)', () => {
 
   describe('Service Delegation', () => {
     it('delegates read() to RetrievalService', async () => {
-      const mockBundle: MemoryBundle = { facts: [], tasks: [], events: [] };
+      const mockBundle: MemoryBundle = { facts: [], tasks: [], events: [], edges: [] };
       const readSpy = vi
         .spyOn(wiki.__testAccess.retrievalService, 'read')
         .mockResolvedValue(mockBundle);

--- a/packages/core/__tests__/embeddingRetrieval.test.ts
+++ b/packages/core/__tests__/embeddingRetrieval.test.ts
@@ -25,7 +25,7 @@ function makeDump(facts: Array<{ id: string; title: string; body: string }>): Me
           deleted_at: null,
         })),
         tasks: [],
-        events: [],
+        events: [], edges: [],
       },
     },
   };

--- a/packages/core/__tests__/formatContext.test.ts
+++ b/packages/core/__tests__/formatContext.test.ts
@@ -49,7 +49,7 @@ function makeEvent(overrides: Partial<WikiEvent> = {}): WikiEvent {
   };
 }
 
-const emptyBundle: MemoryBundle = { facts: [], tasks: [], events: [] };
+const emptyBundle: MemoryBundle = { facts: [], tasks: [], events: [], edges: [] };
 
 describe('formatContext', () => {
   it('returns empty string for empty bundle', () => {
@@ -61,7 +61,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [makeFact()],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     expect(result).toContain('##');
@@ -86,7 +86,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [makeFact({ title: 'My Fact', body: 'My body' })],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle, { format: 'plain' });
     expect(result).toContain('My Fact');
@@ -101,7 +101,7 @@ describe('formatContext', () => {
         makeFact({ id: 'f3', title: 'Fact 3' }),
       ],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle, { maxFacts: 2 });
     const matches = (result.match(/Fact \d/g) || []).length;
@@ -116,7 +116,7 @@ describe('formatContext', () => {
         makeTask({ id: 't2', description: 'Task 2' }),
         makeTask({ id: 't3', description: 'Task 3' }),
       ],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle, { maxTasks: 1 });
     const matches = (result.match(/Task \d/g) || []).length;
@@ -142,7 +142,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [makeFact({ confidence: 'tentative' })],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const withConf = formatContext(bundle, { includeConfidence: true });
     const withoutConf = formatContext(bundle, { includeConfidence: false });
@@ -154,7 +154,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [makeFact({ tags: ['alpha', 'beta'] })],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const withTags = formatContext(bundle, { includeTags: true });
     const withoutTags = formatContext(bundle, { includeTags: false });
@@ -171,7 +171,7 @@ describe('formatContext', () => {
         makeFact({ id: 'f3', title: 'Inferred fact', confidence: 'inferred', updated_at: now, access_count: 0 }),
       ],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     const certIdx = result.indexOf('Certain fact');
@@ -189,7 +189,7 @@ describe('formatContext', () => {
         makeFact({ id: 'f2', title: 'Fresh fact', confidence: 'certain', updated_at: now, access_count: 0 }),
       ],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     expect(result.indexOf('Fresh fact')).toBeLessThan(result.indexOf('Stale fact'));
@@ -216,7 +216,7 @@ describe('formatContext', () => {
         makeTask({ id: 't2', description: 'High priority', priority: 10, created_at: 200 }),
         makeTask({ id: 't3', description: 'High priority early', priority: 10, created_at: 100 }),
       ],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     const hp1 = result.indexOf('High priority early');
@@ -230,7 +230,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [makeFact({ body: 'Line one\nLine two\nLine three' })],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     expect(result).toContain('  Line two');
@@ -242,7 +242,7 @@ describe('formatContext', () => {
     const bundle: MemoryBundle = {
       facts: [],
       tasks: [makeTask({ description: 'Do this\nAnd also this' })],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle);
     expect(result).toContain('  And also this');
@@ -269,39 +269,39 @@ describe('formatContext', () => {
         makeFact({ id: 'f2', title: 'Inferred high-access', confidence: 'inferred', access_count: 100, updated_at: now }),
       ],
       tasks: [],
-      events: [],
+      events: [], edges: [],
     };
     const result = formatContext(bundle, { factWeights: { confidence: 1.0, accessCount: 10, recency: 0.5 } });
     expect(result.indexOf('Inferred high-access')).toBeLessThan(result.indexOf('Certain low-access'));
   });
 
   it('throws for negative maxFacts', () => {
-    expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxFacts: -1 }))
+    expect(() => formatContext({ facts: [], tasks: [], events: [], edges: [] }, { maxFacts: -1 }))
       .toThrow('Invalid maxFacts: must be a non-negative finite number');
   });
 
   it('throws for non-finite maxFacts (Infinity)', () => {
-    expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxFacts: Infinity }))
+    expect(() => formatContext({ facts: [], tasks: [], events: [], edges: [] }, { maxFacts: Infinity }))
       .toThrow('Invalid maxFacts: must be a non-negative finite number');
   });
 
   it('throws for non-finite maxFacts (NaN)', () => {
-    expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxFacts: NaN }))
+    expect(() => formatContext({ facts: [], tasks: [], events: [], edges: [] }, { maxFacts: NaN }))
       .toThrow('Invalid maxFacts: must be a non-negative finite number');
   });
 
   it('throws for negative maxTasks', () => {
-    expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxTasks: -5 }))
+    expect(() => formatContext({ facts: [], tasks: [], events: [], edges: [] }, { maxTasks: -5 }))
       .toThrow('Invalid maxTasks: must be a non-negative finite number');
   });
 
   it('throws for negative maxEvents', () => {
-    expect(() => formatContext({ facts: [], tasks: [], events: [] }, { maxEvents: -1 }))
+    expect(() => formatContext({ facts: [], tasks: [], events: [], edges: [] }, { maxEvents: -1 }))
       .toThrow('Invalid maxEvents: must be a non-negative finite number');
   });
 
   it('can include fact entity_id provenance', () => {
-    const result = formatContext({ facts: [makeFact({ entity_id: 'tier_wisdom' })], tasks: [], events: [] }, {
+    const result = formatContext({ facts: [makeFact({ entity_id: 'tier_wisdom' })], tasks: [], events: [], edges: [] }, {
       includeEntityIds: true,
     });
     expect(result).toContain('{entity_id=tier_wisdom}');
@@ -314,7 +314,7 @@ describe('formatContext', () => {
         makeFact({ id: 'high', title: 'High', access_count: 0 }),
       ],
       tasks: [],
-      events: [],
+      events: [], edges: [],
       factScores: { low: 0.1, high: 2 },
     };
 

--- a/packages/core/__tests__/formatMemoryDump.test.ts
+++ b/packages/core/__tests__/formatMemoryDump.test.ts
@@ -24,9 +24,9 @@ describe('formatMemoryDump', () => {
             id: 't1', entity_id: 'e1', description: 'do x', status: 'pending',
             priority: 5, created_at: 1000, updated_at: 1000, resolved_at: null, deleted_at: null,
           }],
-          events: [],
+          events: [], edges: [],
         },
-        e2: { facts: [], tasks: [], events: [] },
+        e2: { facts: [], tasks: [], events: [], edges: [] },
       },
     };
     const r = formatMemoryDump(dump);
@@ -37,7 +37,7 @@ describe('formatMemoryDump', () => {
   });
 
   it('manifest is valid JSON with entities', () => {
-    const dump: MemoryDump = { generatedAt: 0, entities: { x: { facts: [], tasks: [], events: [] } } };
+    const dump: MemoryDump = { generatedAt: 0, entities: { x: { facts: [], tasks: [], events: [], edges: [] } } };
     const r = formatMemoryDump(dump);
     const parsed = JSON.parse(r.manifest);
     expect(parsed.entities).toHaveProperty('x');
@@ -53,7 +53,7 @@ describe('formatMemoryDump', () => {
     };
     const dump: MemoryDump = {
       generatedAt: 0,
-      entities: { e1: { facts: [factWithBlob], tasks: [], events: [] } },
+      entities: { e1: { facts: [factWithBlob], tasks: [], events: [], edges: [] } },
     };
     const r = formatMemoryDump(dump);
     const parsed = JSON.parse(r.manifest);
@@ -69,7 +69,7 @@ describe('formatMemoryDump', () => {
         e: {
           facts: [],
           tasks: [{ id: 't', entity_id: 'e', description: 'done task', status: 'done', priority: 0, created_at: 0, updated_at: 0, resolved_at: null, deleted_at: null }],
-          events: [],
+          events: [], edges: [],
         },
       },
     };

--- a/packages/core/__tests__/formatOkfBundle.test.ts
+++ b/packages/core/__tests__/formatOkfBundle.test.ts
@@ -61,7 +61,7 @@ describe('formatOkfBundle', () => {
   it('writes one concept file per fact with correct path and excludes embedding_blob', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
-      entities: { alice: { facts: [makeFact()], tasks: [], events: [] } },
+      entities: { alice: { facts: [makeFact()], tasks: [], events: [], edges: [] } },
     };
     const { files } = formatOkfBundle(dump);
     const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md');
@@ -82,7 +82,7 @@ describe('formatOkfBundle', () => {
   it('omits the resource key when source_ref is null', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
-      entities: { alice: { facts: [makeFact({ source_ref: null })], tasks: [], events: [] } },
+      entities: { alice: { facts: [makeFact({ source_ref: null })], tasks: [], events: [], edges: [] } },
     };
     const { files } = formatOkfBundle(dump);
     const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md')!;
@@ -92,7 +92,7 @@ describe('formatOkfBundle', () => {
   it('writes one concept file per task with description as title and empty body', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
-      entities: { alice: { facts: [], tasks: [makeTask()], events: [] } },
+      entities: { alice: { facts: [], tasks: [makeTask()], events: [], edges: [] } },
     };
     const { files } = formatOkfBundle(dump);
     const taskFile = files.find(f => f.path === 'entities/alice/tasks/task_bbb.md');
@@ -110,6 +110,7 @@ describe('formatOkfBundle', () => {
           facts: [makeFact()],
           tasks: [],
           events: [makeEvent({ related_entry_id: 'fact_aaa', summary: 'Confirmed coffee preference' })],
+          edges: [],
         },
       },
     };
@@ -126,6 +127,7 @@ describe('formatOkfBundle', () => {
           facts: [],
           tasks: [],
           events: [makeEvent({ related_entry_id: 'fact_missing', summary: 'Unlinked event' })],
+          edges: [],
         },
       },
     };
@@ -138,7 +140,7 @@ describe('formatOkfBundle', () => {
   it('builds an entity index.md linking to facts, tasks, and the log', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
-      entities: { alice: { facts: [makeFact()], tasks: [makeTask()], events: [] } },
+      entities: { alice: { facts: [makeFact()], tasks: [makeTask()], events: [], edges: [] } },
     };
     const { files } = formatOkfBundle(dump);
     const entityIndex = files.find(f => f.path === 'entities/alice/index.md')!;
@@ -153,8 +155,8 @@ describe('formatOkfBundle', () => {
     const dump: MemoryDump = {
       generatedAt: 0,
       entities: {
-        alice: { facts: [], tasks: [], events: [] },
-        bob: { facts: [], tasks: [], events: [] },
+        alice: { facts: [], tasks: [], events: [], edges: [] },
+        bob: { facts: [], tasks: [], events: [], edges: [] },
       },
     };
     const { files } = formatOkfBundle(dump);
@@ -170,7 +172,7 @@ describe('formatOkfBundle', () => {
         index: {
           facts: [makeFact({ id: 'index', entity_id: 'index' })],
           tasks: [makeTask({ id: 'log', entity_id: 'index' })],
-          events: [],
+          events: [], edges: [],
         },
       },
     };
@@ -193,7 +195,7 @@ describe('formatOkfBundle', () => {
         alice: {
           facts: [makeFact({ id: '../escape', entity_id: 'alice' })],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     };
@@ -201,5 +203,46 @@ describe('formatOkfBundle', () => {
     const factFile = files.find(f => f.path.startsWith('entities/alice/facts/'))!;
     expect(factFile.path).toMatch(/^entities\/alice\/facts\/escape-[0-9a-f]{16}\.md$/);
     expect(factFile.path).not.toContain('..');
+  });
+
+  it('preserves a fact\'s okf_type instead of hardcoding "fact"', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [makeFact({ okf_type: 'meeting_note' })], tasks: [], events: [], edges: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md')!;
+    expect(factFile.content).toContain('type: meeting_note');
+    expect(factFile.content).not.toContain('type: fact');
+  });
+
+  it('falls back to "fact" type when okf_type is absent', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [makeFact()], tasks: [], events: [], edges: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const factFile = files.find(f => f.path === 'entities/alice/facts/fact_aaa.md')!;
+    expect(factFile.content).toContain('type: fact');
+  });
+
+  it('preserves a task\'s okf_type instead of hardcoding "task"', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [], tasks: [makeTask({ okf_type: 'todo_item' })], events: [], edges: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const taskFile = files.find(f => f.path === 'entities/alice/tasks/task_bbb.md')!;
+    expect(taskFile.content).toContain('type: todo_item');
+  });
+
+  it('falls back to "task" type when okf_type is absent', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: { alice: { facts: [], tasks: [makeTask()], events: [], edges: [] } },
+    };
+    const { files } = formatOkfBundle(dump);
+    const taskFile = files.find(f => f.path === 'entities/alice/tasks/task_bbb.md')!;
+    expect(taskFile.content).toContain('type: task');
   });
 });

--- a/packages/core/__tests__/importDump.test.ts
+++ b/packages/core/__tests__/importDump.test.ts
@@ -249,6 +249,7 @@ function makeDump(entityId: string, factId = 'f1'): MemoryDump {
           summary: 'test event',
           created_at: 1000,
         }],
+        edges: [],
       },
     },
   };
@@ -321,7 +322,7 @@ describe('importDump — busy-key protection', () => {
     return {
       generatedAt: Date.now(),
       entities: {
-        [entityId]: { facts: [], tasks: [], events: [] },
+        [entityId]: { facts: [], tasks: [], events: [], edges: [] },
       },
     };
   }
@@ -355,7 +356,7 @@ describe('importDump — busy-key protection', () => {
             deleted_at: null,
           }],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     };

--- a/packages/core/__tests__/importDumpMerge.test.ts
+++ b/packages/core/__tests__/importDumpMerge.test.ts
@@ -67,12 +67,12 @@ describe('importDump LWW — facts', () => {
     const oldTs = 1000;
     await wiki.importDump({
       generatedAt: oldTs,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'old', updated_at: oldTs })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'old', updated_at: oldTs })], tasks: [], events: [], edges: [] } },
     });
 
     const newTs = 2000;
     await wiki.importDump(
-      { generatedAt: newTs, entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'new', updated_at: newTs })], tasks: [], events: [] } } },
+      { generatedAt: newTs, entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'new', updated_at: newTs })], tasks: [], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -86,11 +86,11 @@ describe('importDump LWW — facts', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 5000,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'local-new', updated_at: 5000 })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'local-new', updated_at: 5000 })], tasks: [], events: [], edges: [] } },
     });
 
     await wiki.importDump(
-      { generatedAt: 1000, entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'remote-old', updated_at: 1000 })], tasks: [], events: [] } } },
+      { generatedAt: 1000, entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'remote-old', updated_at: 1000 })], tasks: [], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -104,11 +104,11 @@ describe('importDump LWW — facts', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 1000,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f1', updated_at: 1000 })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f1', updated_at: 1000 })], tasks: [], events: [], edges: [] } },
     });
 
     await wiki.importDump(
-      { generatedAt: 2000, entities: { 'user-1': { facts: [makeFact({ id: 'f2', updated_at: 2000, body: 'novel' })], tasks: [], events: [] } } },
+      { generatedAt: 2000, entities: { 'user-1': { facts: [makeFact({ id: 'f2', updated_at: 2000, body: 'novel' })], tasks: [], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -123,11 +123,11 @@ describe('importDump LWW — tasks', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 1000,
-      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'old', updated_at: 1000 })], events: [] } },
+      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'old', updated_at: 1000 })], events: [], edges: [] } },
     });
 
     await wiki.importDump(
-      { generatedAt: 2000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'new', updated_at: 2000 })], events: [] } } },
+      { generatedAt: 2000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'new', updated_at: 2000 })], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -139,11 +139,11 @@ describe('importDump LWW — tasks', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 5000,
-      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'local-new', updated_at: 5000 })], events: [] } },
+      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'local-new', updated_at: 5000 })], events: [], edges: [] } },
     });
 
     await wiki.importDump(
-      { generatedAt: 1000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'remote-old', updated_at: 1000 })], events: [] } } },
+      { generatedAt: 1000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'remote-old', updated_at: 1000 })], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -155,11 +155,11 @@ describe('importDump LWW — tasks', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 1000,
-      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', updated_at: 1000 })], events: [] } },
+      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', updated_at: 1000 })], events: [], edges: [] } },
     });
 
     await wiki.importDump(
-      { generatedAt: 2000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't2', description: 'novel task', updated_at: 2000 })], events: [] } } },
+      { generatedAt: 2000, entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't2', description: 'novel task', updated_at: 2000 })], events: [], edges: [] } } },
       { merge: true }
     );
 
@@ -174,13 +174,13 @@ describe('importDump non-merge — replace mode', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 1000,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'old fact', updated_at: 1000 })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'old fact', updated_at: 1000 })], tasks: [], events: [], edges: [] } },
     });
 
     // Non-merge import with different id — old fact should be soft-deleted
     await wiki.importDump({
       generatedAt: 2000,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f2', body: 'replacement', updated_at: 2000 })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f2', body: 'replacement', updated_at: 2000 })], tasks: [], events: [], edges: [] } },
     });
 
     const bundle = await wiki.read('user-1', '');
@@ -194,7 +194,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 5000,
-      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'local-valid', updated_at: 5000 })], tasks: [], events: [] } },
+      entities: { 'user-1': { facts: [makeFact({ id: 'f1', body: 'local-valid', updated_at: 5000 })], tasks: [], events: [], edges: [] } },
     });
 
     await wiki.importDump(
@@ -204,7 +204,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
           'user-1': {
             facts: [makeFact({ id: 'f1', body: 'incoming-nan', updated_at: NaN as unknown as number })],
             tasks: [],
-            events: [],
+            events: [], edges: [],
           },
         },
       },
@@ -219,7 +219,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
     const { wiki } = await open();
     await wiki.importDump({
       generatedAt: 5000,
-      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'local-valid', updated_at: 5000 })], events: [] } },
+      entities: { 'user-1': { facts: [], tasks: [makeTask({ id: 't1', description: 'local-valid', updated_at: 5000 })], events: [], edges: [] } },
     });
 
     await wiki.importDump(
@@ -229,7 +229,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
           'user-1': {
             facts: [],
             tasks: [makeTask({ id: 't1', description: 'incoming-nan', updated_at: NaN as unknown as number })],
-            events: [],
+            events: [], edges: [],
           },
         },
       },
@@ -249,7 +249,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
         'user-1': {
           facts: [makeFact({ id: 'f-nan', body: 'new-nan', updated_at: NaN as unknown as number })],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     });
@@ -272,7 +272,7 @@ describe('importDump LWW — invalid updated_at guard', () => {
         'user-1': {
           facts: [],
           tasks: [makeTask({ id: 't-nan', description: 'new-nan', updated_at: NaN as unknown as number })],
-          events: [],
+          events: [], edges: [],
         },
       },
     });
@@ -295,7 +295,7 @@ describe('importDump LWW — events append-only', () => {
 
     await wiki.importDump({
       generatedAt: ts,
-      entities: { 'user-1': { facts: [], tasks: [], events: [makeEvent({ id: 'e1', summary: 'original' })] } },
+      entities: { 'user-1': { facts: [], tasks: [], events: [makeEvent({ id: 'e1', summary: 'original' })], edges: [] } },
     });
 
     await wiki.importDump(
@@ -309,6 +309,7 @@ describe('importDump LWW — events append-only', () => {
               makeEvent({ id: 'e1', summary: 'should be ignored' }),
               makeEvent({ id: 'e2', summary: 'novel' }),
             ],
+            edges: [],
           },
         },
       },

--- a/packages/core/__tests__/migration2.test.ts
+++ b/packages/core/__tests__/migration2.test.ts
@@ -77,7 +77,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('6');
+    expect(meta?.value).toBe('5');
   });
 
   it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 4', async () => {
@@ -101,7 +101,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('6');
+    expect(meta?.value).toBe('5');
   });
 
   it('running setup() twice is idempotent: embedding column appears once', async () => {

--- a/packages/core/__tests__/migration2.test.ts
+++ b/packages/core/__tests__/migration2.test.ts
@@ -60,7 +60,7 @@ async function makeV1Db() {
   return db;
 }
 
-describe('migration 2+3: remove FTS5, add embedding column, setup ends at version 3', () => {
+describe('migrations v2–v5: FTS removal, embeddings, outbox, okf edges; setup ends at version 5', () => {
   it('fresh install: embedding column exists, FTS5 table absent', async () => {
     const db = openTestDatabase();
     const wiki = new WikiMemory(db, stubOptions);
@@ -80,7 +80,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     expect(meta?.value).toBe('5');
   });
 
-  it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 4', async () => {
+  it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 5', async () => {
     const db = await makeV1Db();
     const wiki = new WikiMemory(db, stubOptions);
     await wiki.setup();

--- a/packages/core/__tests__/migration2.test.ts
+++ b/packages/core/__tests__/migration2.test.ts
@@ -77,7 +77,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('4');
+    expect(meta?.value).toBe('5');
   });
 
   it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 4', async () => {
@@ -101,7 +101,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('4');
+    expect(meta?.value).toBe('5');
   });
 
   it('running setup() twice is idempotent: embedding column appears once', async () => {

--- a/packages/core/__tests__/migration2.test.ts
+++ b/packages/core/__tests__/migration2.test.ts
@@ -77,7 +77,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('5');
+    expect(meta?.value).toBe('6');
   });
 
   it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 4', async () => {
@@ -101,7 +101,7 @@ describe('migration 2+3: remove FTS5, add embedding column, setup ends at versio
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('5');
+    expect(meta?.value).toBe('6');
   });
 
   it('running setup() twice is idempotent: embedding column appears once', async () => {

--- a/packages/core/__tests__/migrations.test.ts
+++ b/packages/core/__tests__/migrations.test.ts
@@ -101,7 +101,7 @@ describe('schema migrations', () => {
     // Should have written schema_version
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '5' || c.args[1] === '5')
     );
     expect(versionWrite).toBeDefined();
 
@@ -122,7 +122,7 @@ describe('schema migrations', () => {
     // Version should have been written
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '5' || c.args[1] === '5')
     );
     expect(versionWrite).toBeDefined();
   });
@@ -145,7 +145,7 @@ describe('schema migrations', () => {
   });
 
   it('already at current version → no migration runs', async () => {
-    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '6' });
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '5' });
     const wiki = createWiki(db);
     await wiki.setup();
 
@@ -170,27 +170,11 @@ describe('schema migrations', () => {
 
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '5' || c.args[1] === '5')
     );
     expect(versionWrite).toBeDefined();
   });
 
-  it('existing install at version 5 → migration 6 scopes edges uniqueness to entity_id', async () => {
-    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '5' });
-    const wiki = createWiki(db);
-    await wiki.setup();
-
-    const hasEdgesRecreate = db.execCalls.some(
-      s => s.includes('edges_v6') || (s.includes('DROP TABLE') && s.includes('edges')),
-    );
-    expect(hasEdgesRecreate).toBe(true);
-
-    const versionWrite = db.runCalls.find(
-      c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
-    );
-    expect(versionWrite).toBeDefined();
-  });
 });
 
 // Helper that mirrors the module-level assertion in migrations.ts so we can test

--- a/packages/core/__tests__/migrations.test.ts
+++ b/packages/core/__tests__/migrations.test.ts
@@ -93,7 +93,7 @@ describe('schema migrations', () => {
     // Should have written schema_version
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '4' || c.args[1] === '4')
+           (c.args[0] === '5' || c.args[1] === '5')
     );
     expect(versionWrite).toBeDefined();
 
@@ -114,7 +114,7 @@ describe('schema migrations', () => {
     // Version should have been written
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '4' || c.args[1] === '4')
+           (c.args[0] === '5' || c.args[1] === '5')
     );
     expect(versionWrite).toBeDefined();
   });
@@ -137,12 +137,34 @@ describe('schema migrations', () => {
   });
 
   it('already at current version → no migration runs', async () => {
-    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '4' });
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '5' });
     const wiki = createWiki(db);
     await wiki.setup();
 
     const hasRebuild = db.execCalls.some(s => s.includes('DROP TABLE') || s.includes('DROP TRIGGER'));
     expect(hasRebuild).toBe(false);
+  });
+
+  it('existing install at version 4 → migration 5 adds okf_type columns and creates edges table', async () => {
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '4' });
+    const wiki = createWiki(db);
+    await wiki.setup();
+
+    const hasOkfTypeAlter = db.execCalls.some(
+      s => s.includes('ALTER TABLE') && s.includes('okf_type'),
+    );
+    expect(hasOkfTypeAlter).toBe(true);
+
+    const hasEdgesTable = db.execCalls.some(
+      s => s.includes('CREATE TABLE') && s.includes('edges'),
+    );
+    expect(hasEdgesTable).toBe(true);
+
+    const versionWrite = db.runCalls.find(
+      c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
+           (c.args[0] === '5' || c.args[1] === '5')
+    );
+    expect(versionWrite).toBeDefined();
   });
 });
 

--- a/packages/core/__tests__/migrations.test.ts
+++ b/packages/core/__tests__/migrations.test.ts
@@ -48,6 +48,14 @@ function makeMockDb(opts: {
         }
         return { sql: `CREATE VIRTUAL TABLE x USING fts5(title, tokenize='unicode61')` } as any;
       }
+      // Edges table existence check (created in migration v5)
+      if (sql.includes('sqlite_master') && args[0]?.endsWith('edges')) {
+        const version = currentMetaVersion !== null ? parseInt(currentMetaVersion, 10) : 0;
+        if (hasEntries && version >= 5) {
+          return { name: args[0] } as any;
+        }
+        return null;
+      }
       // Meta version check — matches both literal SQL and parameterized queries
       if (sql.includes('schema_version') || args.includes('schema_version')) {
         if (currentMetaVersion !== null) {
@@ -93,7 +101,7 @@ describe('schema migrations', () => {
     // Should have written schema_version
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '5' || c.args[1] === '5')
+           (c.args[0] === '6' || c.args[1] === '6')
     );
     expect(versionWrite).toBeDefined();
 
@@ -114,7 +122,7 @@ describe('schema migrations', () => {
     // Version should have been written
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '5' || c.args[1] === '5')
+           (c.args[0] === '6' || c.args[1] === '6')
     );
     expect(versionWrite).toBeDefined();
   });
@@ -137,7 +145,7 @@ describe('schema migrations', () => {
   });
 
   it('already at current version → no migration runs', async () => {
-    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '5' });
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '6' });
     const wiki = createWiki(db);
     await wiki.setup();
 
@@ -162,7 +170,24 @@ describe('schema migrations', () => {
 
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '5' || c.args[1] === '5')
+           (c.args[0] === '6' || c.args[1] === '6')
+    );
+    expect(versionWrite).toBeDefined();
+  });
+
+  it('existing install at version 5 → migration 6 scopes edges uniqueness to entity_id', async () => {
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '5' });
+    const wiki = createWiki(db);
+    await wiki.setup();
+
+    const hasEdgesRecreate = db.execCalls.some(
+      s => s.includes('edges_v6') || (s.includes('DROP TABLE') && s.includes('edges')),
+    );
+    expect(hasEdgesRecreate).toBe(true);
+
+    const versionWrite = db.runCalls.find(
+      c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
+           (c.args[0] === '6' || c.args[1] === '6')
     );
     expect(versionWrite).toBeDefined();
   });

--- a/packages/core/__tests__/miniSearchFallback.test.ts
+++ b/packages/core/__tests__/miniSearchFallback.test.ts
@@ -25,7 +25,7 @@ function makeDump(facts: Array<{ id: string; title: string; body: string }>): Me
           deleted_at: null,
         })),
         tasks: [],
-        events: [],
+        events: [], edges: [],
       },
     },
   };

--- a/packages/core/__tests__/multiEntityRead.test.ts
+++ b/packages/core/__tests__/multiEntityRead.test.ts
@@ -98,7 +98,7 @@ describe('read() multi-entity retrieval', () => {
     expect(result).toEqual({
       facts: [],
       tasks: [],
-      events: [],
+      events: [], edges: [],
       metadata: { query: 'apple', entityIds: [] },
     });
   });
@@ -190,11 +190,11 @@ describe('read() multi-entity retrieval', () => {
       entities: {
         tier_boosted: {
           facts: [{ id: 'boosted-weak', entity_id: 'tier_boosted', title: 'apple boosted', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 1000, updated_at: 1000, last_accessed_at: null, access_count: 0, deleted_at: null }],
-          tasks: [], events: [],
+          tasks: [], events: [], edges: [],
         },
         tier_normal: {
           facts: [{ id: 'normal-strong', entity_id: 'tier_normal', title: 'apple normal', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 2000, updated_at: 2000, last_accessed_at: null, access_count: 0, deleted_at: null }],
-          tasks: [], events: [],
+          tasks: [], events: [], edges: [],
         },
       },
     });
@@ -223,11 +223,11 @@ describe('read() multi-entity retrieval', () => {
       entities: {
         tier_boosted: {
           facts: [{ id: 'boosted-weak', entity_id: 'tier_boosted', title: 'apple boosted', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 1000, updated_at: 1000, last_accessed_at: null, access_count: 0, deleted_at: null }],
-          tasks: [], events: [],
+          tasks: [], events: [], edges: [],
         },
         tier_normal: {
           facts: [{ id: 'normal-strong', entity_id: 'tier_normal', title: 'apple normal', body: 'apple', tags: [], confidence: 'certain', source_type: 'user_stated', source_hash: null, source_ref: null, created_at: 2000, updated_at: 2000, last_accessed_at: null, access_count: 0, deleted_at: null }],
-          tasks: [], events: [],
+          tasks: [], events: [], edges: [],
         },
       },
     });

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -216,12 +216,12 @@ describe('parseOkfBundle — field mapping', () => {
     expect(task.priority).toBe(2);
   });
 
-  it('generates an id and uses Date.now() when frontmatter omits id and timestamps', () => {
+  it('uses filename basename as id and Date.now() when frontmatter omits id and timestamps', () => {
     const files: OkfFile[] = [
       conceptFile('entities/alice/facts/foreign.md', { type: 'note', title: 'T' }),
     ];
     const fact = parseOkfBundle('alice', files).entities.alice.facts[0];
-    expect(fact.id).toBe('generated');
+    expect(fact.id).toBe('foreign');
     expect(fact.created_at).toBe(FIXED_NOW);
     expect(fact.updated_at).toBe(FIXED_NOW);
   });
@@ -231,7 +231,7 @@ describe('parseOkfBundle — field mapping', () => {
       conceptFile('entities/alice/facts/foreign_slug.md', { type: 'fact', title: 'T' }),
     ];
     const fact = parseOkfBundle('alice', files).entities.alice.facts[0];
-    expect(fact.id).toBe('generated');
+    expect(fact.id).toBe('foreign_slug');
   });
 });
 

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -127,6 +127,15 @@ describe('parseOkfBundle', () => {
       expect(dump.entities.alice.facts.map(f => f.id)).toEqual(['fact_keep']);
     });
 
+    it('does not treat inherited object keys as typeMapping entries', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/concepts/x.md', { type: 'toString', title: 'C', id: 'concept_x' }),
+      ];
+      const dump = parseOkfBundle('alice', files, { typeMapping: {} });
+      expect(dump.entities.alice.facts).toHaveLength(1);
+      expect(dump.entities.alice.tasks).toHaveLength(0);
+    });
+
     it('ignores index.md and log.md during concept parsing', () => {
       const files: OkfFile[] = [
         { path: 'entities/alice/index.md', content: '# Index\n' },

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -299,6 +299,24 @@ describe('parseOkfBundle — edge extraction', () => {
     expect(parseOkfBundle('alice', files).entities.alice.edges).toEqual([]);
   });
 
+  it('resolves entity-root-relative link targets from nested concept paths', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/facts/target.md', { type: 'fact', title: 'T', id: 'fact_tgt' }),
+      conceptFile(
+        'entities/alice/concepts/source.md',
+        { type: 'fact', title: 'S', id: 'fact_src' },
+        'See [mentions](facts/target.md).',
+      ),
+    ];
+    const edges = parseOkfBundle('alice', files).entities.alice.edges;
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source_id: 'fact_src',
+      target_id: 'fact_tgt',
+      edge_type: 'mentions',
+    });
+  });
+
   it('skips structural navigation links to index.md and log.md', () => {
     const files: OkfFile[] = [
       conceptFile(

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -344,6 +344,16 @@ describe('parseOkfBundle — log and round-trip', () => {
     });
   });
 
+  it('skips log entries with invalid dates', () => {
+    const files: OkfFile[] = [
+      {
+        path: 'entities/alice/log.md',
+        content: '## 2026-99-99\n\n- (observation) Bad date entry\n',
+      },
+    ];
+    expect(parseOkfBundle('alice', files).entities.alice.events).toEqual([]);
+  });
+
   it('parses plain (unlinked) log entries', () => {
     const files: OkfFile[] = [
       {

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildConceptDocument, buildLogMd } from '@equationalapplications/core-okf';
+import type { OkfFile, OkfFrontmatter } from '@equationalapplications/core-okf';
+import { parseOkfBundle } from '../src/utils/parseOkfBundle';
+import { formatOkfBundle } from '../src/utils/formatOkfBundle';
+import type { MemoryDump, WikiFact, WikiTask, WikiEvent } from '../src/types';
+import * as ids from '../src/utils/ids';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+function conceptFile(path: string, fm: OkfFrontmatter, body = ''): OkfFile {
+  return { path, content: buildConceptDocument(fm, body) };
+}
+
+function makeFact(overrides: Partial<WikiFact> = {}): WikiFact {
+  return {
+    id: 'fact_aaa',
+    entity_id: 'alice',
+    title: 'Likes coffee',
+    body: 'See [related](./facts/fact_bbb.md).',
+    tags: ['preference'],
+    confidence: 'certain',
+    source_type: 'user_stated',
+    source_hash: null,
+    source_ref: null,
+    created_at: 1_700_000_000_000,
+    updated_at: 1_700_000_010_000,
+    last_accessed_at: null,
+    access_count: 0,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<WikiTask> = {}): WikiTask {
+  return {
+    id: 'task_bbb',
+    entity_id: 'alice',
+    description: 'Order beans',
+    status: 'pending',
+    priority: 1,
+    created_at: 1_700_000_020_000,
+    updated_at: 1_700_000_030_000,
+    resolved_at: null,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<WikiEvent> = {}): WikiEvent {
+  return {
+    id: 'evt_ccc',
+    entity_id: 'alice',
+    event_type: 'observation',
+    summary: 'Noted preference',
+    related_entry_id: 'fact_aaa',
+    created_at: 1_700_000_040_000,
+    ...overrides,
+  };
+}
+
+describe('parseOkfBundle', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+    vi.spyOn(ids, 'generateId').mockImplementation((prefix = '') => `${prefix}generated`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('routing precedence', () => {
+    it('routes via typeMapping over directory convention', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/facts/custom.md', { type: 'meeting_note', title: 'M', id: 'fact_custom' }),
+      ];
+      const dump = parseOkfBundle('alice', files, {
+        typeMapping: { meeting_note: 'task' },
+      });
+      const bundle = dump.entities.alice;
+      expect(bundle.tasks).toHaveLength(1);
+      expect(bundle.facts).toHaveLength(0);
+      expect(bundle.tasks[0].id).toBe('fact_custom');
+    });
+
+    it('routes via /facts/ directory when typeMapping has no entry', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/facts/x.md', { type: 'note', title: 'N', id: 'fact_x' }),
+      ];
+      const dump = parseOkfBundle('alice', files);
+      expect(dump.entities.alice.facts).toHaveLength(1);
+      expect(dump.entities.alice.tasks).toHaveLength(0);
+    });
+
+    it('routes via /tasks/ directory when typeMapping has no entry', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/tasks/x.md', { type: 'note', title: 'T', id: 'task_x' }),
+      ];
+      const dump = parseOkfBundle('alice', files);
+      expect(dump.entities.alice.tasks).toHaveLength(1);
+      expect(dump.entities.alice.facts).toHaveLength(0);
+    });
+
+    it('falls back to defaultSchema when neither typeMapping nor directory applies', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/concepts/x.md', { type: 'note', title: 'C', id: 'concept_x' }),
+      ];
+      const dump = parseOkfBundle('alice', files, { defaultSchema: 'task' });
+      expect(dump.entities.alice.tasks).toHaveLength(1);
+      expect(dump.entities.alice.facts).toHaveLength(0);
+    });
+
+    it('defaults to fact when no mapping, directory, or defaultSchema is set', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/concepts/x.md', { type: 'note', title: 'C', id: 'concept_x' }),
+      ];
+      const dump = parseOkfBundle('alice', files);
+      expect(dump.entities.alice.facts).toHaveLength(1);
+    });
+
+    it('skips a concept entirely when routing resolves to ignore', () => {
+      const files: OkfFile[] = [
+        conceptFile('entities/alice/facts/skip.md', { type: 'noise', title: 'S', id: 'fact_skip' }),
+        conceptFile('entities/alice/facts/keep.md', { type: 'fact', title: 'K', id: 'fact_keep' }),
+      ];
+      const dump = parseOkfBundle('alice', files, { typeMapping: { noise: 'ignore' } });
+      expect(dump.entities.alice.facts.map(f => f.id)).toEqual(['fact_keep']);
+    });
+
+    it('ignores index.md and log.md during concept parsing', () => {
+      const files: OkfFile[] = [
+        { path: 'entities/alice/index.md', content: '# Index\n' },
+        { path: 'entities/alice/log.md', content: buildLogMd([]) },
+        conceptFile('entities/alice/facts/only.md', { type: 'fact', title: 'O', id: 'fact_only' }),
+      ];
+      const dump = parseOkfBundle('alice', files);
+      expect(dump.entities.alice.facts).toHaveLength(1);
+    });
+  });
+});
+
+describe('parseOkfBundle — field mapping', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+    vi.spyOn(ids, 'generateId').mockImplementation((prefix = '') => `${prefix}generated`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves arbitrary third-party okf_type strings verbatim', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/facts/x.md', {
+        type: 'meeting_note',
+        title: 'Standup',
+        id: 'fact_x',
+      }),
+    ];
+    const dump = parseOkfBundle('alice', files);
+    expect(dump.entities.alice.facts[0].okf_type).toBe('meeting_note');
+  });
+
+  it('maps fact frontmatter fields back onto WikiFact', () => {
+    const files: OkfFile[] = [
+      conceptFile(
+        'entities/alice/facts/x.md',
+        {
+          type: 'fact',
+          title: 'Likes coffee',
+          tags: ['preference'],
+          timestamp: '2023-11-14T22:15:00.000Z',
+          resource: 'chat-1',
+          id: 'fact_x',
+          confidence: 'certain',
+          source_type: 'user_stated',
+          source_hash: 'abc',
+          created_at: 1_700_000_000_000,
+          access_count: 3,
+          last_accessed_at: 1_700_000_020_000,
+          deleted_at: null,
+        },
+        'Body text',
+      ),
+    ];
+    const fact = parseOkfBundle('alice', files).entities.alice.facts[0];
+    expect(fact.title).toBe('Likes coffee');
+    expect(fact.body).toBe('Body text');
+    expect(fact.tags).toEqual(['preference']);
+    expect(fact.source_ref).toBe('chat-1');
+    expect(fact.confidence).toBe('certain');
+    expect(fact.source_type).toBe('user_stated');
+    expect(fact.source_hash).toBe('abc');
+    expect(fact.access_count).toBe(3);
+    expect(fact.updated_at).toBe(Date.parse('2023-11-14T22:15:00.000Z'));
+  });
+
+  it('maps task frontmatter fields back onto WikiTask', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/tasks/x.md', {
+        type: 'todo_item',
+        title: 'Buy beans',
+        id: 'task_x',
+        status: 'pending',
+        priority: 2,
+        created_at: 1_700_000_030_000,
+        timestamp: '2023-11-14T22:20:00.000Z',
+        resolved_at: null,
+        deleted_at: null,
+      }),
+    ];
+    const task = parseOkfBundle('alice', files).entities.alice.tasks[0];
+    expect(task.description).toBe('Buy beans');
+    expect(task.okf_type).toBe('todo_item');
+    expect(task.status).toBe('pending');
+    expect(task.priority).toBe(2);
+  });
+
+  it('generates an id and uses Date.now() when frontmatter omits id and timestamps', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/facts/foreign.md', { type: 'note', title: 'T' }),
+    ];
+    const fact = parseOkfBundle('alice', files).entities.alice.facts[0];
+    expect(fact.id).toBe('generated');
+    expect(fact.created_at).toBe(FIXED_NOW);
+    expect(fact.updated_at).toBe(FIXED_NOW);
+  });
+
+  it('resolves id from filename basename when frontmatter omits id', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/facts/foreign_slug.md', { type: 'fact', title: 'T' }),
+    ];
+    const fact = parseOkfBundle('alice', files).entities.alice.facts[0];
+    expect(fact.id).toBe('generated');
+  });
+});
+
+describe('parseOkfBundle — edge extraction', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+    vi.spyOn(ids, 'generateId').mockImplementation((prefix = '') => `${prefix}generated`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts edges from markdown links in a concept body', () => {
+    const files: OkfFile[] = [
+      conceptFile(
+        'entities/alice/facts/source.md',
+        { type: 'fact', title: 'S', id: 'fact_src' },
+        'See [mentions](./target.md).',
+      ),
+      conceptFile('entities/alice/facts/target.md', { type: 'fact', title: 'T', id: 'fact_tgt' }),
+    ];
+    const edges = parseOkfBundle('alice', files).entities.alice.edges;
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toMatchObject({
+      source_id: 'fact_src',
+      target_id: 'fact_tgt',
+      edge_type: 'mentions',
+      entity_id: 'alice',
+      created_at: FIXED_NOW,
+    });
+    expect(edges[0].id).toBe('generated');
+  });
+
+  it('skips links that do not resolve to a concept in the bundle', () => {
+    const files: OkfFile[] = [
+      conceptFile(
+        'entities/alice/facts/source.md',
+        { type: 'fact', title: 'S', id: 'fact_src' },
+        'See [missing](./missing.md).',
+      ),
+    ];
+    expect(parseOkfBundle('alice', files).entities.alice.edges).toEqual([]);
+  });
+
+  it('skips structural navigation links to index.md and log.md', () => {
+    const files: OkfFile[] = [
+      conceptFile(
+        'entities/alice/facts/source.md',
+        { type: 'fact', title: 'S', id: 'fact_src' },
+        '[log](./log.md) and [index](./index.md)',
+      ),
+      { path: 'entities/alice/log.md', content: buildLogMd([]) },
+      { path: 'entities/alice/index.md', content: '# Index\n' },
+    ];
+    expect(parseOkfBundle('alice', files).entities.alice.edges).toEqual([]);
+  });
+});
+
+describe('parseOkfBundle — log and round-trip', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+    vi.spyOn(ids, 'generateId').mockImplementation((prefix = '') => `${prefix}generated`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses linked log entries and hydrates related_entry_id', () => {
+    const files: OkfFile[] = [
+      conceptFile('entities/alice/facts/fact_aaa.md', { type: 'fact', title: 'A', id: 'fact_aaa' }),
+      {
+        path: 'entities/alice/log.md',
+        content: buildLogMd([
+          { date: '2023-11-14', text: '(observation) [Noted preference](./facts/fact_aaa.md)' },
+        ]),
+      },
+    ];
+    const events = parseOkfBundle('alice', files).entities.alice.events;
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: 'evt_generated',
+      event_type: 'observation',
+      summary: 'Noted preference',
+      related_entry_id: 'fact_aaa',
+      created_at: new Date('2023-11-14T00:00:00.000Z').getTime(),
+    });
+  });
+
+  it('parses plain (unlinked) log entries', () => {
+    const files: OkfFile[] = [
+      {
+        path: 'entities/alice/log.md',
+        content: buildLogMd([{ date: '2023-11-14', text: '(decision) Chose option A' }]),
+      },
+    ];
+    const events = parseOkfBundle('alice', files).entities.alice.events;
+    expect(events[0]).toMatchObject({
+      event_type: 'decision',
+      summary: 'Chose option A',
+      related_entry_id: null,
+    });
+  });
+
+  it('formatOkfBundle → parseOkfBundle yields structurally equivalent facts, tasks, events, and edges', () => {
+    const original: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: {
+          facts: [
+            makeFact({
+              body: 'See [related task](../tasks/task_bbb.md).',
+              okf_type: 'preference',
+            }),
+            makeFact({ id: 'fact_bbb', title: 'Target fact', body: 'Target body', okf_type: 'note' }),
+          ],
+          tasks: [makeTask({ okf_type: 'todo_item' })],
+          events: [makeEvent()],
+          edges: [
+            {
+              id: 'edge_1',
+              entity_id: 'alice',
+              source_id: 'fact_aaa',
+              target_id: 'task_bbb',
+              edge_type: 'related task',
+              created_at: FIXED_NOW,
+            },
+          ],
+        },
+      },
+    };
+
+    const { files } = formatOkfBundle(original);
+    const entityFiles = files.filter(f => f.path.startsWith('entities/alice/'));
+    const parsed = parseOkfBundle('alice', entityFiles);
+
+    const orig = original.entities.alice;
+    const round = parsed.entities.alice;
+
+    expect(round.facts.map(f => f.id).sort()).toEqual(orig.facts.map(f => f.id).sort());
+    expect(round.tasks.map(t => t.id).sort()).toEqual(orig.tasks.map(t => t.id).sort());
+
+    for (const fact of orig.facts) {
+      const found = round.facts.find(f => f.id === fact.id)!;
+      expect(found.title).toBe(fact.title);
+      expect(found.body).toBe(fact.body);
+      expect(found.okf_type).toBe(fact.okf_type);
+      expect(found.tags).toEqual(fact.tags);
+      expect(found.confidence).toBe(fact.confidence);
+    }
+
+    for (const task of orig.tasks) {
+      const found = round.tasks.find(t => t.id === task.id)!;
+      expect(found.description).toBe(task.description);
+      expect(found.okf_type).toBe(task.okf_type);
+      expect(found.status).toBe(task.status);
+    }
+
+    expect(round.edges.map(e => [e.source_id, e.target_id, e.edge_type].join('|')).sort()).toEqual(
+      orig.edges.map(e => [e.source_id, e.target_id, e.edge_type].join('|')).sort(),
+    );
+
+    expect(round.events).toHaveLength(orig.events.length);
+    for (let i = 0; i < orig.events.length; i++) {
+      expect(round.events[i].event_type).toBe(orig.events[i].event_type);
+      expect(round.events[i].summary).toBe(orig.events[i].summary);
+      expect(round.events[i].related_entry_id).toBe(orig.events[i].related_entry_id);
+      expect(new Date(round.events[i].created_at).toISOString().slice(0, 10)).toBe(
+        new Date(orig.events[i].created_at).toISOString().slice(0, 10),
+      );
+    }
+  });
+});

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -127,6 +127,19 @@ describe('parseOkfBundle', () => {
       expect(dump.entities.alice.facts.map(f => f.id)).toEqual(['fact_keep']);
     });
 
+    it('does not resolve edges to concepts routed to ignore', () => {
+      const files: OkfFile[] = [
+        conceptFile(
+          'entities/alice/facts/keep.md',
+          { type: 'fact', title: 'K', id: 'fact_keep' },
+          'See [noise](./skip.md).',
+        ),
+        conceptFile('entities/alice/facts/skip.md', { type: 'noise', title: 'S', id: 'fact_skip' }),
+      ];
+      const dump = parseOkfBundle('alice', files, { typeMapping: { noise: 'ignore' } });
+      expect(dump.entities.alice.edges).toEqual([]);
+    });
+
     it('does not treat inherited object keys as typeMapping entries', () => {
       const files: OkfFile[] = [
         conceptFile('entities/alice/concepts/x.md', { type: 'toString', title: 'C', id: 'concept_x' }),

--- a/packages/core/__tests__/repositories/EdgeRepository.test.ts
+++ b/packages/core/__tests__/repositories/EdgeRepository.test.ts
@@ -66,6 +66,24 @@ describe('EdgeRepository', () => {
     expect(rows.length).toBe(2);
   });
 
+  it('addIgnoreDuplicate() throws when id collides with a different edge tuple', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({
+      id: 'edge_collision',
+      source_id: 'a',
+      target_id: 'b',
+      edge_type: 'mentions',
+    }));
+
+    await expect(
+      repo.addIgnoreDuplicate(makeEdge({
+        id: 'edge_collision',
+        source_id: 'c',
+        target_id: 'd',
+        edge_type: 'reports_to',
+      })),
+    ).rejects.toThrow(/Edge id collision/);
+  });
+
   it('addIgnoreDuplicate() allows distinct edge_type between the same source/target', async () => {
     await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_1', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
     await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_2', source_id: 'a', target_id: 'b', edge_type: 'reports_to' }));

--- a/packages/core/__tests__/repositories/EdgeRepository.test.ts
+++ b/packages/core/__tests__/repositories/EdgeRepository.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openTestDatabase } from '../helpers/sqliteAdapter';
+import { setupDatabase } from '../../src/db/schema';
+import { EdgeRepository } from '../../src/repositories/EdgeRepository';
+import type { WikiEdge } from '../../src/types';
+
+const PREFIX = 'llm_wiki_';
+
+function makeEdge(overrides?: Partial<WikiEdge>): WikiEdge {
+  return {
+    id: 'edge_' + Math.random().toString(36).slice(2),
+    entity_id: 'entity1',
+    source_id: 'fact_a',
+    target_id: 'fact_b',
+    edge_type: 'mentions',
+    created_at: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('EdgeRepository', () => {
+  let db: ReturnType<typeof openTestDatabase>;
+  let repo: EdgeRepository;
+
+  beforeEach(async () => {
+    db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    repo = new EdgeRepository(db, PREFIX);
+  });
+
+  it('addIgnoreDuplicate() inserts an edge with all columns', async () => {
+    const edge = makeEdge({ id: 'edge_1', created_at: 1000 });
+    await repo.addIgnoreDuplicate(edge);
+
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}edges WHERE id = 'edge_1'`);
+    expect(rows.length).toBe(1);
+    expect(rows[0].entity_id).toBe('entity1');
+    expect(rows[0].source_id).toBe('fact_a');
+    expect(rows[0].target_id).toBe('fact_b');
+    expect(rows[0].edge_type).toBe('mentions');
+    expect(Number(rows[0].created_at)).toBe(1000);
+  });
+
+  it('addIgnoreDuplicate() is idempotent on (source_id, target_id, edge_type)', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_1', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_2', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
+
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}edges`);
+    expect(rows.length).toBe(1);
+  });
+
+  it('addIgnoreDuplicate() allows distinct edge_type between the same source/target', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_1', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_2', source_id: 'a', target_id: 'b', edge_type: 'reports_to' }));
+
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}edges`);
+    expect(rows.length).toBe(2);
+  });
+
+  it('getByEntityId() returns edges scoped to entity, ordered by created_at ASC', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_a', entity_id: 'entity1', source_id: 'a', target_id: 'b', created_at: 200 }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_b', entity_id: 'entity1', source_id: 'c', target_id: 'd', created_at: 100 }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_c', entity_id: 'entity2', source_id: 'e', target_id: 'f', created_at: 50 }));
+
+    const edges = await repo.getByEntityId('entity1');
+    expect(edges.map(e => e.id)).toEqual(['edge_b', 'edge_a']);
+  });
+
+  it('bulkDeleteByEntityId() deletes only that entity\'s edges', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_a', entity_id: 'entity1', source_id: 'a', target_id: 'b' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_b', entity_id: 'entity2', source_id: 'c', target_id: 'd' }));
+
+    await db.withTransactionAsync(async (tx) => {
+      await repo.bulkDeleteByEntityId('entity1', tx);
+    });
+
+    expect(await repo.getByEntityId('entity1')).toEqual([]);
+    expect((await repo.getByEntityId('entity2')).length).toBe(1);
+  });
+
+  it('addIgnoreDuplicate() with tx — rollback means edge is not persisted', async () => {
+    const sentinel = new Error('intentional rollback');
+
+    await expect(
+      db.withTransactionAsync(async () => {
+        await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_tx' }), db);
+        const inTx = await db.getAllAsync<any>(`SELECT id FROM ${PREFIX}edges WHERE id = 'edge_tx'`);
+        expect(inTx.length).toBe(1);
+        throw sentinel;
+      }),
+    ).rejects.toThrow('intentional rollback');
+
+    const afterRollback = await db.getAllAsync<any>(`SELECT id FROM ${PREFIX}edges WHERE id = 'edge_tx'`);
+    expect(afterRollback.length).toBe(0);
+  });
+});

--- a/packages/core/__tests__/repositories/EdgeRepository.test.ts
+++ b/packages/core/__tests__/repositories/EdgeRepository.test.ts
@@ -82,9 +82,9 @@ describe('EdgeRepository', () => {
     const sentinel = new Error('intentional rollback');
 
     await expect(
-      db.withTransactionAsync(async () => {
-        await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_tx' }), db);
-        const inTx = await db.getAllAsync<any>(`SELECT id FROM ${PREFIX}edges WHERE id = 'edge_tx'`);
+      db.withTransactionAsync(async (tx) => {
+        await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_tx' }), tx);
+        const inTx = await tx.getAllAsync<any>(`SELECT id FROM ${PREFIX}edges WHERE id = 'edge_tx'`);
         expect(inTx.length).toBe(1);
         throw sentinel;
       }),

--- a/packages/core/__tests__/repositories/EdgeRepository.test.ts
+++ b/packages/core/__tests__/repositories/EdgeRepository.test.ts
@@ -49,6 +49,23 @@ describe('EdgeRepository', () => {
     expect(rows.length).toBe(1);
   });
 
+  it('addIgnoreDuplicate() is idempotent on the same primary key id', async () => {
+    const edge = makeEdge({ id: 'edge_same', source_id: 'a', target_id: 'b', edge_type: 'mentions' });
+    await repo.addIgnoreDuplicate(edge);
+    await repo.addIgnoreDuplicate(edge);
+
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}edges WHERE id = 'edge_same'`);
+    expect(rows.length).toBe(1);
+  });
+
+  it('addIgnoreDuplicate() allows the same source/target/type across different entities', async () => {
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_e1', entity_id: 'entity1', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_e2', entity_id: 'entity2', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
+
+    const rows = await db.getAllAsync<any>(`SELECT * FROM ${PREFIX}edges`);
+    expect(rows.length).toBe(2);
+  });
+
   it('addIgnoreDuplicate() allows distinct edge_type between the same source/target', async () => {
     await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_1', source_id: 'a', target_id: 'b', edge_type: 'mentions' }));
     await repo.addIgnoreDuplicate(makeEdge({ id: 'edge_2', source_id: 'a', target_id: 'b', edge_type: 'reports_to' }));

--- a/packages/core/__tests__/repositories/EntryRepository.test.ts
+++ b/packages/core/__tests__/repositories/EntryRepository.test.ts
@@ -225,4 +225,25 @@ describe('EntryRepository with OutboxRepository', () => {
     const pending = await outbox.fetchPending();
     expect(pending.length).toBe(0);
   });
+
+  it('upsertForImport persists and round-trips okf_type', async () => {
+    const fact = makeFact({ id: 'fact_okf', okf_type: 'meeting_note' });
+    await db.withTransactionAsync(async (tx) => {
+      await repo.upsertForImport(fact, tx);
+    });
+
+    const [found] = await repo.findAllByEntityId('entity1');
+    expect(found.okf_type).toBe('meeting_note');
+  });
+
+  it('upsertForImport defaults okf_type to null when absent', async () => {
+    const fact = makeFact({ id: 'fact_no_okf' });
+    delete (fact as any).okf_type;
+    await db.withTransactionAsync(async (tx) => {
+      await repo.upsertForImport(fact, tx);
+    });
+
+    const [found] = await repo.findAllByEntityId('entity1');
+    expect(found.okf_type).toBeNull();
+  });
 });

--- a/packages/core/__tests__/repositories/TaskRepository.test.ts
+++ b/packages/core/__tests__/repositories/TaskRepository.test.ts
@@ -331,4 +331,27 @@ describe('TaskRepository', () => {
       expect(outboxRows.length).toBe(0);
     });
   });
+
+  describe('upsertForImport', () => {
+    it('persists and round-trips okf_type', async () => {
+      const task = makeTask({ id: 'task_okf', okf_type: 'todo_item' });
+      await db.withTransactionAsync(async (tx) => {
+        await repo.upsertForImport(task, tx);
+      });
+
+      const found = await repo.findById('task_okf');
+      expect(found?.okf_type).toBe('todo_item');
+    });
+
+    it('defaults okf_type to null when absent', async () => {
+      const task = makeTask({ id: 'task_no_okf' });
+      delete (task as any).okf_type;
+      await db.withTransactionAsync(async (tx) => {
+        await repo.upsertForImport(task, tx);
+      });
+
+      const found = await repo.findById('task_no_okf');
+      expect(found?.okf_type).toBeNull();
+    });
+  });
 });

--- a/packages/core/__tests__/services/ImportExportService.test.ts
+++ b/packages/core/__tests__/services/ImportExportService.test.ts
@@ -396,7 +396,7 @@ describe('ImportExportService', () => {
             tasks: [],
             events: [],
             edges: [
-              { id: 'edge_1', entity_id: 'user_1', source_id: 'a', target_id: 'b', edge_type: 'mentions', created_at: 100 },
+              { id: 'edge_1', entity_id: 'spoofed_entity', source_id: 'a', target_id: 'b', edge_type: 'mentions', created_at: 100 },
               { id: 'edge_2', entity_id: 'user_1', source_id: 'b', target_id: 'c', edge_type: 'reports_to', created_at: 200 },
             ],
           },
@@ -407,7 +407,7 @@ describe('ImportExportService', () => {
 
       expect(mockEdgeRepo.addIgnoreDuplicate).toHaveBeenCalledTimes(2);
       expect(mockEdgeRepo.addIgnoreDuplicate).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'edge_1', edge_type: 'mentions' }),
+        expect.objectContaining({ id: 'edge_1', edge_type: 'mentions', entity_id: 'user_1' }),
         mockDb,
       );
     });

--- a/packages/core/__tests__/services/ImportExportService.test.ts
+++ b/packages/core/__tests__/services/ImportExportService.test.ts
@@ -7,6 +7,7 @@ describe('ImportExportService', () => {
   let mockEntryRepo: any;
   let mockTaskRepo: any;
   let mockEventRepo: any;
+  let mockEdgeRepo: any;
   let mockMetadataRepo: any;
   let mockSearchService: any;
   let mockJobManager: any;
@@ -42,6 +43,12 @@ describe('ImportExportService', () => {
       addIgnoreDuplicate: vi.fn().mockResolvedValue(undefined),
     };
 
+    mockEdgeRepo = {
+      getByEntityId: vi.fn().mockResolvedValue([]),
+      addIgnoreDuplicate: vi.fn().mockResolvedValue(undefined),
+      bulkDeleteByEntityId: vi.fn().mockResolvedValue(undefined),
+    };
+
     mockMetadataRepo = {
       getDistinctEntityIds: vi.fn().mockResolvedValue(['user_1', 'user_2']),
       deleteCheckpoint: vi.fn().mockResolvedValue(undefined),
@@ -71,6 +78,7 @@ describe('ImportExportService', () => {
       mockEntryRepo,
       mockTaskRepo,
       mockEventRepo,
+      mockEdgeRepo,
       mockMetadataRepo,
       mockSearchService,
       mockJobManager,
@@ -127,7 +135,7 @@ describe('ImportExportService', () => {
               } as WikiFact,
             ],
             tasks: [],
-            events: [],
+            events: [], edges: [],
           },
         },
       };
@@ -285,7 +293,7 @@ describe('ImportExportService', () => {
               } as unknown as WikiFact,
             ],
             tasks: [],
-            events: [],
+            events: [], edges: [],
           },
         },
       };
@@ -328,7 +336,7 @@ describe('ImportExportService', () => {
               } as unknown as WikiFact,
             ],
             tasks: [],
-            events: [],
+            events: [], edges: [],
           },
         },
       };
@@ -341,6 +349,67 @@ describe('ImportExportService', () => {
       expect(upserted.embedding_blob).toBeUndefined();
       // Fact still imports and falls through to re-embed (no preserved blob).
       expect(mockEmbeddingService.embedFact).toHaveBeenCalled();
+    });
+  });
+
+  describe('Importing: Edges', () => {
+    it('fetches edges via getFullBundle', async () => {
+      mockEdgeRepo.getByEntityId.mockResolvedValue([
+        { id: 'edge_1', entity_id: 'user_1', source_id: 'fact_1', target_id: 'fact_2', edge_type: 'mentions', created_at: 100 },
+      ]);
+
+      const bundle = await importExportService.getFullBundle('user_1');
+
+      expect(mockEdgeRepo.getByEntityId).toHaveBeenCalledWith('user_1');
+      expect(bundle.edges).toHaveLength(1);
+      expect(bundle.edges[0].edge_type).toBe('mentions');
+    });
+
+    it('wipes existing edges in replace mode (merge: false)', async () => {
+      const dump = {
+        generatedAt: Date.now(),
+        entities: { user_1: { facts: [], tasks: [], events: [], edges: [] } },
+      };
+
+      await importExportService.importDump(dump, { merge: false });
+
+      expect(mockEdgeRepo.bulkDeleteByEntityId).toHaveBeenCalledWith('user_1', mockDb);
+    });
+
+    it('does not wipe edges in merge mode (merge: true)', async () => {
+      const dump = {
+        generatedAt: Date.now(),
+        entities: { user_1: { facts: [], tasks: [], events: [], edges: [] } },
+      };
+
+      await importExportService.importDump(dump, { merge: true });
+
+      expect(mockEdgeRepo.bulkDeleteByEntityId).not.toHaveBeenCalled();
+    });
+
+    it('inserts each edge via addIgnoreDuplicate', async () => {
+      const dump = {
+        generatedAt: Date.now(),
+        entities: {
+          user_1: {
+            facts: [],
+            tasks: [],
+            events: [],
+            edges: [
+              { id: 'edge_1', entity_id: 'user_1', source_id: 'a', target_id: 'b', edge_type: 'mentions', created_at: 100 },
+              { id: 'edge_2', entity_id: 'user_1', source_id: 'b', target_id: 'c', edge_type: 'reports_to', created_at: 200 },
+            ],
+          },
+        },
+      };
+
+      await importExportService.importDump(dump, { merge: true });
+
+      expect(mockEdgeRepo.addIgnoreDuplicate).toHaveBeenCalledTimes(2);
+      expect(mockEdgeRepo.addIgnoreDuplicate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'edge_1', edge_type: 'mentions' }),
+        mockDb,
+      );
     });
   });
 });

--- a/packages/core/__tests__/services/RetrievalService.test.ts
+++ b/packages/core/__tests__/services/RetrievalService.test.ts
@@ -87,7 +87,7 @@ describe('RetrievalService', () => {
       expect(result).toEqual({
         facts: [],
         tasks: [],
-        events: [],
+        events: [], edges: [],
         metadata: { query: 'query', entityIds: [] },
       });
       expect(mockOptions.llmProvider.embed).not.toHaveBeenCalled();

--- a/packages/core/__tests__/vectorCache.test.ts
+++ b/packages/core/__tests__/vectorCache.test.ts
@@ -325,7 +325,7 @@ describe('vector cache — importDump() invalidation', () => {
             },
           ],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     };
@@ -375,7 +375,7 @@ describe('vector cache — importDump() invalidation', () => {
             },
           ],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     };
@@ -431,7 +431,7 @@ describe('vector cache — importDump() invalidation', () => {
             },
           ],
           tasks: [],
-          events: [],
+          events: [], edges: [],
         },
       },
     };

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -25,7 +25,7 @@ function makeDump(facts: Array<{ id: string; title: string; body: string }>): Me
           deleted_at: null,
         })),
         tasks: [],
-        events: [],
+        events: [], edges: [],
       },
     },
   };

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -14,6 +14,7 @@ import { EntryRepository } from './repositories/EntryRepository';
 import { OutboxRepository } from './repositories/OutboxRepository';
 import { TaskRepository } from './repositories/TaskRepository';
 import { EventRepository } from './repositories/EventRepository';
+import { EdgeRepository } from './repositories/EdgeRepository';
 import { MetadataRepository } from './repositories/MetadataRepository';
 import { SearchService } from './services/SearchService';
 import { JobManager } from './services/JobManager';
@@ -56,6 +57,7 @@ export class WikiMemory {
   private outboxRepo: OutboxRepository;
   private taskRepo: TaskRepository;
   private eventRepo: EventRepository;
+  private edgeRepo: EdgeRepository;
   private metadataRepo: MetadataRepository;
   private embeddingService: EmbeddingService;
   private searchService: SearchService;
@@ -81,6 +83,7 @@ export class WikiMemory {
     this.entryRepo = new EntryRepository(db, this.prefix, this.outboxRepo);
     this.taskRepo = new TaskRepository(db, this.prefix, this.outboxRepo);
     this.eventRepo = new EventRepository(db, this.prefix);
+    this.edgeRepo = new EdgeRepository(db, this.prefix);
     this.metadataRepo = new MetadataRepository(db, this.prefix);
     this.embeddingService = new EmbeddingService(this.db, this.options, this.entryRepo, this.metadataRepo);
     this.searchService = new SearchService(this.entryRepo);
@@ -114,6 +117,7 @@ export class WikiMemory {
       this.entryRepo,
       this.taskRepo,
       this.eventRepo,
+      this.edgeRepo,
       this.metadataRepo,
       this.searchService,
       this.jobManager,

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -98,36 +98,6 @@ export const MIGRATIONS: Migration[] = [
       `);
     },
   },
-  {
-    version: 6,
-    description: 'Scope edges uniqueness to entity_id (fix cross-entity dedup)',
-    run: async (db, prefix) => {
-      const table = await db.getFirstAsync<{ name: string }>(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
-        [`${prefix}edges`],
-      );
-      if (!table) return;
-
-      await db.withTransactionAsync(async (tx) => {
-        await tx.execAsync(`
-          CREATE TABLE ${prefix}edges_v6 (
-            id TEXT PRIMARY KEY,
-            entity_id TEXT NOT NULL,
-            source_id TEXT NOT NULL,
-            target_id TEXT NOT NULL,
-            edge_type TEXT NOT NULL,
-            created_at INTEGER NOT NULL,
-            UNIQUE(entity_id, source_id, target_id, edge_type)
-          );
-          INSERT OR IGNORE INTO ${prefix}edges_v6
-            SELECT id, entity_id, source_id, target_id, edge_type, created_at FROM ${prefix}edges;
-          DROP TABLE ${prefix}edges;
-          ALTER TABLE ${prefix}edges_v6 RENAME TO ${prefix}edges;
-          CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
-        `);
-      });
-    },
-  },
 ];
 
 // Verify MIGRATIONS are in strictly ascending version order at module load time.

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -92,10 +92,40 @@ export const MIGRATIONS: Migration[] = [
           target_id TEXT NOT NULL,
           edge_type TEXT NOT NULL,
           created_at INTEGER NOT NULL,
-          UNIQUE(source_id, target_id, edge_type)
+          UNIQUE(entity_id, source_id, target_id, edge_type)
         );
         CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
       `);
+    },
+  },
+  {
+    version: 6,
+    description: 'Scope edges uniqueness to entity_id (fix cross-entity dedup)',
+    run: async (db, prefix) => {
+      const table = await db.getFirstAsync<{ name: string }>(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+        [`${prefix}edges`],
+      );
+      if (!table) return;
+
+      await db.withTransactionAsync(async (tx) => {
+        await tx.execAsync(`
+          CREATE TABLE ${prefix}edges_v6 (
+            id TEXT PRIMARY KEY,
+            entity_id TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            edge_type TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(entity_id, source_id, target_id, edge_type)
+          );
+          INSERT OR IGNORE INTO ${prefix}edges_v6
+            SELECT id, entity_id, source_id, target_id, edge_type, created_at FROM ${prefix}edges;
+          DROP TABLE ${prefix}edges;
+          ALTER TABLE ${prefix}edges_v6 RENAME TO ${prefix}edges;
+          CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
+        `);
+      });
     },
   },
 ];

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -72,6 +72,32 @@ export const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    version: 5,
+    description: 'Add okf_type to entries/tasks for OKF type fidelity; create edges table for OKF graph import',
+    run: async (db, prefix) => {
+      for (const table of ['entries', 'tasks'] as const) {
+        const cols = await db.getAllAsync<{ name: string }>(
+          `PRAGMA table_info(${prefix}${table})`
+        );
+        if (!cols.some(c => c.name === 'okf_type')) {
+          await db.execAsync(`ALTER TABLE ${prefix}${table} ADD COLUMN okf_type TEXT`);
+        }
+      }
+      await db.execAsync(`
+        CREATE TABLE IF NOT EXISTS ${prefix}edges (
+          id TEXT PRIMARY KEY,
+          entity_id TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          target_id TEXT NOT NULL,
+          edge_type TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          UNIQUE(source_id, target_id, edge_type)
+        );
+        CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges (entity_id);
+      `);
+    },
+  },
 ];
 
 // Verify MIGRATIONS are in strictly ascending version order at module load time.

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -18,7 +18,8 @@ export async function setupDatabase(db: SQLiteAdapter, prefix: string) {
       access_count INTEGER NOT NULL DEFAULT 0,
       deleted_at INTEGER,
       embedding TEXT,
-      embedding_blob BLOB
+      embedding_blob BLOB,
+      okf_type TEXT
     );
 
     CREATE INDEX IF NOT EXISTS ${prefix}entries_entity_idx ON ${prefix}entries(entity_id);
@@ -35,10 +36,23 @@ export async function setupDatabase(db: SQLiteAdapter, prefix: string) {
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       resolved_at INTEGER,
-      deleted_at INTEGER
+      deleted_at INTEGER,
+      okf_type TEXT
     );
 
     CREATE INDEX IF NOT EXISTS ${prefix}tasks_entity_idx ON ${prefix}tasks(entity_id, status);
+
+    CREATE TABLE IF NOT EXISTS ${prefix}edges (
+      id TEXT PRIMARY KEY,
+      entity_id TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      edge_type TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE(source_id, target_id, edge_type)
+    );
+
+    CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges(entity_id);
 
     CREATE TABLE IF NOT EXISTS ${prefix}events (
       id TEXT PRIMARY KEY,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -49,7 +49,7 @@ export async function setupDatabase(db: SQLiteAdapter, prefix: string) {
       target_id TEXT NOT NULL,
       edge_type TEXT NOT NULL,
       created_at INTEGER NOT NULL,
-      UNIQUE(source_id, target_id, edge_type)
+      UNIQUE(entity_id, source_id, target_id, edge_type)
     );
 
     CREATE INDEX IF NOT EXISTS ${prefix}edges_entity_idx ON ${prefix}edges(entity_id);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type { WikiMemoryTestAccess } from './WikiMemory';
 export { formatContext } from './utils/formatContext';
 export { formatMemoryDump } from './utils/formatMemoryDump';
 export { formatOkfBundle } from './utils/formatOkfBundle';
+export { parseOkfBundle, type OkfImportOptions } from './utils/parseOkfBundle';
 export { parseEmbedding } from './utils/embedding';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -6,8 +6,9 @@ export class EdgeRepository extends BaseRepository {
   async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<void> {
     const executor = this.getExecutor(tx);
     await executor.runAsync(
-      `INSERT OR IGNORE INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(source_id, target_id, edge_type) DO NOTHING`,
       [edge.id, edge.entity_id, edge.source_id, edge.target_id, edge.edge_type, edge.created_at],
     );
   }

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -2,14 +2,42 @@ import { BaseRepository } from './BaseRepository';
 import type { WikiEdge, SQLiteAdapter } from '../types';
 
 export class EdgeRepository extends BaseRepository {
-  /** Insert an edge, silently skipping on primary-key or uniqueness conflicts. */
+  /**
+   * Insert an edge, silently skipping on primary-key or uniqueness conflicts.
+   * Throws when the insert was skipped due to an id collision with a different edge tuple.
+   */
   async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<void> {
     const executor = this.getExecutor(tx);
-    await executor.runAsync(
+    const result = await executor.runAsync(
       `INSERT OR IGNORE INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
        VALUES (?, ?, ?, ?, ?, ?)`,
       [edge.id, edge.entity_id, edge.source_id, edge.target_id, edge.edge_type, edge.created_at],
     );
+
+    if (result.changes > 0) return;
+
+    const existing = await executor.getFirstAsync<{
+      entity_id: string;
+      source_id: string;
+      target_id: string;
+      edge_type: string;
+    }>(
+      `SELECT entity_id, source_id, target_id, edge_type FROM ${this.prefix}edges WHERE id = ?`,
+      [edge.id],
+    );
+
+    if (!existing) return;
+
+    if (
+      String(existing.entity_id) !== edge.entity_id ||
+      String(existing.source_id) !== edge.source_id ||
+      String(existing.target_id) !== edge.target_id ||
+      String(existing.edge_type) !== edge.edge_type
+    ) {
+      throw new Error(
+        `Edge id collision: ${JSON.stringify(edge.id)} already exists with a different (entity_id, source_id, target_id, edge_type) tuple`,
+      );
+    }
   }
 
   async getByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<WikiEdge[]> {

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -1,0 +1,28 @@
+import { BaseRepository } from './BaseRepository';
+import type { WikiEdge, SQLiteAdapter } from '../types';
+
+export class EdgeRepository extends BaseRepository {
+  /** Insert an edge, silently skipping if (source_id, target_id, edge_type) already exists. */
+  async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<void> {
+    const executor = this.getExecutor(tx);
+    await executor.runAsync(
+      `INSERT OR IGNORE INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [edge.id, edge.entity_id, edge.source_id, edge.target_id, edge.edge_type, edge.created_at],
+    );
+  }
+
+  async getByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<WikiEdge[]> {
+    const executor = this.getExecutor(tx);
+    return executor.getAllAsync<WikiEdge>(
+      `SELECT * FROM ${this.prefix}edges WHERE entity_id = ? ORDER BY created_at ASC`,
+      [entityId],
+    );
+  }
+
+  /** Hard delete — edges have no soft-delete concept, only presence/absence. `tx` is REQUIRED. */
+  async bulkDeleteByEntityId(entityId: string, tx: SQLiteAdapter): Promise<void> {
+    const executor = this.getExecutor(tx);
+    await executor.runAsync(`DELETE FROM ${this.prefix}edges WHERE entity_id = ?`, [entityId]);
+  }
+}

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -14,10 +14,18 @@ export class EdgeRepository extends BaseRepository {
 
   async getByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<WikiEdge[]> {
     const executor = this.getExecutor(tx);
-    return executor.getAllAsync<WikiEdge>(
+    const rows = await executor.getAllAsync<any>(
       `SELECT * FROM ${this.prefix}edges WHERE entity_id = ? ORDER BY created_at ASC`,
       [entityId],
     );
+    return rows.map((row) => ({
+      id: String(row.id),
+      entity_id: String(row.entity_id),
+      source_id: String(row.source_id),
+      target_id: String(row.target_id),
+      edge_type: String(row.edge_type),
+      created_at: Number(row.created_at),
+    }));
   }
 
   /** Hard delete — edges have no soft-delete concept, only presence/absence. `tx` is REQUIRED. */

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -2,13 +2,12 @@ import { BaseRepository } from './BaseRepository';
 import type { WikiEdge, SQLiteAdapter } from '../types';
 
 export class EdgeRepository extends BaseRepository {
-  /** Insert an edge, silently skipping if (source_id, target_id, edge_type) already exists. */
+  /** Insert an edge, silently skipping on primary-key or uniqueness conflicts. */
   async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<void> {
     const executor = this.getExecutor(tx);
     await executor.runAsync(
-      `INSERT INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
-       VALUES (?, ?, ?, ?, ?, ?)
-       ON CONFLICT(source_id, target_id, edge_type) DO NOTHING`,
+      `INSERT OR IGNORE INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
       [edge.id, edge.entity_id, edge.source_id, edge.target_id, edge.edge_type, edge.created_at],
     );
   }

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -38,6 +38,7 @@ function mapRowToFact(row: any): WikiFact {
       : Number(row.last_accessed_at),
     deleted_at: row.deleted_at != null ? Number(row.deleted_at) : null,
     access_count: Number(row.access_count ?? 0),
+    okf_type: row.okf_type ?? null,
   };
 }
 
@@ -247,8 +248,8 @@ export class EntryRepository extends BaseRepository {
       `INSERT INTO ${this.prefix}entries (
         id, entity_id, title, body, tags, confidence, source_type,
         source_hash, source_ref, created_at, updated_at, last_accessed_at, access_count,
-        deleted_at, embedding_blob, embedding
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        deleted_at, embedding_blob, embedding, okf_type
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         entity_id = excluded.entity_id,
         title = excluded.title,
@@ -264,7 +265,8 @@ export class EntryRepository extends BaseRepository {
         access_count = excluded.access_count,
         deleted_at = excluded.deleted_at,
         embedding_blob = excluded.embedding_blob,
-        embedding = NULL`,
+        embedding = NULL,
+        okf_type = excluded.okf_type`,
       [
         fact.id,
         fact.entity_id,
@@ -282,6 +284,7 @@ export class EntryRepository extends BaseRepository {
         fact.deleted_at ?? null,
         embeddingBlob ?? null,
         null,
+        fact.okf_type ?? null,
       ],
     );
 

--- a/packages/core/src/repositories/TaskRepository.ts
+++ b/packages/core/src/repositories/TaskRepository.ts
@@ -13,6 +13,7 @@ function mapRowToTask(row: any): WikiTask {
     updated_at: Number(row.updated_at),
     resolved_at: row.resolved_at != null ? Number(row.resolved_at) : null,
     deleted_at: row.deleted_at != null ? Number(row.deleted_at) : null,
+    okf_type: row.okf_type ?? null,
   };
 }
 
@@ -133,8 +134,8 @@ export class TaskRepository extends BaseRepository {
     await executor.runAsync(
       `INSERT INTO ${this.prefix}tasks (
         id, entity_id, description, status, priority,
-        created_at, updated_at, resolved_at, deleted_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        created_at, updated_at, resolved_at, deleted_at, okf_type
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         entity_id = excluded.entity_id,
         description = excluded.description,
@@ -142,7 +143,8 @@ export class TaskRepository extends BaseRepository {
         priority = excluded.priority,
         updated_at = excluded.updated_at,
         resolved_at = excluded.resolved_at,
-        deleted_at = excluded.deleted_at`,
+        deleted_at = excluded.deleted_at,
+        okf_type = excluded.okf_type`,
       [
         task.id,
         task.entity_id,
@@ -153,6 +155,7 @@ export class TaskRepository extends BaseRepository {
         now,
         task.resolved_at ?? null,
         task.deleted_at ?? null,
+        task.okf_type ?? null,
       ],
     );
   }

--- a/packages/core/src/services/ImportExportService.ts
+++ b/packages/core/src/services/ImportExportService.ts
@@ -2,6 +2,7 @@ import type { SQLiteAdapter, MemoryBundle, MemoryDump, WikiFact } from '../types
 import type { EntryRepository } from '../repositories/EntryRepository';
 import type { TaskRepository } from '../repositories/TaskRepository';
 import type { EventRepository } from '../repositories/EventRepository';
+import type { EdgeRepository } from '../repositories/EdgeRepository';
 import type { MetadataRepository } from '../repositories/MetadataRepository';
 import type { SearchService } from './SearchService';
 import type { JobManager } from './JobManager';
@@ -18,6 +19,7 @@ export class ImportExportService {
     private entryRepo: EntryRepository,
     private taskRepo: TaskRepository,
     private eventRepo: EventRepository,
+    private edgeRepo: EdgeRepository,
     private metadataRepo: MetadataRepository,
     private searchService: SearchService,
     private jobManager: JobManager,
@@ -74,12 +76,13 @@ export class ImportExportService {
     entityId: string,
     opts?: { maxEvents?: number; includeBlobs?: boolean },
   ): Promise<MemoryBundle> {
-    const [factsRaw, tasks, events] = await Promise.all([
+    const [factsRaw, tasks, events, edges] = await Promise.all([
       opts?.includeBlobs
         ? this.entryRepo.findAllByEntityIdWithBlobs(entityId)
         : this.entryRepo.findAllByEntityId(entityId),
       this.taskRepo.findAllByEntityId(entityId),
       this.eventRepo.getByEntityId(entityId, opts?.maxEvents),
+      this.edgeRepo.getByEntityId(entityId),
     ]);
 
     const facts = factsRaw.map((f) => {
@@ -109,7 +112,7 @@ export class ImportExportService {
       };
     });
 
-    return { facts, tasks, events };
+    return { facts, tasks, events, edges };
   }
 
   /** Single-entity import transaction + post-processing; package-internal hook for tests. */
@@ -137,6 +140,7 @@ export class ImportExportService {
         softDeletedFactIds.push(...deletedLiveFactIds);
         await this.entryRepo.bulkSoftDeleteByEntityId(entityId, tx);
         await this.taskRepo.bulkSoftDeleteByEntityId(entityId, tx);
+        await this.edgeRepo.bulkDeleteByEntityId(entityId, tx);
         await this.metadataRepo.deleteCheckpoint(entityId, tx);
       }
 
@@ -260,6 +264,7 @@ export class ImportExportService {
           access_count: fact.access_count,
           deleted_at: fact.deleted_at,
           embedding_blob: blobData ?? undefined,
+          okf_type: fact.okf_type ?? null,
         };
 
         await this.entryRepo.upsertForImport(factObj, tx);
@@ -322,6 +327,7 @@ export class ImportExportService {
             updated_at: safeUpdatedAt,
             resolved_at: task.resolved_at,
             deleted_at: task.deleted_at,
+            okf_type: task.okf_type ?? null,
           },
           tx,
           safeUpdatedAt,
@@ -343,6 +349,20 @@ export class ImportExportService {
             summary: event.summary,
             related_entry_id: event.related_entry_id ?? null,
             created_at: event.created_at,
+          },
+          tx,
+        );
+      }
+
+      for (const edge of bundle.edges ?? []) {
+        await this.edgeRepo.addIgnoreDuplicate(
+          {
+            id: edge.id,
+            entity_id: entityId,
+            source_id: edge.source_id,
+            target_id: edge.target_id,
+            edge_type: edge.edge_type,
+            created_at: edge.created_at,
           },
           tx,
         );

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -30,7 +30,7 @@ export class RetrievalService {
     const exposeMetadata = shouldExposeReadMetadata(entityId);
 
     if (entityIds.length === 0) {
-      const empty: MemoryBundle = { facts: [], tasks: [], events: [] };
+      const empty: MemoryBundle = { facts: [], tasks: [], events: [], edges: [] };
       if (exposeMetadata) {
         empty.metadata = { query, entityIds: [] };
         if (sanitizedTierWeights && Object.keys(sanitizedTierWeights).length > 0) empty.metadata.tierWeights = sanitizedTierWeights;
@@ -546,7 +546,7 @@ export class RetrievalService {
       factScores = Object.fromEntries(facts.map(fact => [fact.id, scoreByFactId!.get(fact.id) ?? 0]));
     }
 
-    const bundle: MemoryBundle = { facts, tasks, events: events.reverse() };
+    const bundle: MemoryBundle = { facts, tasks, events: events.reverse(), edges: [] };
 
     if (exposeMetadata) {
       bundle.metadata = { query, entityIds };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -339,7 +339,7 @@ export interface MemoryBundle {
   facts: WikiFact[];
   tasks: WikiTask[];
   events: WikiEvent[];
-  edges: WikiEdge[];
+  edges?: WikiEdge[];
   factScores?: Record<string, number>;
   metadata?: {
     query: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -119,6 +119,12 @@ export interface WikiFact {
   last_accessed_at: number | null;
   access_count: number;
   deleted_at: number | null;
+  /**
+   * Verbatim OKF `type:` frontmatter value when this fact originated from (or was
+   * re-imported via) an OKF bundle. `null`/`undefined` for facts never touched by
+   * OKF import. Distinct from `source_type`, which governs immutability rules.
+   */
+  okf_type?: string | null;
 }
 
 export interface WikiTask {
@@ -131,6 +137,8 @@ export interface WikiTask {
   updated_at: number;
   resolved_at: number | null;
   deleted_at: number | null;
+  /** Verbatim OKF `type:` frontmatter value when this task originated from an OKF bundle. */
+  okf_type?: string | null;
 }
 
 export interface WikiEvent {
@@ -139,6 +147,15 @@ export interface WikiEvent {
   event_type: 'observation' | 'decision' | 'action' | 'outcome';
   summary: string;
   related_entry_id?: string | null;
+  created_at: number;
+}
+
+export interface WikiEdge {
+  id: string;
+  entity_id: string;
+  source_id: string;
+  target_id: string;
+  edge_type: string;
   created_at: number;
 }
 
@@ -322,6 +339,7 @@ export interface MemoryBundle {
   facts: WikiFact[];
   tasks: WikiTask[];
   events: WikiEvent[];
+  edges: WikiEdge[];
   factScores?: Record<string, number>;
   metadata?: {
     query: string;

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -14,7 +14,7 @@ import { sanitizeConceptId, sanitizeForFilename } from './sanitizeForFilename';
 
 function factFrontmatter(f: WikiFact): OkfFrontmatter {
   return {
-    type: f.okf_type || 'fact',
+    type: f.okf_type ?? 'fact',
     title: f.title,
     tags: f.tags,
     timestamp: new Date(f.updated_at).toISOString(),

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -14,7 +14,7 @@ import { sanitizeConceptId, sanitizeForFilename } from './sanitizeForFilename';
 
 function factFrontmatter(f: WikiFact): OkfFrontmatter {
   return {
-    type: f.okf_type ?? 'fact',
+    type: f.okf_type || 'fact',
     title: f.title,
     tags: f.tags,
     timestamp: new Date(f.updated_at).toISOString(),
@@ -33,7 +33,7 @@ function factFrontmatter(f: WikiFact): OkfFrontmatter {
 
 function taskFrontmatter(t: WikiTask): OkfFrontmatter {
   return {
-    type: t.okf_type ?? 'task',
+    type: t.okf_type || 'task',
     title: t.description,
     timestamp: new Date(t.updated_at).toISOString(),
     id: t.id,

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -33,7 +33,7 @@ function factFrontmatter(f: WikiFact): OkfFrontmatter {
 
 function taskFrontmatter(t: WikiTask): OkfFrontmatter {
   return {
-    type: t.okf_type || 'task',
+    type: t.okf_type ?? 'task',
     title: t.description,
     timestamp: new Date(t.updated_at).toISOString(),
     id: t.id,

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -14,7 +14,7 @@ import { sanitizeConceptId, sanitizeForFilename } from './sanitizeForFilename';
 
 function factFrontmatter(f: WikiFact): OkfFrontmatter {
   return {
-    type: 'fact',
+    type: f.okf_type ?? 'fact',
     title: f.title,
     tags: f.tags,
     timestamp: new Date(f.updated_at).toISOString(),
@@ -33,7 +33,7 @@ function factFrontmatter(f: WikiFact): OkfFrontmatter {
 
 function taskFrontmatter(t: WikiTask): OkfFrontmatter {
   return {
-    type: 'task',
+    type: t.okf_type ?? 'task',
     title: t.description,
     timestamp: new Date(t.updated_at).toISOString(),
     id: t.id,

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -198,7 +198,7 @@ function frontmatterToTask(
         : null,
     deleted_at:
       frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
-    okf_type: frontmatter.type || null,
+    okf_type: frontmatter.type,
   };
 }
 

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -217,6 +217,8 @@ export function parseOkfBundle(
   for (const file of files) {
     if (!isConceptFile(file.path)) continue;
     const { frontmatter } = parseConcept(file.content);
+    const route = resolveRoute(file.path, frontmatter.type ?? '', options);
+    if (route === 'ignore') continue;
     const resolvedId =
       typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : basenameMd(file.path);
     addPathAliases(pathToResolvedId, file.path, resolvedId);

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -166,7 +166,7 @@ function frontmatterToFact(
     access_count: typeof frontmatter.access_count === 'number' ? frontmatter.access_count : 0,
     deleted_at:
       frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
-    okf_type: frontmatter.type,
+    okf_type: frontmatter.type || null,
   };
 }
 

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -198,7 +198,7 @@ function frontmatterToTask(
         : null,
     deleted_at:
       frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
-    okf_type: frontmatter.type,
+    okf_type: frontmatter.type || null,
   };
 }
 

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -1,0 +1,281 @@
+import type { MemoryDump, WikiFact, WikiTask, WikiEvent, WikiEdge } from '../types';
+import type { OkfFile, OkfFrontmatter, OkfFrontmatterValue } from '@equationalapplications/core-okf';
+import { parseConcept, parseLogMd, extractMarkdownLinks } from '@equationalapplications/core-okf';
+import { generateId } from './ids';
+
+export interface OkfImportOptions {
+  typeMapping?: Record<string, 'fact' | 'task' | 'ignore'>;
+  defaultSchema?: 'fact' | 'task' | 'ignore';
+}
+
+type Route = 'fact' | 'task' | 'ignore';
+
+const CONFIDENCE_VALUES = new Set(['certain', 'inferred', 'tentative']);
+const SOURCE_TYPES = new Set([
+  'user_stated',
+  'librarian_inferred',
+  'user_confirmed',
+  'immutable_document',
+]);
+const TASK_STATUSES = new Set(['pending', 'in_progress', 'done', 'abandoned']);
+const EVENT_TYPES = new Set(['observation', 'decision', 'action', 'outcome']);
+
+function basenameMd(filePath: string): string {
+  const name = filePath.slice(filePath.lastIndexOf('/') + 1);
+  return name.endsWith('.md') ? name.slice(0, -3) : name;
+}
+
+function isConceptFile(filePath: string): boolean {
+  if (!filePath.endsWith('.md')) return false;
+  if (filePath.endsWith('/index.md') || filePath === 'index.md') return false;
+  if (filePath.endsWith('/log.md') || filePath === 'log.md') return false;
+  return true;
+}
+
+function isStructuralPath(filePath: string): boolean {
+  return (
+    filePath.endsWith('/index.md') ||
+    filePath === 'index.md' ||
+    filePath.endsWith('/log.md') ||
+    filePath === 'log.md'
+  );
+}
+
+function posixDirname(filePath: string): string {
+  const idx = filePath.lastIndexOf('/');
+  return idx === -1 ? '' : filePath.slice(0, idx);
+}
+
+function resolveRelativePath(fromFile: string, linkPath: string): string {
+  const baseDir = posixDirname(fromFile);
+  const segments = [...(baseDir ? baseDir.split('/') : []), ...linkPath.split('/')];
+  const resolved: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(seg);
+  }
+  return resolved.join('/');
+}
+
+function addPathAliases(map: Map<string, string>, filePath: string, resolvedId: string): void {
+  map.set(filePath, resolvedId);
+  const withoutDot = filePath.replace(/^\.\//, '');
+  if (withoutDot !== filePath) map.set(withoutDot, resolvedId);
+  const entityRelative = filePath.replace(/^entities\/[^/]+\//, '');
+  if (entityRelative !== filePath) {
+    map.set(entityRelative, resolvedId);
+    map.set(`./${entityRelative}`, resolvedId);
+  }
+}
+
+function lookupResolvedId(map: Map<string, string>, path: string): string | undefined {
+  const normalized = path.replace(/^\.\//, '');
+  return map.get(path) ?? map.get(normalized) ?? map.get(`./${normalized}`);
+}
+
+function resolveRoute(filePath: string, frontmatterType: string, options?: OkfImportOptions): Route {
+  if (options?.typeMapping && frontmatterType in options.typeMapping) {
+    return options.typeMapping[frontmatterType]!;
+  }
+  if (filePath.includes('/facts/')) return 'fact';
+  if (filePath.includes('/tasks/')) return 'task';
+  return options?.defaultSchema ?? 'fact';
+}
+
+function parseFrontmatterTimestamp(value: OkfFrontmatterValue | undefined, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function unescapeLogSummary(summary: string): string {
+  return summary.replace(/\\\]/g, ']').replace(/\\\[/g, '[').replace(/\\\\/g, '\\');
+}
+
+const LOG_LINE_PATTERN = /^\(([^)]+)\)\s*(?:\[((?:\\.|[^\]])*)\]\(([^)]+)\)|(.+))$/;
+
+function parseLogEntryText(text: string): {
+  event_type: WikiEvent['event_type'];
+  summary: string;
+  linkPath?: string;
+} | null {
+  const match = LOG_LINE_PATTERN.exec(text.trim());
+  if (!match) return null;
+  const [, rawType, linkedSummary, linkPath, plainSummary] = match;
+  const event_type = EVENT_TYPES.has(rawType) ? (rawType as WikiEvent['event_type']) : 'observation';
+  if (linkPath) {
+    return { event_type, summary: unescapeLogSummary(linkedSummary), linkPath };
+  }
+  return { event_type, summary: (plainSummary ?? '').trim() };
+}
+
+function frontmatterToFact(
+  entityId: string,
+  frontmatter: OkfFrontmatter,
+  body: string,
+  now: number,
+): WikiFact {
+  const id = typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : generateId();
+  const created_at = parseFrontmatterTimestamp(frontmatter.created_at, now);
+  const updated_at = parseFrontmatterTimestamp(
+    frontmatter.timestamp,
+    parseFrontmatterTimestamp(frontmatter.updated_at, now),
+  );
+
+  return {
+    id,
+    entity_id: entityId,
+    title: typeof frontmatter.title === 'string' ? frontmatter.title : '',
+    body,
+    tags: Array.isArray(frontmatter.tags)
+      ? frontmatter.tags.filter((t): t is string => typeof t === 'string')
+      : [],
+    confidence: CONFIDENCE_VALUES.has(String(frontmatter.confidence))
+      ? (frontmatter.confidence as WikiFact['confidence'])
+      : 'tentative',
+    source_type: SOURCE_TYPES.has(String(frontmatter.source_type))
+      ? (frontmatter.source_type as WikiFact['source_type'])
+      : 'user_stated',
+    source_hash: typeof frontmatter.source_hash === 'string' ? frontmatter.source_hash : null,
+    source_ref: typeof frontmatter.resource === 'string' ? frontmatter.resource : null,
+    created_at,
+    updated_at,
+    last_accessed_at:
+      frontmatter.last_accessed_at != null
+        ? parseFrontmatterTimestamp(frontmatter.last_accessed_at, now)
+        : null,
+    access_count: typeof frontmatter.access_count === 'number' ? frontmatter.access_count : 0,
+    deleted_at:
+      frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
+    okf_type: frontmatter.type,
+  };
+}
+
+function frontmatterToTask(entityId: string, frontmatter: OkfFrontmatter, now: number): WikiTask {
+  const id = typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : generateId();
+  const created_at = parseFrontmatterTimestamp(frontmatter.created_at, now);
+  const updated_at = parseFrontmatterTimestamp(
+    frontmatter.timestamp,
+    parseFrontmatterTimestamp(frontmatter.updated_at, now),
+  );
+
+  return {
+    id,
+    entity_id: entityId,
+    description: typeof frontmatter.title === 'string' ? frontmatter.title : '',
+    status: TASK_STATUSES.has(String(frontmatter.status))
+      ? (frontmatter.status as WikiTask['status'])
+      : 'pending',
+    priority: typeof frontmatter.priority === 'number' ? frontmatter.priority : 0,
+    created_at,
+    updated_at,
+    resolved_at:
+      frontmatter.resolved_at != null
+        ? parseFrontmatterTimestamp(frontmatter.resolved_at, now)
+        : null,
+    deleted_at:
+      frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
+    okf_type: frontmatter.type,
+  };
+}
+
+function findLogMdPath(files: OkfFile[]): string | undefined {
+  return files.find(f => f.path.endsWith('/log.md') || f.path === 'log.md')?.path;
+}
+
+export function parseOkfBundle(
+  entityId: string,
+  files: OkfFile[],
+  options?: OkfImportOptions,
+): MemoryDump {
+  const now = Date.now();
+  const pathToResolvedId = new Map<string, string>();
+
+  for (const file of files) {
+    if (!isConceptFile(file.path)) continue;
+    const { frontmatter } = parseConcept(file.content);
+    const resolvedId =
+      typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : basenameMd(file.path);
+    addPathAliases(pathToResolvedId, file.path, resolvedId);
+  }
+
+  const facts: WikiFact[] = [];
+  const tasks: WikiTask[] = [];
+  const edges: WikiEdge[] = [];
+  let logContent: string | null = null;
+  const logMdPath = findLogMdPath(files);
+
+  for (const file of files) {
+    if (file.path.endsWith('/log.md') || file.path === 'log.md') {
+      logContent = file.content;
+      continue;
+    }
+    if (!isConceptFile(file.path)) continue;
+
+    const { frontmatter, body } = parseConcept(file.content);
+    const route = resolveRoute(file.path, frontmatter.type ?? '', options);
+    if (route === 'ignore') continue;
+
+    const resolvedId =
+      typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : basenameMd(file.path);
+
+    if (route === 'fact') {
+      facts.push(frontmatterToFact(entityId, frontmatter, body, now));
+    } else {
+      tasks.push(frontmatterToTask(entityId, frontmatter, now));
+    }
+
+    for (const link of extractMarkdownLinks(body)) {
+      const targetPath = resolveRelativePath(file.path, link.path);
+      if (isStructuralPath(targetPath)) continue;
+      const targetId = lookupResolvedId(pathToResolvedId, targetPath);
+      if (!targetId) continue;
+      edges.push({
+        id: generateId(),
+        entity_id: entityId,
+        source_id: resolvedId,
+        target_id: targetId,
+        edge_type: link.text,
+        created_at: now,
+      });
+    }
+  }
+
+  const events: WikiEvent[] = [];
+  if (logContent != null) {
+    const logPath = logMdPath ?? `entities/${entityId}/log.md`;
+    for (const entry of parseLogMd(logContent)) {
+      const parsed = parseLogEntryText(entry.text);
+      if (!parsed) continue;
+      let related_entry_id: string | null = null;
+      if (parsed.linkPath) {
+        const targetPath = resolveRelativePath(logPath, parsed.linkPath);
+        if (!isStructuralPath(targetPath)) {
+          related_entry_id = lookupResolvedId(pathToResolvedId, targetPath) ?? null;
+        }
+      }
+      events.push({
+        id: generateId('evt_'),
+        entity_id: entityId,
+        event_type: parsed.event_type,
+        summary: parsed.summary,
+        related_entry_id,
+        created_at: new Date(`${entry.date}T00:00:00.000Z`).getTime(),
+      });
+    }
+  }
+
+  return {
+    generatedAt: now,
+    entities: {
+      [entityId]: { facts, tasks, events, edges },
+    },
+  };
+}

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -77,6 +77,15 @@ function lookupResolvedId(map: Map<string, string>, path: string): string | unde
   return map.get(path) ?? map.get(normalized) ?? map.get(`./${normalized}`);
 }
 
+function stripLinkSuffix(linkPath: string): string {
+  const hashIdx = linkPath.indexOf('#');
+  const queryIdx = linkPath.indexOf('?');
+  if (hashIdx === -1 && queryIdx === -1) return linkPath;
+  const cut =
+    hashIdx === -1 ? queryIdx : queryIdx === -1 ? hashIdx : Math.min(hashIdx, queryIdx);
+  return linkPath.slice(0, cut);
+}
+
 function resolveRoute(filePath: string, frontmatterType: string, options?: OkfImportOptions): Route {
   if (options?.typeMapping && frontmatterType in options.typeMapping) {
     return options.typeMapping[frontmatterType]!;
@@ -237,7 +246,7 @@ export function parseOkfBundle(
     }
 
     for (const link of extractMarkdownLinks(body)) {
-      const targetPath = resolveRelativePath(file.path, link.path);
+      const targetPath = resolveRelativePath(file.path, stripLinkSuffix(link.path));
       if (isStructuralPath(targetPath)) continue;
       const targetId = lookupResolvedId(pathToResolvedId, targetPath);
       if (!targetId) continue;
@@ -260,8 +269,8 @@ export function parseOkfBundle(
       if (!parsed) continue;
       let related_entry_id: string | null = null;
       if (parsed.linkPath) {
-        const targetPath = resolveRelativePath(logPath, parsed.linkPath);
-        if (!isStructuralPath(targetPath)) {
+        const targetPath = resolveRelativePath(logPath, stripLinkSuffix(parsed.linkPath));
+        if (!isStructuralPath(targetPath) && targetPath.includes('/facts/')) {
           related_entry_id = lookupResolvedId(pathToResolvedId, targetPath) ?? null;
         }
       }

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -118,11 +118,11 @@ function parseLogEntryText(text: string): {
 
 function frontmatterToFact(
   entityId: string,
+  id: string,
   frontmatter: OkfFrontmatter,
   body: string,
   now: number,
 ): WikiFact {
-  const id = typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : generateId();
   const created_at = parseFrontmatterTimestamp(frontmatter.created_at, now);
   const updated_at = parseFrontmatterTimestamp(
     frontmatter.timestamp,
@@ -158,8 +158,12 @@ function frontmatterToFact(
   };
 }
 
-function frontmatterToTask(entityId: string, frontmatter: OkfFrontmatter, now: number): WikiTask {
-  const id = typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : generateId();
+function frontmatterToTask(
+  entityId: string,
+  id: string,
+  frontmatter: OkfFrontmatter,
+  now: number,
+): WikiTask {
   const created_at = parseFrontmatterTimestamp(frontmatter.created_at, now);
   const updated_at = parseFrontmatterTimestamp(
     frontmatter.timestamp,
@@ -227,9 +231,9 @@ export function parseOkfBundle(
       typeof frontmatter.id === 'string' && frontmatter.id ? frontmatter.id : basenameMd(file.path);
 
     if (route === 'fact') {
-      facts.push(frontmatterToFact(entityId, frontmatter, body, now));
+      facts.push(frontmatterToFact(entityId, resolvedId, frontmatter, body, now));
     } else {
-      tasks.push(frontmatterToTask(entityId, frontmatter, now));
+      tasks.push(frontmatterToTask(entityId, resolvedId, frontmatter, now));
     }
 
     for (const link of extractMarkdownLinks(body)) {

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -87,7 +87,10 @@ function stripLinkSuffix(linkPath: string): string {
 }
 
 function resolveRoute(filePath: string, frontmatterType: string, options?: OkfImportOptions): Route {
-  if (options?.typeMapping && frontmatterType in options.typeMapping) {
+  if (
+    options?.typeMapping &&
+    Object.prototype.hasOwnProperty.call(options.typeMapping, frontmatterType)
+  ) {
     return options.typeMapping[frontmatterType]!;
   }
   if (filePath.includes('/facts/')) return 'fact';

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -250,11 +250,15 @@ export function parseOkfBundle(
       tasks.push(frontmatterToTask(entityId, resolvedId, frontmatter, now));
     }
 
+    const seenEdges = new Set<string>();
     for (const link of extractMarkdownLinks(body)) {
       const targetPath = resolveRelativePath(file.path, stripLinkSuffix(link.path));
       if (isStructuralPath(targetPath)) continue;
       const targetId = lookupResolvedId(pathToResolvedId, targetPath);
       if (!targetId) continue;
+      const edgeKey = `${resolvedId}\u0000${targetId}\u0000${link.text}`;
+      if (seenEdges.has(edgeKey)) continue;
+      seenEdges.add(edgeKey);
       edges.push({
         id: generateId(),
         entity_id: entityId,

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -279,13 +279,16 @@ export function parseOkfBundle(
           related_entry_id = lookupResolvedId(pathToResolvedId, targetPath) ?? null;
         }
       }
+      const created_at = new Date(`${entry.date}T00:00:00.000Z`).getTime();
+      if (!Number.isFinite(created_at)) continue;
+
       events.push({
         id: generateId('evt_'),
         entity_id: entityId,
         event_type: parsed.event_type,
         summary: parsed.summary,
         related_entry_id,
-        created_at: new Date(`${entry.date}T00:00:00.000Z`).getTime(),
+        created_at,
       });
     }
   }

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -252,9 +252,11 @@ export function parseOkfBundle(
 
     const seenEdges = new Set<string>();
     for (const link of extractMarkdownLinks(body)) {
-      const targetPath = resolveRelativePath(file.path, stripLinkSuffix(link.path));
-      if (isStructuralPath(targetPath)) continue;
-      const targetId = lookupResolvedId(pathToResolvedId, targetPath);
+      const strippedPath = stripLinkSuffix(link.path);
+      const directTargetId = lookupResolvedId(pathToResolvedId, strippedPath);
+      const resolvedTargetPath = resolveRelativePath(file.path, strippedPath);
+      if (isStructuralPath(strippedPath) || isStructuralPath(resolvedTargetPath)) continue;
+      const targetId = directTargetId ?? lookupResolvedId(pathToResolvedId, resolvedTargetPath);
       if (!targetId) continue;
       const edgeKey = `${resolvedId}\u0000${targetId}\u0000${link.text}`;
       if (seenEdges.has(edgeKey)) continue;

--- a/packages/core/src/utils/parseOkfBundle.ts
+++ b/packages/core/src/utils/parseOkfBundle.ts
@@ -166,7 +166,7 @@ function frontmatterToFact(
     access_count: typeof frontmatter.access_count === 'number' ? frontmatter.access_count : 0,
     deleted_at:
       frontmatter.deleted_at != null ? parseFrontmatterTimestamp(frontmatter.deleted_at, 0) : null,
-    okf_type: frontmatter.type || null,
+    okf_type: frontmatter.type,
   };
 }
 

--- a/packages/okf/__tests__/concept.test.ts
+++ b/packages/okf/__tests__/concept.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildConceptDocument } from '../src/concept';
+import { buildConceptDocument, parseConcept } from '../src/concept';
 
 describe('buildConceptDocument', () => {
   it('concatenates frontmatter and body with a blank line between', () => {
@@ -10,5 +10,27 @@ describe('buildConceptDocument', () => {
   it('supports the minimal case where only type is present', () => {
     const result = buildConceptDocument({ type: 'task' }, '');
     expect(result).toBe('---\ntype: task\n---\n\n');
+  });
+});
+
+describe('parseConcept', () => {
+  it('splits frontmatter and body', () => {
+    const doc = buildConceptDocument({ type: 'fact', title: 'T' }, 'Body text');
+    const { frontmatter, body } = parseConcept(doc);
+    expect(frontmatter).toEqual({ type: 'fact', title: 'T' });
+    expect(body).toBe('Body text');
+  });
+
+  it('supports the minimal case where only type is present and body is empty', () => {
+    const doc = buildConceptDocument({ type: 'task' }, '');
+    const { frontmatter, body } = parseConcept(doc);
+    expect(frontmatter).toEqual({ type: 'task' });
+    expect(body).toBe('');
+  });
+
+  it('round-trips a multi-line body', () => {
+    const doc = buildConceptDocument({ type: 'fact' }, 'line one\nline two\nline three');
+    const { body } = parseConcept(doc);
+    expect(body).toBe('line one\nline two\nline three');
   });
 });

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serializeFrontmatter } from '../src/frontmatter';
+import { serializeFrontmatter, parseFrontmatter } from '../src/frontmatter';
 
 describe('serializeFrontmatter', () => {
   it('serializes a minimal type-only frontmatter block', () => {
@@ -109,5 +109,81 @@ describe('serializeFrontmatter', () => {
   it('quotes custom keys that would parse as YAML literals', () => {
     const result = serializeFrontmatter({ '123': 'n', type: 'fact', true: 'b' } as any);
     expect(result).toBe('---\n"123": n\ntype: fact\n"true": b\n---\n');
+  });
+});
+
+describe('parseFrontmatter', () => {
+  it('parses a minimal type-only frontmatter block', () => {
+    const { frontmatter, rest } = parseFrontmatter('---\ntype: fact\n---\n');
+    expect(frontmatter).toEqual({ type: 'fact' });
+    expect(rest).toBe('');
+  });
+
+  it('parses string, number, boolean, and null scalars', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\ntype: fact\npriority: 5\nactive: true\nresolved_at: null\n---\n',
+    );
+    expect(frontmatter).toEqual({ type: 'fact', priority: 5, active: true, resolved_at: null });
+  });
+
+  it('parses a YAML block list back into a string array', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\ntags:\n  - a\n  - b\n---\n');
+    expect(frontmatter.tags).toEqual(['a', 'b']);
+  });
+
+  it('parses an empty array', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\ntags: []\n---\n');
+    expect(frontmatter.tags).toEqual([]);
+  });
+
+  it('does not unquote ISO 8601 timestamps (none are quoted by the serializer)', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\ntype: fact\ntimestamp: 2026-05-28T14:30:00+05:00\n---\n',
+    );
+    expect(frontmatter.timestamp).toBe('2026-05-28T14:30:00+05:00');
+  });
+
+  it('unquotes a value containing a colon', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\ntitle: "Note: important"\n---\n');
+    expect(frontmatter.title).toBe('Note: important');
+  });
+
+  it('unquotes a value that looks like a YAML boolean/null/number literal', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\ntags:\n  - "true"\n---\n');
+    expect(frontmatter.tags).toEqual(['true']);
+  });
+
+  it('unquotes escaped newline, tab, and carriage return sequences', () => {
+    const { frontmatter } = parseFrontmatter(
+      '---\ntype: fact\ndescription: "line one\\nline two"\n---\n',
+    );
+    expect(frontmatter.description).toBe('line one\nline two');
+  });
+
+  it('unquotes a quoted custom key', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\n"custom key": v\n---\n');
+    expect(frontmatter['custom key']).toBe('v');
+  });
+
+  it('returns the body after the closing delimiter as rest', () => {
+    const { rest } = parseFrontmatter('---\ntype: fact\n---\n\nBody text\nline two');
+    expect(rest).toBe('\nBody text\nline two');
+  });
+
+  it('falls back to type: "" when no frontmatter block is present', () => {
+    const { frontmatter, rest } = parseFrontmatter('Just plain text, no frontmatter.');
+    expect(frontmatter).toEqual({ type: '' });
+    expect(rest).toBe('Just plain text, no frontmatter.');
+  });
+
+  it('falls back to type: "" when the closing delimiter is missing', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\ntitle: T\n');
+    expect(frontmatter).toEqual({ type: '' });
+  });
+
+  it('defaults type to "" when the frontmatter block omits it', () => {
+    const { frontmatter } = parseFrontmatter('---\ntitle: T\n---\n');
+    expect(frontmatter.type).toBe('');
+    expect(frontmatter.title).toBe('T');
   });
 });

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -165,6 +165,21 @@ describe('parseFrontmatter', () => {
     expect(frontmatter['custom key']).toBe('v');
   });
 
+  it('unquotes a quoted custom key containing a colon', () => {
+    const { frontmatter } = parseFrontmatter('---\ntype: fact\n"meta:field": w\n---\n');
+    expect(frontmatter['meta:field']).toBe('w');
+  });
+
+  it('round-trips quoted keys containing colons', () => {
+    const serialized = serializeFrontmatter({
+      type: 'fact',
+      'meta:field': 'w',
+      'a:b': 'v',
+    } as any);
+    const { frontmatter } = parseFrontmatter(serialized);
+    expect(frontmatter).toEqual({ type: 'fact', 'meta:field': 'w', 'a:b': 'v' });
+  });
+
   it('returns the body after the closing delimiter as rest', () => {
     const { rest } = parseFrontmatter('---\ntype: fact\n---\n\nBody text\nline two');
     expect(rest).toBe('\nBody text\nline two');

--- a/packages/okf/__tests__/frontmatter.test.ts
+++ b/packages/okf/__tests__/frontmatter.test.ts
@@ -165,6 +165,12 @@ describe('parseFrontmatter', () => {
     expect(frontmatter['custom key']).toBe('v');
   });
 
+  it('unquotes single-quoted keys and scalar values', () => {
+    const { frontmatter } = parseFrontmatter("---\n'type': 'fact'\ntitle: 'It''s fine'\n---\n");
+    expect(frontmatter.type).toBe('fact');
+    expect(frontmatter.title).toBe("It's fine");
+  });
+
   it('unquotes a quoted custom key containing a colon', () => {
     const { frontmatter } = parseFrontmatter('---\ntype: fact\n"meta:field": w\n---\n');
     expect(frontmatter['meta:field']).toBe('w');

--- a/packages/okf/__tests__/log-md.test.ts
+++ b/packages/okf/__tests__/log-md.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildLogMd } from '../src/log-md';
+import { buildLogMd, parseLogMd } from '../src/log-md';
 
 describe('buildLogMd', () => {
   it('groups entries by date, sorts groups descending, preserves entry order within a group', () => {
@@ -18,5 +18,49 @@ describe('buildLogMd', () => {
 
   it('renders an empty string for an empty entries list', () => {
     expect(buildLogMd([])).toBe('');
+  });
+});
+
+describe('parseLogMd', () => {
+  it('extracts date headings and bullet entries', () => {
+    const content = '## 2026-01-02\n\n- B\n\n## 2026-01-01\n\n- A\n- C\n';
+    expect(parseLogMd(content)).toEqual([
+      { date: '2026-01-02', text: 'B' },
+      { date: '2026-01-01', text: 'A' },
+      { date: '2026-01-01', text: 'C' },
+    ]);
+  });
+
+  it('round-trips through buildLogMd for a single entry', () => {
+    const built = buildLogMd([{ date: '2026-06-18', text: 'X' }]);
+    expect(parseLogMd(built)).toEqual([{ date: '2026-06-18', text: 'X' }]);
+  });
+
+  it('round-trips through buildLogMd for multiple dates and entries', () => {
+    const entries = [
+      { date: '2026-01-01', text: 'A' },
+      { date: '2026-01-02', text: 'B' },
+      { date: '2026-01-01', text: 'C' },
+    ];
+    const built = buildLogMd(entries);
+    expect(parseLogMd(built)).toEqual([
+      { date: '2026-01-02', text: 'B' },
+      { date: '2026-01-01', text: 'A' },
+      { date: '2026-01-01', text: 'C' },
+    ]);
+  });
+
+  it('returns an empty array for empty content', () => {
+    expect(parseLogMd('')).toEqual([]);
+  });
+
+  it('ignores bullet lines that appear before any date heading', () => {
+    const content = '- orphan bullet\n\n## 2026-01-01\n\n- A\n';
+    expect(parseLogMd(content)).toEqual([{ date: '2026-01-01', text: 'A' }]);
+  });
+
+  it('ignores lines that are neither a heading nor a bullet', () => {
+    const content = '## 2026-01-01\n\nSome prose line.\n- A\n';
+    expect(parseLogMd(content)).toEqual([{ date: '2026-01-01', text: 'A' }]);
   });
 });

--- a/packages/okf/__tests__/markdown-links.test.ts
+++ b/packages/okf/__tests__/markdown-links.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { extractMarkdownLinks } from '../src/markdown-links';
+
+describe('extractMarkdownLinks', () => {
+  it('extracts a single inline link', () => {
+    expect(extractMarkdownLinks('See [related task](./tasks/abc.md) for details.')).toEqual([
+      { text: 'related task', path: './tasks/abc.md' },
+    ]);
+  });
+
+  it('extracts multiple links from one body', () => {
+    const body = '[reports_to](../people/bob.md) and [mentions](./facts/x.md)';
+    expect(extractMarkdownLinks(body)).toEqual([
+      { text: 'reports_to', path: '../people/bob.md' },
+      { text: 'mentions', path: './facts/x.md' },
+    ]);
+  });
+
+  it('excludes http(s) links', () => {
+    expect(extractMarkdownLinks('See [docs](https://example.com/page)')).toEqual([]);
+  });
+
+  it('excludes mailto links', () => {
+    expect(extractMarkdownLinks('Contact [Alice](mailto:alice@example.com)')).toEqual([]);
+  });
+
+  it('returns an empty array when there are no links', () => {
+    expect(extractMarkdownLinks('Plain text with no links at all.')).toEqual([]);
+  });
+
+  it('handles an empty link text', () => {
+    expect(extractMarkdownLinks('[](./facts/x.md)')).toEqual([{ text: '', path: './facts/x.md' }]);
+  });
+});

--- a/packages/okf/__tests__/markdown-links.test.ts
+++ b/packages/okf/__tests__/markdown-links.test.ts
@@ -31,4 +31,9 @@ describe('extractMarkdownLinks', () => {
   it('handles an empty link text', () => {
     expect(extractMarkdownLinks('[](./facts/x.md)')).toEqual([{ text: '', path: './facts/x.md' }]);
   });
+
+  it('ignores links inside fenced code blocks', () => {
+    const body = 'Real [link](./facts/x.md)\n\n```\n[fake](./facts/y.md)\n```';
+    expect(extractMarkdownLinks(body)).toEqual([{ text: 'link', path: './facts/x.md' }]);
+  });
 });

--- a/packages/okf/src/concept.ts
+++ b/packages/okf/src/concept.ts
@@ -1,6 +1,13 @@
 import type { OkfFrontmatter } from './types';
-import { serializeFrontmatter } from './frontmatter';
+import { serializeFrontmatter, parseFrontmatter } from './frontmatter';
 
 export function buildConceptDocument(fm: OkfFrontmatter, body: string): string {
   return `${serializeFrontmatter(fm)}\n${body}`;
+}
+
+/** Reverse of {@link buildConceptDocument}: strips the single leading blank-line separator. */
+export function parseConcept(content: string): { frontmatter: OkfFrontmatter; body: string } {
+  const { frontmatter, rest } = parseFrontmatter(content);
+  const body = rest.startsWith('\n') ? rest.slice(1) : rest;
+  return { frontmatter, body };
 }

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -98,19 +98,30 @@ function unescapeFrontmatterString(escaped: string): string {
   return result;
 }
 
-function parseKey(raw: string): string {
+function unescapeSingleQuotedString(escaped: string): string {
+  return escaped.replace(/''/g, "'");
+}
+
+function parseQuotedScalar(raw: string): string | null {
   const trimmed = raw.trim();
-  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+  if (trimmed.length < 2) return null;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
     return unescapeFrontmatterString(trimmed.slice(1, -1));
   }
-  return trimmed;
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return unescapeSingleQuotedString(trimmed.slice(1, -1));
+  }
+  return null;
+}
+
+function parseKey(raw: string): string {
+  return parseQuotedScalar(raw) ?? raw.trim();
 }
 
 function parseScalarValue(raw: string): OkfFrontmatterScalar {
+  const quoted = parseQuotedScalar(raw);
+  if (quoted !== null) return quoted;
   const trimmed = raw.trim();
-  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return unescapeFrontmatterString(trimmed.slice(1, -1));
-  }
   if (trimmed === 'null') return null;
   if (trimmed === 'true') return true;
   if (trimmed === 'false') return false;

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -164,7 +164,7 @@ export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter
       frontmatter[key] = items;
       continue;
     }
-    const kvMatch = /^([^:]+):\s(.*)$/.exec(line);
+    const kvMatch = /^([^:]+):\s*(.*)$/.exec(line);
     if (kvMatch) {
       frontmatter[parseKey(kvMatch[1])] = parseScalarValue(kvMatch[2]);
     }

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -118,13 +118,24 @@ function parseScalarValue(raw: string): OkfFrontmatterScalar {
   return trimmed;
 }
 
+function matchFrontmatterKeyValue(
+  line: string,
+): { key: string; value: string; hasValue: boolean } | null {
+  const keyMatch = /^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^:]+)/.exec(line);
+  if (!keyMatch) return null;
+  const key = keyMatch[0];
+  if (line[key.length] !== ':') return null;
+  const tail = line.slice(key.length + 1);
+  return { key, value: tail.trimStart(), hasValue: tail.trim().length > 0 };
+}
+
 /**
  * Parses the subset of YAML frontmatter that {@link serializeFrontmatter} produces:
  * scalar string/number/boolean/null values, quoted strings, and block string-lists.
  * NOT a general YAML parser — flow collections (`[...]`/`{...}`), multi-line block
  * scalars (`|`/`>`), anchors, and aliases are not recognized. Lines that don't match
- * a recognized shape (including quoted keys/values containing an embedded, unescaped
- * colon) are silently skipped rather than throwing, so a foreign bundle never crashes
+ * a recognized shape are silently skipped rather than throwing, so a foreign bundle
+ * never crashes
  * the import — it just loses fidelity on the unrecognized line.
  */
 export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter; rest: string } {
@@ -146,15 +157,18 @@ export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter
   let i = 1;
   while (i < closingIndex) {
     const line = lines[i];
-    const emptyArrayMatch = /^([^:]+):\s*\[\]\s*$/.exec(line);
-    if (emptyArrayMatch) {
-      frontmatter[parseKey(emptyArrayMatch[1])] = [];
+    const kv = matchFrontmatterKeyValue(line);
+    if (!kv) {
       i++;
       continue;
     }
-    const arrayHeaderMatch = /^([^:]+):\s*$/.exec(line);
-    if (arrayHeaderMatch) {
-      const key = parseKey(arrayHeaderMatch[1]);
+    if (kv.value.trim() === '[]') {
+      frontmatter[parseKey(kv.key)] = [];
+      i++;
+      continue;
+    }
+    if (!kv.hasValue) {
+      const key = parseKey(kv.key);
       const items: OkfFrontmatterScalar[] = [];
       i++;
       while (i < closingIndex && /^\s*-\s/.test(lines[i])) {
@@ -164,10 +178,7 @@ export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter
       frontmatter[key] = items;
       continue;
     }
-    const kvMatch = /^([^:]+):\s*(.*)$/.exec(line);
-    if (kvMatch) {
-      frontmatter[parseKey(kvMatch[1])] = parseScalarValue(kvMatch[2]);
-    }
+    frontmatter[parseKey(kv.key)] = parseScalarValue(kv.value);
     i++;
   }
 

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -1,4 +1,4 @@
-import type { OkfFrontmatter } from './types';
+import type { OkfFrontmatter, OkfFrontmatterScalar, OkfFrontmatterValue } from './types';
 
 const RESERVED_LITERALS = new Set(['true', 'false', 'yes', 'no', 'on', 'off', 'null', '~', '']);
 
@@ -79,4 +79,104 @@ export function serializeFrontmatter(fm: OkfFrontmatter): string {
   }
   lines.push('---');
   return lines.join('\n') + '\n';
+}
+
+function unescapeFrontmatterString(escaped: string): string {
+  let result = '';
+  for (let i = 0; i < escaped.length; i++) {
+    const ch = escaped[i];
+    if (ch === '\\' && i + 1 < escaped.length) {
+      const next = escaped[i + 1];
+      if (next === 'n') { result += '\n'; i++; continue; }
+      if (next === 'r') { result += '\r'; i++; continue; }
+      if (next === 't') { result += '\t'; i++; continue; }
+      if (next === '"') { result += '"'; i++; continue; }
+      if (next === '\\') { result += '\\'; i++; continue; }
+    }
+    result += ch;
+  }
+  return result;
+}
+
+function parseKey(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return unescapeFrontmatterString(trimmed.slice(1, -1));
+  }
+  return trimmed;
+}
+
+function parseScalarValue(raw: string): OkfFrontmatterScalar {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return unescapeFrontmatterString(trimmed.slice(1, -1));
+  }
+  if (trimmed === 'null') return null;
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(trimmed)) return Number(trimmed);
+  return trimmed;
+}
+
+/**
+ * Parses the subset of YAML frontmatter that {@link serializeFrontmatter} produces:
+ * scalar string/number/boolean/null values, quoted strings, and block string-lists.
+ * NOT a general YAML parser — flow collections (`[...]`/`{...}`), multi-line block
+ * scalars (`|`/`>`), anchors, and aliases are not recognized. Lines that don't match
+ * a recognized shape (including quoted keys/values containing an embedded, unescaped
+ * colon) are silently skipped rather than throwing, so a foreign bundle never crashes
+ * the import — it just loses fidelity on the unrecognized line.
+ */
+export function parseFrontmatter(content: string): { frontmatter: OkfFrontmatter; rest: string } {
+  const lines = content.split(/\r?\n/);
+  const fallback = { frontmatter: { type: '' } as OkfFrontmatter, rest: content };
+
+  if (lines[0]?.trim() !== '---') return fallback;
+
+  let closingIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      closingIndex = i;
+      break;
+    }
+  }
+  if (closingIndex === -1) return fallback;
+
+  const frontmatter: Record<string, OkfFrontmatterValue> = {};
+  let i = 1;
+  while (i < closingIndex) {
+    const line = lines[i];
+    const emptyArrayMatch = /^([^:]+):\s*\[\]\s*$/.exec(line);
+    if (emptyArrayMatch) {
+      frontmatter[parseKey(emptyArrayMatch[1])] = [];
+      i++;
+      continue;
+    }
+    const arrayHeaderMatch = /^([^:]+):\s*$/.exec(line);
+    if (arrayHeaderMatch) {
+      const key = parseKey(arrayHeaderMatch[1]);
+      const items: OkfFrontmatterScalar[] = [];
+      i++;
+      while (i < closingIndex && /^\s*-\s/.test(lines[i])) {
+        items.push(parseScalarValue(lines[i].replace(/^\s*-\s/, '')));
+        i++;
+      }
+      frontmatter[key] = items;
+      continue;
+    }
+    const kvMatch = /^([^:]+):\s(.*)$/.exec(line);
+    if (kvMatch) {
+      frontmatter[parseKey(kvMatch[1])] = parseScalarValue(kvMatch[2]);
+    }
+    i++;
+  }
+
+  if (typeof frontmatter['type'] !== 'string') {
+    frontmatter['type'] = '';
+  }
+
+  const restLines = lines.slice(closingIndex + 1);
+  const rest = restLines.length > 0 ? restLines.join('\n') : '';
+
+  return { frontmatter: frontmatter as OkfFrontmatter, rest };
 }

--- a/packages/okf/src/frontmatter.ts
+++ b/packages/okf/src/frontmatter.ts
@@ -132,7 +132,7 @@ function parseScalarValue(raw: string): OkfFrontmatterScalar {
 function matchFrontmatterKeyValue(
   line: string,
 ): { key: string; value: string; hasValue: boolean } | null {
-  const keyMatch = /^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^:]+)/.exec(line);
+  const keyMatch = /^(?:"(?:\\.|[^"\\])*"|'(?:''|[^'])*'|[^:]+)/.exec(line);
   if (!keyMatch) return null;
   const key = keyMatch[0];
   if (line[key.length] !== ':') return null;

--- a/packages/okf/src/index.ts
+++ b/packages/okf/src/index.ts
@@ -1,5 +1,6 @@
-export type { OkfFrontmatter, OkfIndexEntry, OkfIndexSection, OkfLogEntry, OkfFile } from './types';
-export { serializeFrontmatter } from './frontmatter';
-export { buildConceptDocument } from './concept';
+export type { OkfFrontmatter, OkfFrontmatterScalar, OkfFrontmatterValue, OkfIndexEntry, OkfIndexSection, OkfLogEntry, OkfFile, OkfMarkdownLink } from './types';
+export { serializeFrontmatter, parseFrontmatter } from './frontmatter';
+export { buildConceptDocument, parseConcept } from './concept';
 export { buildIndexMd, buildRootIndexMd } from './index-md';
-export { buildLogMd } from './log-md';
+export { buildLogMd, parseLogMd } from './log-md';
+export { extractMarkdownLinks } from './markdown-links';

--- a/packages/okf/src/log-md.ts
+++ b/packages/okf/src/log-md.ts
@@ -23,3 +23,31 @@ export function buildLogMd(entries: OkfLogEntry[]): string {
   if (lines.length === 0) return '';
   return lines.join('\n').trimEnd() + '\n';
 }
+
+const DATE_HEADING = /^##\s+(\d{4}-\d{2}-\d{2})\s*$/;
+const BULLET = /^-\s+(.*)$/;
+
+/**
+ * Reverse of {@link buildLogMd}. Best-effort: lines that don't match the exact
+ * `## YYYY-MM-DD` heading or `- text` bullet shape buildLogMd emits are skipped,
+ * not thrown — a foreign log.md in a different format degrades to fewer entries
+ * rather than failing the import.
+ */
+export function parseLogMd(content: string): OkfLogEntry[] {
+  const entries: OkfLogEntry[] = [];
+  let currentDate: string | null = null;
+
+  for (const line of content.split(/\r?\n/)) {
+    const headingMatch = DATE_HEADING.exec(line);
+    if (headingMatch) {
+      currentDate = headingMatch[1];
+      continue;
+    }
+    const bulletMatch = BULLET.exec(line);
+    if (bulletMatch && currentDate) {
+      entries.push({ date: currentDate, text: bulletMatch[1] });
+    }
+  }
+
+  return entries;
+}

--- a/packages/okf/src/markdown-links.ts
+++ b/packages/okf/src/markdown-links.ts
@@ -1,0 +1,22 @@
+import type { OkfMarkdownLink } from './types';
+
+const LINK_PATTERN = /\[([^\]]*)\]\(([^)\s]+)\)/g;
+const EXCLUDED_SCHEME = /^(https?:|mailto:)/i;
+
+/**
+ * Extracts inline markdown links (`[text](path)`) from a concept body.
+ * Single-line regex, not a CommonMark parser — reference-style links, links
+ * split across lines, and links inside code fences are not recognized.
+ * `http(s):` and `mailto:` targets are excluded; only relative/local paths
+ * are candidates for graph edges.
+ */
+export function extractMarkdownLinks(body: string): OkfMarkdownLink[] {
+  const links: OkfMarkdownLink[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = LINK_PATTERN.exec(body)) !== null) {
+    const [, text, path] = match;
+    if (EXCLUDED_SCHEME.test(path)) continue;
+    links.push({ text, path });
+  }
+  return links;
+}

--- a/packages/okf/src/markdown-links.ts
+++ b/packages/okf/src/markdown-links.ts
@@ -2,6 +2,7 @@ import type { OkfMarkdownLink } from './types';
 
 const LINK_PATTERN = /\[([^\]]*)\]\(([^)\s]+)\)/g;
 const EXCLUDED_SCHEME = /^(https?:|mailto:)/i;
+const FENCED_CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
 
 /**
  * Extracts inline markdown links (`[text](path)`) from a concept body.
@@ -11,9 +12,11 @@ const EXCLUDED_SCHEME = /^(https?:|mailto:)/i;
  * are candidates for graph edges.
  */
 export function extractMarkdownLinks(body: string): OkfMarkdownLink[] {
+  const searchableBody = body.replace(FENCED_CODE_BLOCK_PATTERN, '');
   const links: OkfMarkdownLink[] = [];
   let match: RegExpExecArray | null;
-  while ((match = LINK_PATTERN.exec(body)) !== null) {
+  LINK_PATTERN.lastIndex = 0;
+  while ((match = LINK_PATTERN.exec(searchableBody)) !== null) {
     const [, text, path] = match;
     if (EXCLUDED_SCHEME.test(path)) continue;
     links.push({ text, path });

--- a/packages/okf/src/markdown-links.ts
+++ b/packages/okf/src/markdown-links.ts
@@ -1,6 +1,5 @@
 import type { OkfMarkdownLink } from './types';
 
-const LINK_PATTERN = /\[([^\]]*)\]\(([^)\s]+)\)/g;
 const EXCLUDED_SCHEME = /^(https?:|mailto:)/i;
 const FENCED_CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
 
@@ -13,10 +12,10 @@ const FENCED_CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
  */
 export function extractMarkdownLinks(body: string): OkfMarkdownLink[] {
   const searchableBody = body.replace(FENCED_CODE_BLOCK_PATTERN, '');
+  const linkPattern = /\[([^\]]*)\]\(([^)\s]+)\)/g;
   const links: OkfMarkdownLink[] = [];
   let match: RegExpExecArray | null;
-  LINK_PATTERN.lastIndex = 0;
-  while ((match = LINK_PATTERN.exec(searchableBody)) !== null) {
+  while ((match = linkPattern.exec(searchableBody)) !== null) {
     const [, text, path] = match;
     if (EXCLUDED_SCHEME.test(path)) continue;
     links.push({ text, path });

--- a/packages/okf/src/types.ts
+++ b/packages/okf/src/types.ts
@@ -31,3 +31,8 @@ export interface OkfFile {
   path: string;
   content: string;
 }
+
+export interface OkfMarkdownLink {
+  text: string;
+  path: string;
+}


### PR DESCRIPTION
## Summary

- Add OKF parse primitives in `@equationalapplications/core-okf` (`parseFrontmatter`, `parseConcept`, `parseLogMd`, `extractMarkdownLinks`) so foreign or self-produced bundles can be read back with fidelity on `type:` strings and markdown-link relationships.
- Extend `packages/core` with schema migration v5 (`okf_type` columns + `edges` table), `EdgeRepository`, and `ImportExportService` wiring so edges and `okf_type` round-trip through `importDump` / `exportDump`.
- Introduce `parseOkfBundle` — an adapter that turns `OkfFile[]` into a `MemoryDump` for the existing import pipeline, with routing, path-map link resolution, log → events, and a `formatOkfBundle` round-trip test.

**Spec:** [docs/superpowers/specs/2026-06-22-okf-import-design.md](docs/superpowers/specs/2026-06-22-okf-import-design.md)

## Test plan

- [x] `cd packages/okf && pnpm test && pnpm typecheck`
- [x] `cd packages/core && pnpm test && pnpm typecheck`
- [ ] Smoke: export an entity via `formatOkfBundle`, run `parseOkfBundle`, `importDump` merge/replace, confirm facts/tasks/events/edges and `okf_type` values match expectations


Made with [Cursor](https://cursor.com)