### PR TITLE
feat: knowledge graph traversal API

### DIFF
--- a/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
+++ b/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
@@ -1,7 +1,7 @@
 # Spec: Knowledge Graph Traversal API
 
 **Date:** 2026-06-23
-**Status:** Draft
+**Status:** Approved
 **Builds on:** [2026-06-22-okf-import-design.md](./2026-06-22-okf-import-design.md) (`llm_wiki_edges` table), [2026-06-23-per-entity-seeded-ontology-design.md](./2026-06-23-per-entity-seeded-ontology-design.md) (ontology manifest, `okf_type`)
 **Packages:** `@equationalapplications/core-llm-wiki` (`packages/core`), `@equationalapplications/react-llm-wiki` (`packages/react`), `@equationalapplications/core-llm-tools` (`packages/core-llm-tools`)
 

--- a/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
+++ b/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
@@ -1,0 +1,358 @@
+# Spec: Knowledge Graph Traversal API
+
+**Date:** 2026-06-23
+**Status:** Draft
+**Builds on:** [2026-06-22-okf-import-design.md](./2026-06-22-okf-import-design.md) (`llm_wiki_edges` table), [2026-06-23-per-entity-seeded-ontology-design.md](./2026-06-23-per-entity-seeded-ontology-design.md) (ontology manifest, `okf_type`)
+**Packages:** `@equationalapplications/core-llm-wiki` (`packages/core`), `@equationalapplications/react-llm-wiki` (`packages/react`), `@equationalapplications/core-llm-tools` (`packages/core-llm-tools`)
+
+---
+
+## Problem
+
+The engine persists typed knowledge nodes (`okf_type` column on `entries`) and relationships (`llm_wiki_edges` table) via the OKF import and Seeded Ontology extraction passes (`OntologyService.resolveAndPersistEdges()`, called from `MaintenanceService.doRunLibrarian()`). But the retrieval surface — `WikiMemory.read()` — only does semantic/keyword search over individual facts. There is no way for the LLM (or a UI) to walk the graph structurally: "who reports to X," "what connects to this project," "show me everything two hops from this fact."
+
+`runLibrarian` and `ingestDocument` already write edges in the background. This spec adds the read path on top of that existing data — no schema changes.
+
+## Goals
+
+- `EdgeRepository.getNeighborhood()` — single-query multi-hop traversal via SQLite `WITH RECURSIVE`, entity-scoped, depth/confidence/source-type/edge-type filtered, cycle-safe, capped and ordered at the SQL level.
+- `GraphTraversalService.traverseGraph()` — orchestrates: merge `WikiConfig` defaults with per-call `GraphTraversalOptions`, call the repository, hydrate node IDs into `WikiFact[]`.
+- `WikiMemory.traverseGraph(entityId, options)` — thin facade delegate.
+- `formatGraphContext(neighborhood)` — pure function, dense text serialization for LLM prompt injection. Exported from `core-llm-wiki`'s public surface.
+- `useWikiTraversal(entityId, options)` — reactive React hook mirroring `useMemoryRead`.
+- `wikiGetOntologyManifest` and `wikiTraverseGraphManifest` tool schemas in `core-llm-tools`, scope `memory:read`.
+
+## Non-Goals (v1)
+
+- **Arbitrary graph query languages.** No GraphQL/Cypher/Gremlin. Traversal is strictly N-hops from one starting node.
+- **Global graph analysis.** PageRank, clustering, etc. — too heavy for edge/mobile SQLite, out of scope.
+- **Vector search over edges.** Traversal is purely structural; semantic search stays in `read()`.
+- **Schema changes.** `llm_wiki_edges` and `entries` already have every column this feature needs (`source_id`, `target_id`, `edge_type`, `entity_id`, `confidence`, `source_type`, `deleted_at`, `updated_at`).
+- **Tool executor wiring.** `core-llm-tools` ships JSON schema declarations only. The functions that actually call `WikiMemory.traverseGraph()` / `formatGraphContext()` and register them with a model runner live in the host application (e.g. Clanker for the Edge Agent, or an `@google/adk` cloud runner) — out of scope for this repo, matching the precedent set in [2026-06-18-google-search-tool-design.md](./2026-06-18-google-search-tool-design.md) ("Backend wiring in Clanker. Out of scope for this repo/package").
+- **Cross-hook auto-refetch / push updates.** `useWikiTraversal` follows the same manual-`refetch()` convention as every other hook in `packages/react` (e.g. `useOntologyManifest`).
+
+---
+
+## Types (`core-llm-wiki`)
+
+```typescript
+// packages/core/src/types.ts
+
+export interface GraphTraversalOptions {
+  sourceId: string;
+  /** Hop count. Default 1. Clamped to [1, 3] regardless of input. */
+  maxDepth?: number;
+  /** Default 'both'. Falls back to WikiConfig.traversalDirection, then 'both'. */
+  direction?: 'inbound' | 'outbound' | 'both';
+  /**
+   * Allowed edge types. `undefined` = no filter (all types).
+   * `[]` (explicit empty array) = match nothing — distinct from `undefined`.
+   */
+  edgeTypes?: string[];
+  /** Total node cap (anchor + neighbors). Default 20 via WikiConfig.maxTraversalNodes. */
+  maxTraversalNodes?: number;
+  /** Minimum confidence tier for *discovered* nodes. Does not gate the anchor. Default 'tentative'. */
+  minTraversalConfidence?: 'certain' | 'inferred' | 'tentative';
+  /** source_type values to dead-end on for *discovered* nodes. Does not gate the anchor. Default []. */
+  excludeSourceTypes?: Array<WikiFact['source_type']>;
+}
+
+export interface GraphNeighborhood {
+  /** Anchor node first, then discovered neighbors ordered by depth ASC, then updated_at DESC. */
+  nodes: WikiFact[];
+  /** Only edges where both endpoints are present in `nodes`. */
+  edges: WikiEdge[];
+}
+```
+
+`WikiConfig` (`packages/core/src/types.ts`) gains four optional fields, following the existing `maxResults`/`preFilterLimit` pattern — global defaults, overridable per-call:
+
+```typescript
+interface WikiConfig {
+  // ...existing fields...
+  maxTraversalNodes?: number;       // default 20
+  minTraversalConfidence?: 'certain' | 'inferred' | 'tentative'; // default 'tentative'
+  traversalDirection?: 'inbound' | 'outbound' | 'both'; // default 'both'
+  excludeSourceTypes?: Array<WikiFact['source_type']>;  // default []
+}
+```
+
+**Confidence ranking** (lowest to highest reliability): `tentative` (0) < `inferred` (1) < `certain` (2). `minTraversalConfidence: 'inferred'` admits `inferred` and `certain` discovered nodes, excludes `tentative` ones.
+
+---
+
+## `EdgeRepository.getNeighborhood()`
+
+All filtering, dead-ending, ordering, and capping happens inside this one method — `GraphTraversalService` does not re-filter or re-sort anything it returns.
+
+```typescript
+// packages/core/src/repositories/EdgeRepository.ts
+
+interface NeighborhoodQueryOptions {
+  maxDepth: number;                 // already clamped to [1,3] by caller
+  direction: 'inbound' | 'outbound' | 'both';
+  edgeTypes?: string[];             // undefined = no filter; [] = match nothing
+  minConfidence: 'certain' | 'inferred' | 'tentative';
+  excludeSourceTypes: string[];
+  maxNodes: number;
+}
+
+async getNeighborhood(
+  entityId: string,
+  sourceId: string,
+  opts: NeighborhoodQueryOptions,
+  tx?: SQLiteAdapter,
+): Promise<{ nodeIds: string[]; edges: WikiEdge[] }>
+```
+
+### Behavior
+
+1. **`edgeTypes: []` short-circuits.** If the caller passed an explicit empty array, return `{ nodeIds: [sourceId-if-it-exists], edges: [] }` without running the recursive query — no edge type can match nothing, so the CTE work is wasted. Still need one query to confirm the anchor exists (deleted/cross-entity check, below).
+2. **Anchor validation, not anchor filtering.** The anchor is included whenever it exists, belongs to `entityId`, and isn't soft-deleted — confidence and source_type do **not** gate it. The caller already named this node by ID (e.g. from a prior `wiki_read` result); they're asking to expand outward from it, not asking permission to see it.
+3. **Discovered-node dead-end gate.** Every node beyond the anchor is gated by `minConfidence` and `excludeSourceTypes` *during* the walk (joined against `entries` inside the recursive step), not after. A node that fails the gate is never added to the frontier, so it cannot act as an invisible bridge to nodes beyond it.
+4. **Cycle guard.** Track visited IDs as a delimited string (`,id1,id2,...,`) per path; check with `instr(visited, ',' || next_id || ',') = 0` before allowing a re-visit. Plain (undelimited) substring matching is unsafe — e.g. ID `123` would false-positive-match inside `,91234,`.
+5. **Cap + order.** Final `SELECT DISTINCT node_id, MIN(depth)` grouped, then `ORDER BY depth ASC, entries.updated_at DESC LIMIT maxNodes`. Ties at the same depth go to the most-recently-updated fact first.
+6. **Edges re-query.** After node IDs are capped, re-query edges scoped to `entity_id = ?` AND both `source_id` and `target_id` IN the capped ID set. This guarantees no edge in the result references a node that didn't make the cap.
+
+### CTE shape
+
+```sql
+WITH RECURSIVE walk(node_id, depth, visited) AS (
+  -- Base case: anchor validation only (no confidence/source_type gate)
+  SELECT id, 0, ',' || id || ','
+  FROM entries
+  WHERE id = ?sourceId AND entity_id = ?entityId AND deleted_at IS NULL
+
+  UNION
+
+  -- Recursive step: SQLite has no LATERAL join, so a derived "next_id" table
+  -- can't correlate against w/e. Repeat the CASE expression inline at each
+  -- of the three places that need it (join target, visited-string append,
+  -- cycle check) instead of aliasing it once.
+  SELECT
+    CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END,
+    w.depth + 1,
+    w.visited || (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END) || ','
+  FROM walk w
+  JOIN edges e
+    ON e.entity_id = ?entityId
+    AND (
+      (?direction != 'inbound'  AND e.source_id = w.node_id) OR
+      (?direction != 'outbound' AND e.target_id = w.node_id)
+    )
+    AND (?edgeTypes IS NULL OR e.edge_type IN (?edgeTypes))
+  JOIN entries n
+    ON n.id = (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END)
+    AND n.entity_id = ?entityId
+    AND n.deleted_at IS NULL
+    AND (CASE n.confidence WHEN 'tentative' THEN 0 WHEN 'inferred' THEN 1 ELSE 2 END)
+        >= (CASE ?minConfidence WHEN 'tentative' THEN 0 WHEN 'inferred' THEN 1 ELSE 2 END)
+    AND n.source_type NOT IN (?excludeSourceTypes)
+  WHERE w.depth < ?maxDepth
+    AND instr(w.visited, ',' || (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END) || ',') = 0
+)
+SELECT node_id, MIN(depth) AS depth
+FROM walk
+GROUP BY node_id
+ORDER BY depth ASC, (SELECT updated_at FROM entries WHERE id = node_id) DESC
+LIMIT ?maxNodes;
+```
+
+`?edgeTypes` and `?excludeSourceTypes` are expanded to `(?, ?, ...)` placeholder lists at call time, same pattern as `EntryRepository.findByIds()`'s chunked `IN (...)` construction. When `excludeSourceTypes` is empty, the clause becomes `NOT IN ()`, which SQLite evaluates as always-true (no exclusion) — verify this with a unit test rather than special-casing it.
+
+---
+
+## `GraphTraversalService`
+
+New file, `packages/core/src/services/GraphTraversalService.ts`, alongside `RetrievalService`, `OntologyService`, `MaintenanceService`. Pure orchestrator — no SQL.
+
+```typescript
+export class GraphTraversalService {
+  constructor(
+    private edgeRepo: EdgeRepository,
+    private entryRepo: EntryRepository,
+    private config: WikiConfig,
+  ) {}
+
+  async traverseGraph(entityId: string, options: GraphTraversalOptions): Promise<GraphNeighborhood> {
+    const opts: NeighborhoodQueryOptions = {
+      maxDepth: Math.max(1, Math.min(options.maxDepth ?? 1, 3)),
+      direction: options.direction ?? this.config.traversalDirection ?? 'both',
+      edgeTypes: options.edgeTypes,
+      minConfidence: options.minTraversalConfidence ?? this.config.minTraversalConfidence ?? 'tentative',
+      excludeSourceTypes: options.excludeSourceTypes ?? this.config.excludeSourceTypes ?? [],
+      maxNodes: options.maxTraversalNodes ?? this.config.maxTraversalNodes ?? 20,
+    };
+
+    const { nodeIds, edges } = await this.edgeRepo.getNeighborhood(entityId, options.sourceId, opts);
+    if (nodeIds.length === 0) return { nodes: [], edges: [] };
+
+    // findByIds() already returns facts in input-ID order (Map-based lookup,
+    // see packages/core/src/repositories/EntryRepository.ts:78-109) — no
+    // re-sort needed here.
+    const nodes = await this.entryRepo.findByIds(nodeIds, [entityId]);
+    return { nodes, edges };
+  }
+}
+```
+
+### Error / edge cases
+
+| Case | Behavior |
+| :--- | :--- |
+| `sourceId` missing, soft-deleted, or belongs to a different `entityId` | `{ nodes: [], edges: [] }`, no throw — matches `read()`'s graceful-empty convention. |
+| `maxDepth` outside `[1, 3]` | Silently clamped, not an error — caller mistakes shouldn't break a conversation. |
+| `edgeTypes: []` | Treated as "match nothing." `undefined` means "no filter." |
+| `excludeSourceTypes` empty | No exclusion (default — all source types traversable). |
+
+`WikiMemory.traverseGraph(entityId, options)` (`packages/core/src/WikiMemory.ts`) is a one-line delegate to `GraphTraversalService.traverseGraph()`, same shape as the existing `getOntologyManifest` delegate.
+
+---
+
+## `formatGraphContext()`
+
+Pure function, `packages/core/src/utils/formatGraphContext.ts` (sibling to `ontology.ts`), **exported from `packages/core/src/index.ts`** so host applications can format a `GraphNeighborhood` before injecting it into a prompt without re-deriving the logic.
+
+```typescript
+export function formatGraphContext(neighborhood: GraphNeighborhood): string
+```
+
+Output shape (per the original draft):
+
+```text
+[person] John Doe (ID: 123)
+  -[reports_to]-> [person] Jane Smith
+  <-[contributes_to]- [project] Alpha Rewrite
+```
+
+**Determinism:**
+- Top-level grouping follows `neighborhood.nodes` order as already produced by `GraphTraversalService` (depth ASC, then `updated_at` DESC).
+- For each node, render its outbound edges (`-[type]->`) before inbound edges (`<-[type]-`).
+- Within each direction group, sort by `edge_type` then by the connected node's `title`.
+
+This keeps repeated calls with the same underlying data byte-identical, which matters for prompt caching.
+
+---
+
+## React hook (`react-llm-wiki`)
+
+`packages/react/src/useWikiTraversal.ts`, mirrors `useMemoryRead`/`useOntologyManifest`'s fetch-on-mount, refetch-on-change, in-flight-queue contract.
+
+```typescript
+export interface WikiTraversalState {
+  nodes: WikiFact[];
+  edges: WikiEdge[];
+  isPending: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useWikiTraversal(entityId: string, options: GraphTraversalOptions): WikiTraversalState;
+```
+
+**Behavior:**
+
+1. Reads `wiki` via `useWiki()`.
+2. On mount and whenever `entityId` or a *stable serialization* of `options` changes, calls `wiki.traverseGraph(entityId, options)`.
+3. Uses the in-flight fetch queue pattern from `useMemoryRead` (`packages/react/src/useMemoryRead.ts:125-155`) — never discards an in-flight result.
+4. **Stable options key:** `normalizeReadOptionsKey` in `useMemoryRead.ts` is a private, file-local helper (not exported) — `useWikiTraversal.ts` implements its own local `normalizeTraversalOptionsKey(options)` following the same approach (sort/normalize known fields into a deterministic string for the `useEffect` dependency), rather than importing across hook files. This avoids the infinite-refetch risk of a naive `JSON.stringify` on an inline object literal.
+5. Naming: `isPending`, not `isLoading` — matches every other hook in this package.
+
+---
+
+## `core-llm-tools` manifests
+
+New file `packages/core-llm-tools/src/manifests/graph.ts`. Scope `memory:read` for both (read-only, per the existing `AgentScope` union) — the live agent never writes edges directly; that stays in the background `runLibrarian` pass.
+
+```typescript
+export const wikiGetOntologyManifest: FunctionToolManifest = {
+  name: 'wiki_get_ontology',
+  scope: 'memory:read',
+  kind: 'function',
+  schema: {
+    name: 'wiki_get_ontology',
+    description: "Retrieve the current ontology manifest (allowed node types and edge types) for the user's memory. Use this to understand the structure of the knowledge graph and what relationships exist.",
+    parameters: {
+      type: 'object',
+      properties: {
+        entityId: { type: 'string', description: 'The namespace/entity ID to inspect.' },
+      },
+      required: ['entityId'],
+    },
+  },
+};
+
+export const wikiTraverseGraphManifest: FunctionToolManifest = {
+  name: 'wiki_traverse_graph',
+  scope: 'memory:read',
+  kind: 'function',
+  schema: {
+    name: 'wiki_traverse_graph',
+    description: 'Traverse the knowledge graph starting from a specific fact ID to discover connected concepts and relationships. Returns a formatted neighborhood subgraph.',
+    parameters: {
+      type: 'object',
+      properties: {
+        entityId: { type: 'string', description: 'The namespace/entity ID to traverse.' },
+        sourceId: { type: 'string', description: 'The exact ID of the starting fact node (obtained from a previous wiki_read call).' },
+        maxDepth: { type: 'integer', description: 'How many relationship hops to traverse. Maximum allowed is 3.' },
+        direction: { type: 'string', enum: ['inbound', 'outbound', 'both'], description: "The direction of relationships to follow. Default 'both'." },
+        edgeTypes: { type: 'array', items: { type: 'string' }, description: 'Optional filter. If provided, traversal only follows these edge types (e.g. ["reports_to", "depends_on"]).' },
+      },
+      required: ['entityId', 'sourceId'],
+    },
+  },
+};
+```
+
+**Package boundary:** `core-llm-tools` contains *only* these JSON schema declarations and their `memory:read` scope tag — it has no dependency on `core-llm-wiki` and does not call `traverseGraph()` or `formatGraphContext()` itself. The host application's tool executor (wherever it registers function-calling tools with a model runner) is responsible for: receiving the model's tool call, invoking `wiki.traverseGraph(entityId, options)`, passing the result through `formatGraphContext()`, and returning the formatted string as the tool result. That wiring is out of scope for this repo (see Non-Goals).
+
+---
+
+## Testing
+
+- **`EdgeRepository.getNeighborhood()`** (unit, real SQLite): depth clamp behavior at the caller boundary; `direction` in/out/both; `edgeTypes` allow-list including the explicit-`[]` short-circuit; confidence dead-end (a `tentative` node blocks traversal past it); `excludeSourceTypes` dead-end; cycle guard via a hand-built cyclic fixture (A→B→A); node cap + depth/recency tie-break ordering; anchor returned even when its own confidence/source_type would fail the discovered-node gate; empty result for missing/cross-entity/soft-deleted `sourceId`.
+- **`GraphTraversalService`**: config-default vs. per-call-option precedence for all four tunables; empty-result passthrough; entity-scoped hydration via `findByIds(ids, [entityId])`.
+- **`formatGraphContext()`**: pure-function snapshot tests; deterministic ordering across repeated calls with identical input.
+- **`useWikiTraversal`**: extend `packages/react/__tests__/hooks.test.tsx`, same `makeMockWiki()` + `wrapper` pattern as `useOntologyManifest` — initial fetch, `options`-change refetch, error path, queued-fetch-while-in-flight, `refetch()`.
+- **Tool manifests**: schema-shape validation only (`name`, `scope`, required params) — no executor behavior to test in this repo.
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+| :--- | :--- | :--- |
+| Modify | `packages/core/src/types.ts` | `GraphTraversalOptions`, `GraphNeighborhood`, `WikiConfig` additions |
+| Modify | `packages/core/src/repositories/EdgeRepository.ts` | `getNeighborhood()` |
+| Create | `packages/core/src/services/GraphTraversalService.ts` | Orchestration |
+| Modify | `packages/core/src/WikiMemory.ts` | `traverseGraph()` delegate |
+| Create | `packages/core/src/utils/formatGraphContext.ts` | Presenter utility |
+| Modify | `packages/core/src/index.ts` | Export `formatGraphContext`, `GraphTraversalOptions`, `GraphNeighborhood` |
+| Create | `packages/react/src/useWikiTraversal.ts` | Reactive hook |
+| Modify | `packages/react/src/index.ts` | Export hook + `WikiTraversalState` |
+| Modify | `packages/react/__tests__/hooks.test.tsx` | Unit tests |
+| Create | `packages/core-llm-tools/src/manifests/graph.ts` | `wikiGetOntologyManifest`, `wikiTraverseGraphManifest` |
+| Modify | `packages/core-llm-tools/src/index.ts` | Export new manifests |
+| Modify | `packages/react/README.md`, `packages/expo/README.md` | Document `useWikiTraversal` (follow the checklist structure used in [2026-06-23-ontology-react-hooks-design.md](./2026-06-23-ontology-react-hooks-design.md)) |
+
+No `packages/core/src/db/schema.ts` changes — every column this feature reads already exists.
+
+---
+
+## Versioning & changelog
+
+- **Do not edit `CHANGELOG.md` manually** — semantic-release generates entries from conventional commits.
+- Suggested PR title: `feat(core): add knowledge graph traversal API`, with a follow-up or same-PR `feat(react): add useWikiTraversal hook` and `feat(core-llm-tools): add wiki_get_ontology and wiki_traverse_graph manifests` depending on how the implementation plan splits the work.
+
+---
+
+## Acceptance
+
+- [ ] `EdgeRepository.getNeighborhood()` passes all cases in §Testing.
+- [ ] `GraphTraversalService.traverseGraph()` and `WikiMemory.traverseGraph()` implemented and delegate correctly.
+- [ ] `formatGraphContext()` exported from `core-llm-wiki` public surface, deterministic output verified by snapshot test.
+- [ ] `useWikiTraversal` exported from `packages/react` and reachable via `packages/expo` with zero expo-package code changes.
+- [ ] `wikiGetOntologyManifest` and `wikiTraverseGraphManifest` exported from `core-llm-tools`, scope `memory:read`.
+- [ ] No `packages/core/src/db/schema.ts` changes.
+- [ ] `packages/react/README.md` and `packages/expo/README.md` document `useWikiTraversal`.
+- [ ] `CHANGELOG.md` untouched.

--- a/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
+++ b/docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md
@@ -158,7 +158,7 @@ ORDER BY depth ASC, (SELECT updated_at FROM entries WHERE id = node_id) DESC
 LIMIT ?maxNodes;
 ```
 
-`?edgeTypes` and `?excludeSourceTypes` are expanded to `(?, ?, ...)` placeholder lists at call time, same pattern as `EntryRepository.findByIds()`'s chunked `IN (...)` construction. When `excludeSourceTypes` is empty, the clause becomes `NOT IN ()`, which SQLite evaluates as always-true (no exclusion) — verify this with a unit test rather than special-casing it.
+`?edgeTypes` and `?excludeSourceTypes` are not single bind params — SQLite has no array binding. `getNeighborhood()` must build the `(?, ?, ...)` placeholder string dynamically (one `?` per array element, joined with `,`) and splice it into the SQL text *before* execution, then pass the flattened values as part of the single positional-params array handed to `SQLiteAdapter`. Same pattern as `EntryRepository.findByIds()`'s chunked `IN (...)` construction — do not attempt to bind the array directly as one parameter. When `excludeSourceTypes` is empty, the clause becomes `NOT IN ()`, which SQLite evaluates as always-true (no exclusion) — verify this with a unit test rather than special-casing it.
 
 ---
 

--- a/packages/core-llm-tools/__tests__/manifests-graph.test.ts
+++ b/packages/core-llm-tools/__tests__/manifests-graph.test.ts
@@ -37,9 +37,11 @@ describe('wikiTraverseGraphManifest', () => {
   });
 
   it('declares maxDepth, direction, and edgeTypes as optional parameters', () => {
-    const props = wikiTraverseGraphManifest.schema.parameters?.properties as Record<string, unknown>;
+    const props = wikiTraverseGraphManifest.schema.parameters?.properties as Record<string, any>;
     expect(props).toHaveProperty('maxDepth');
     expect(props).toHaveProperty('direction');
     expect(props).toHaveProperty('edgeTypes');
+    expect(props.maxDepth).toMatchObject({ type: 'integer', minimum: 1, maximum: 3 });
+    expect(props.direction).toMatchObject({ type: 'string', enum: ['inbound', 'outbound', 'both'] });
   });
 });

--- a/packages/core-llm-tools/__tests__/manifests-graph.test.ts
+++ b/packages/core-llm-tools/__tests__/manifests-graph.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { wikiGetOntologyManifest, wikiTraverseGraphManifest } from '../src/manifests/graph';
+
+describe('wikiGetOntologyManifest', () => {
+  it('has name wiki_get_ontology', () => {
+    expect(wikiGetOntologyManifest.name).toBe('wiki_get_ontology');
+  });
+
+  it('scope is memory:read', () => {
+    expect(wikiGetOntologyManifest.scope).toBe('memory:read');
+  });
+
+  it('schema name matches manifest name', () => {
+    expect(wikiGetOntologyManifest.schema.name).toBe(wikiGetOntologyManifest.name);
+  });
+
+  it('requires entityId', () => {
+    expect(wikiGetOntologyManifest.schema.parameters?.required).toEqual(['entityId']);
+  });
+});
+
+describe('wikiTraverseGraphManifest', () => {
+  it('has name wiki_traverse_graph', () => {
+    expect(wikiTraverseGraphManifest.name).toBe('wiki_traverse_graph');
+  });
+
+  it('scope is memory:read', () => {
+    expect(wikiTraverseGraphManifest.scope).toBe('memory:read');
+  });
+
+  it('schema name matches manifest name', () => {
+    expect(wikiTraverseGraphManifest.schema.name).toBe(wikiTraverseGraphManifest.name);
+  });
+
+  it('requires entityId and sourceId', () => {
+    expect(wikiTraverseGraphManifest.schema.parameters?.required).toEqual(['entityId', 'sourceId']);
+  });
+
+  it('declares maxDepth, direction, and edgeTypes as optional parameters', () => {
+    const props = wikiTraverseGraphManifest.schema.parameters?.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('maxDepth');
+    expect(props).toHaveProperty('direction');
+    expect(props).toHaveProperty('edgeTypes');
+  });
+});

--- a/packages/core-llm-tools/src/index.ts
+++ b/packages/core-llm-tools/src/index.ts
@@ -17,3 +17,7 @@ export {
   escalateToCloudManifest,
   googleSearchManifest,
 } from './manifests/core';
+export {
+  wikiGetOntologyManifest,
+  wikiTraverseGraphManifest,
+} from './manifests/graph';

--- a/packages/core-llm-tools/src/manifests/graph.ts
+++ b/packages/core-llm-tools/src/manifests/graph.ts
@@ -1,0 +1,39 @@
+import type { AgentToolManifest } from '../types';
+
+export const wikiGetOntologyManifest: AgentToolManifest = {
+  name: 'wiki_get_ontology',
+  scope: 'memory:read',
+  schema: {
+    name: 'wiki_get_ontology',
+    description:
+      "Retrieve the current ontology manifest (allowed node types and edge types) for the user's memory. Use this to understand the structure of the knowledge graph and what relationships exist.",
+    parameters: {
+      type: 'object',
+      properties: {
+        entityId: { type: 'string', description: 'The namespace/entity ID to inspect.' },
+      },
+      required: ['entityId'],
+    },
+  },
+};
+
+export const wikiTraverseGraphManifest: AgentToolManifest = {
+  name: 'wiki_traverse_graph',
+  scope: 'memory:read',
+  schema: {
+    name: 'wiki_traverse_graph',
+    description:
+      'Traverse the knowledge graph starting from a specific fact ID to discover connected concepts and relationships. Returns a formatted neighborhood subgraph.',
+    parameters: {
+      type: 'object',
+      properties: {
+        entityId: { type: 'string', description: 'The namespace/entity ID to traverse.' },
+        sourceId: { type: 'string', description: 'The exact ID of the starting fact node (obtained from a previous wiki_read call).' },
+        maxDepth: { type: 'integer', description: 'How many relationship hops to traverse. Maximum allowed is 3.' },
+        direction: { type: 'string', enum: ['inbound', 'outbound', 'both'], description: "The direction of relationships to follow. Default 'both'." },
+        edgeTypes: { type: 'array', items: { type: 'string' }, description: 'Optional filter. If provided, traversal only follows these edge types (e.g. ["reports_to", "depends_on"]).' },
+      },
+      required: ['entityId', 'sourceId'],
+    },
+  },
+};

--- a/packages/core-llm-tools/src/manifests/graph.ts
+++ b/packages/core-llm-tools/src/manifests/graph.ts
@@ -29,7 +29,12 @@ export const wikiTraverseGraphManifest: AgentToolManifest = {
       properties: {
         entityId: { type: 'string', description: 'The namespace/entity ID to traverse.' },
         sourceId: { type: 'string', description: 'The exact ID of the starting fact node (obtained from a previous wiki_read call).' },
-        maxDepth: { type: 'integer', description: 'How many relationship hops to traverse. Maximum allowed is 3.' },
+        maxDepth: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 3,
+          description: 'How many relationship hops to traverse. Maximum allowed is 3.',
+        },
         direction: { type: 'string', enum: ['inbound', 'outbound', 'both'], description: "The direction of relationships to follow. Default 'both'." },
         edgeTypes: { type: 'array', items: { type: 'string' }, description: 'Optional filter. If provided, traversal only follows these edge types (e.g. ["reports_to", "depends_on"]).' },
       },

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -85,6 +85,19 @@ describe('WikiMemory (Facade Layer)', () => {
       expect(pruneSpy).toHaveBeenCalledWith('user_123', { vacuum: true });
       expect(result).toEqual({ entries: 1, tasks: 0, events: 5 });
     });
+
+    it('delegates traverseGraph() to GraphTraversalService', async () => {
+      const mockNeighborhood = { nodes: [], edges: [] };
+      const traverseSpy = vi
+        .spyOn(wiki.__testAccess.graphTraversalService, 'traverseGraph')
+        .mockResolvedValue(mockNeighborhood);
+
+      const result = await wiki.traverseGraph('user_123', { sourceId: 'fact_1', maxDepth: 2 });
+
+      expect(traverseSpy).toHaveBeenCalledTimes(1);
+      expect(traverseSpy).toHaveBeenCalledWith('user_123', { sourceId: 'fact_1', maxDepth: 2 });
+      expect(result).toBe(mockNeighborhood);
+    });
   });
 
   describe('Setup and Migrations', () => {

--- a/packages/core/__tests__/repositories/EdgeRepository.test.ts
+++ b/packages/core/__tests__/repositories/EdgeRepository.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { openTestDatabase } from '../helpers/sqliteAdapter';
 import { setupDatabase } from '../../src/db/schema';
 import { EdgeRepository } from '../../src/repositories/EdgeRepository';
-import type { WikiEdge } from '../../src/types';
+import type { WikiEdge, SQLiteAdapter } from '../../src/types';
 
 const PREFIX = 'llm_wiki_';
 
@@ -127,5 +127,221 @@ describe('EdgeRepository', () => {
 
     const afterRollback = await db.getAllAsync<any>(`SELECT id FROM ${PREFIX}edges WHERE id = 'edge_tx'`);
     expect(afterRollback.length).toBe(0);
+  });
+});
+
+async function insertEntry(
+  db: SQLiteAdapter,
+  overrides: Partial<{
+    id: string;
+    entity_id: string;
+    title: string;
+    confidence: string;
+    source_type: string;
+    deleted_at: number | null;
+    created_at: number;
+    updated_at: number;
+  }> = {},
+): Promise<string> {
+  const e = {
+    id: 'fact_' + Math.random().toString(36).slice(2),
+    entity_id: 'entity1',
+    title: 'Title',
+    confidence: 'certain',
+    source_type: 'user_stated',
+    deleted_at: null as number | null,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+  await db.runAsync(
+    `INSERT INTO ${PREFIX}entries (id, entity_id, title, body, tags, confidence, source_type, created_at, updated_at, deleted_at)
+     VALUES (?, ?, ?, 'body', '[]', ?, ?, ?, ?, ?)`,
+    [e.id, e.entity_id, e.title, e.confidence, e.source_type, e.created_at, e.updated_at, e.deleted_at],
+  );
+  return e.id;
+}
+
+describe('EdgeRepository.getNeighborhood()', () => {
+  let db: SQLiteAdapter;
+  let repo: EdgeRepository;
+
+  beforeEach(async () => {
+    db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    repo = new EdgeRepository(db, PREFIX);
+  });
+
+  const baseOpts = {
+    maxDepth: 1,
+    direction: 'both' as const,
+    edgeTypes: undefined as string[] | undefined,
+    minConfidence: 'tentative' as const,
+    excludeSourceTypes: [] as string[],
+    maxNodes: 20,
+  };
+
+  it('traverses one outbound hop', async () => {
+    const a = await insertEntry(db, { id: 'a' });
+    const b = await insertEntry(db, { id: 'b' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: a, target_id: b, edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', a, { ...baseOpts, direction: 'outbound', maxDepth: 1 });
+
+    expect(result.nodeIds).toEqual(['a', 'b']);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source_id).toBe('a');
+    expect(result.edges[0].target_id).toBe('b');
+  });
+
+  it('respects maxDepth=2 to reach a second hop, but not beyond', async () => {
+    await insertEntry(db, { id: 'a' });
+    await insertEntry(db, { id: 'b' });
+    await insertEntry(db, { id: 'c' });
+    await insertEntry(db, { id: 'd' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'b', target_id: 'c', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e3', source_id: 'c', target_id: 'd', edge_type: 'link' }));
+
+    const depth1 = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, direction: 'outbound', maxDepth: 1 });
+    expect(depth1.nodeIds.sort()).toEqual(['a', 'b']);
+
+    const depth2 = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, direction: 'outbound', maxDepth: 2 });
+    expect(depth2.nodeIds.sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('direction "inbound" only follows incoming edges', async () => {
+    await insertEntry(db, { id: 'a' });
+    await insertEntry(db, { id: 'b' });
+    await insertEntry(db, { id: 'c' });
+    // b -> a (incoming to a), a -> c (outgoing from a)
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'b', target_id: 'a', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'a', target_id: 'c', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, direction: 'inbound', maxDepth: 1 });
+    expect(result.nodeIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('edgeTypes allow-list filters to matching edge_type only', async () => {
+    await insertEntry(db, { id: 'a' });
+    await insertEntry(db, { id: 'b' });
+    await insertEntry(db, { id: 'c' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'reports_to' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'a', target_id: 'c', edge_type: 'mentions' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', {
+      ...baseOpts,
+      direction: 'outbound',
+      maxDepth: 1,
+      edgeTypes: ['reports_to'],
+    });
+    expect(result.nodeIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('edgeTypes: [] short-circuits to anchor-only, no edges', async () => {
+    await insertEntry(db, { id: 'a' });
+    await insertEntry(db, { id: 'b' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, edgeTypes: [] });
+    expect(result).toEqual({ nodeIds: ['a'], edges: [] });
+  });
+
+  it('a tentative node dead-ends traversal past it', async () => {
+    await insertEntry(db, { id: 'a', confidence: 'certain' });
+    await insertEntry(db, { id: 'b', confidence: 'tentative' });
+    await insertEntry(db, { id: 'c', confidence: 'certain' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'b', target_id: 'c', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', {
+      ...baseOpts,
+      direction: 'outbound',
+      maxDepth: 3,
+      minConfidence: 'inferred',
+    });
+    expect(result.nodeIds).toEqual(['a']);
+  });
+
+  it('excludeSourceTypes dead-ends a matching node', async () => {
+    await insertEntry(db, { id: 'a', source_type: 'user_stated' });
+    await insertEntry(db, { id: 'b', source_type: 'immutable_document' });
+    await insertEntry(db, { id: 'c', source_type: 'user_stated' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'b', target_id: 'c', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', {
+      ...baseOpts,
+      direction: 'outbound',
+      maxDepth: 3,
+      excludeSourceTypes: ['immutable_document'],
+    });
+    expect(result.nodeIds).toEqual(['a']);
+  });
+
+  it('excludeSourceTypes: [] excludes nothing (NOT IN () is always-true)', async () => {
+    await insertEntry(db, { id: 'a', source_type: 'user_stated' });
+    await insertEntry(db, { id: 'b', source_type: 'user_stated' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, direction: 'outbound', maxDepth: 1 });
+    expect(result.nodeIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('cycle guard prevents infinite loop on A<->B with direction "both"', async () => {
+    await insertEntry(db, { id: 'a' });
+    await insertEntry(db, { id: 'b' });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', { ...baseOpts, direction: 'both', maxDepth: 3 });
+    expect(result.nodeIds.sort()).toEqual(['a', 'b']);
+  });
+
+  it('caps nodes and orders by depth ASC then updated_at DESC', async () => {
+    await insertEntry(db, { id: 'a', updated_at: 1 });
+    await insertEntry(db, { id: 'b', updated_at: 400 });
+    await insertEntry(db, { id: 'c', updated_at: 300 });
+    await insertEntry(db, { id: 'd', updated_at: 200 });
+    await insertEntry(db, { id: 'e', updated_at: 100 });
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e2', source_id: 'a', target_id: 'c', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e3', source_id: 'a', target_id: 'd', edge_type: 'link' }));
+    await repo.addIgnoreDuplicate(makeEdge({ id: 'e4', source_id: 'a', target_id: 'e', edge_type: 'link' }));
+
+    const result = await repo.getNeighborhood('entity1', 'a', {
+      ...baseOpts,
+      direction: 'outbound',
+      maxDepth: 1,
+      maxNodes: 3,
+    });
+    expect(result.nodeIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns the anchor even when its own confidence/source_type would fail the discovered-node gate', async () => {
+    await insertEntry(db, { id: 'a', confidence: 'tentative', source_type: 'immutable_document' });
+
+    const result = await repo.getNeighborhood('entity1', 'a', {
+      ...baseOpts,
+      minConfidence: 'certain',
+      excludeSourceTypes: ['immutable_document'],
+    });
+    expect(result.nodeIds).toEqual(['a']);
+  });
+
+  it('returns empty for a missing sourceId', async () => {
+    const result = await repo.getNeighborhood('entity1', 'does-not-exist', baseOpts);
+    expect(result).toEqual({ nodeIds: [], edges: [] });
+  });
+
+  it('returns empty for a cross-entity sourceId', async () => {
+    await insertEntry(db, { id: 'a', entity_id: 'entity2' });
+    const result = await repo.getNeighborhood('entity1', 'a', baseOpts);
+    expect(result).toEqual({ nodeIds: [], edges: [] });
+  });
+
+  it('returns empty for a soft-deleted sourceId', async () => {
+    await insertEntry(db, { id: 'a', deleted_at: 999 });
+    const result = await repo.getNeighborhood('entity1', 'a', baseOpts);
+    expect(result).toEqual({ nodeIds: [], edges: [] });
   });
 });

--- a/packages/core/__tests__/services/GraphTraversalService.test.ts
+++ b/packages/core/__tests__/services/GraphTraversalService.test.ts
@@ -187,7 +187,7 @@ describe('GraphTraversalService', () => {
     [Infinity, 20],
     [1.9, 1],
     [5, 5],
-  ])('sanitizes maxTraversalNodes=%s to %s', async (input, expected) => {
+  ])('sanitizes per-call maxTraversalNodes=%s to %s', async (input, expected) => {
     const { edgeRepo, entryRepo } = makeMocks();
     vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
     vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
@@ -199,6 +199,40 @@ describe('GraphTraversalService', () => {
       'entity1',
       'a',
       expect.objectContaining({ maxNodes: expected }),
+    );
+  });
+
+  it.each([
+    [0, 20],
+    [NaN, 20],
+    [Infinity, 20],
+  ])('sanitizes invalid config.maxTraversalNodes=%s to 20', async (configMax, expected) => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, { maxTraversalNodes: configMax });
+    await svc.traverseGraph('entity1', { sourceId: 'a' });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith(
+      'entity1',
+      'a',
+      expect.objectContaining({ maxNodes: expected }),
+    );
+  });
+
+  it('falls back to sanitized config default when per-call maxTraversalNodes is invalid', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, { maxTraversalNodes: 5 });
+    await svc.traverseGraph('entity1', { sourceId: 'a', maxTraversalNodes: Infinity });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith(
+      'entity1',
+      'a',
+      expect.objectContaining({ maxNodes: 5 }),
     );
   });
 });

--- a/packages/core/__tests__/services/GraphTraversalService.test.ts
+++ b/packages/core/__tests__/services/GraphTraversalService.test.ts
@@ -168,7 +168,7 @@ describe('GraphTraversalService', () => {
     expect(entryRepo.findByIds).not.toHaveBeenCalled();
   });
 
-  it('hydrates node IDs into facts scoped to entityId, passing edges through unchanged', async () => {
+  it('hydrates node IDs into facts scoped to entityId and drops dangling edges', async () => {
     const { edgeRepo, entryRepo } = makeMocks();
     vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a', 'b'], edges: [sampleEdge] });
     vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
@@ -177,6 +177,28 @@ describe('GraphTraversalService', () => {
     const result = await svc.traverseGraph('entity1', { sourceId: 'a' });
 
     expect(entryRepo.findByIds).toHaveBeenCalledWith(['a', 'b'], ['entity1']);
-    expect(result).toEqual({ nodes: [sampleFact], edges: [sampleEdge] });
+    expect(result).toEqual({ nodes: [sampleFact], edges: [] });
+  });
+
+  it.each([
+    [0, 20],
+    [-1, 20],
+    [NaN, 20],
+    [Infinity, 20],
+    [1.9, 1],
+    [5, 5],
+  ])('sanitizes maxTraversalNodes=%s to %s', async (input, expected) => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    await svc.traverseGraph('entity1', { sourceId: 'a', maxTraversalNodes: input });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith(
+      'entity1',
+      'a',
+      expect.objectContaining({ maxNodes: expected }),
+    );
   });
 });

--- a/packages/core/__tests__/services/GraphTraversalService.test.ts
+++ b/packages/core/__tests__/services/GraphTraversalService.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphTraversalService } from '../../src/services/GraphTraversalService';
+import type { EdgeRepository } from '../../src/repositories/EdgeRepository';
+import type { EntryRepository } from '../../src/repositories/EntryRepository';
+import type { WikiConfig, WikiFact, WikiEdge } from '../../src/types';
+
+function makeMocks() {
+  const edgeRepo = {
+    getNeighborhood: vi.fn(),
+  } as unknown as EdgeRepository;
+
+  const entryRepo = {
+    findByIds: vi.fn(),
+  } as unknown as EntryRepository;
+
+  return { edgeRepo, entryRepo };
+}
+
+const sampleFact: WikiFact = {
+  id: 'a',
+  entity_id: 'entity1',
+  title: 'A',
+  body: 'body',
+  tags: [],
+  confidence: 'certain',
+  source_type: 'user_stated',
+  source_hash: null,
+  source_ref: null,
+  created_at: 1,
+  updated_at: 1,
+  last_accessed_at: null,
+  access_count: 0,
+  deleted_at: null,
+};
+
+const sampleEdge: WikiEdge = {
+  id: 'e1',
+  entity_id: 'entity1',
+  source_id: 'a',
+  target_id: 'b',
+  edge_type: 'link',
+  created_at: 1,
+};
+
+describe('GraphTraversalService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses hardcoded defaults when neither per-call nor config values are set', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    await svc.traverseGraph('entity1', { sourceId: 'a' });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith('entity1', 'a', {
+      maxDepth: 1,
+      direction: 'both',
+      edgeTypes: undefined,
+      minConfidence: 'tentative',
+      excludeSourceTypes: [],
+      maxNodes: 20,
+    });
+  });
+
+  it('uses config defaults when no per-call option is given', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const config: WikiConfig = {
+      maxTraversalNodes: 5,
+      minTraversalConfidence: 'certain',
+      traversalDirection: 'outbound',
+      excludeSourceTypes: ['immutable_document'],
+    };
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, config);
+    await svc.traverseGraph('entity1', { sourceId: 'a' });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith('entity1', 'a', {
+      maxDepth: 1,
+      direction: 'outbound',
+      edgeTypes: undefined,
+      minConfidence: 'certain',
+      excludeSourceTypes: ['immutable_document'],
+      maxNodes: 5,
+    });
+  });
+
+  it('per-call options override config defaults', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const config: WikiConfig = {
+      maxTraversalNodes: 5,
+      minTraversalConfidence: 'certain',
+      traversalDirection: 'outbound',
+      excludeSourceTypes: ['immutable_document'],
+    };
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, config);
+    await svc.traverseGraph('entity1', {
+      sourceId: 'a',
+      maxDepth: 2,
+      direction: 'inbound',
+      maxTraversalNodes: 8,
+      minTraversalConfidence: 'tentative',
+      excludeSourceTypes: ['user_stated'],
+    });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith('entity1', 'a', {
+      maxDepth: 2,
+      direction: 'inbound',
+      edgeTypes: undefined,
+      minConfidence: 'tentative',
+      excludeSourceTypes: ['user_stated'],
+      maxNodes: 8,
+    });
+  });
+
+  it.each([
+    [0, 1],
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [4, 3],
+    [-5, 1],
+  ])('clamps maxDepth=%d to %d', async (input, expected) => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    await svc.traverseGraph('entity1', { sourceId: 'a', maxDepth: input });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith(
+      'entity1',
+      'a',
+      expect.objectContaining({ maxDepth: expected }),
+    );
+  });
+
+  it('passes edgeTypes: [] through unchanged (does not default it away)', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a'], edges: [] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    await svc.traverseGraph('entity1', { sourceId: 'a', edgeTypes: [] });
+
+    expect(edgeRepo.getNeighborhood).toHaveBeenCalledWith(
+      'entity1',
+      'a',
+      expect.objectContaining({ edgeTypes: [] }),
+    );
+  });
+
+  it('returns empty result without calling findByIds when getNeighborhood finds nothing', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: [], edges: [] });
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    const result = await svc.traverseGraph('entity1', { sourceId: 'missing' });
+
+    expect(result).toEqual({ nodes: [], edges: [] });
+    expect(entryRepo.findByIds).not.toHaveBeenCalled();
+  });
+
+  it('hydrates node IDs into facts scoped to entityId, passing edges through unchanged', async () => {
+    const { edgeRepo, entryRepo } = makeMocks();
+    vi.mocked(edgeRepo.getNeighborhood).mockResolvedValue({ nodeIds: ['a', 'b'], edges: [sampleEdge] });
+    vi.mocked(entryRepo.findByIds).mockResolvedValue([sampleFact]);
+
+    const svc = new GraphTraversalService(edgeRepo, entryRepo, {});
+    const result = await svc.traverseGraph('entity1', { sourceId: 'a' });
+
+    expect(entryRepo.findByIds).toHaveBeenCalledWith(['a', 'b'], ['entity1']);
+    expect(result).toEqual({ nodes: [sampleFact], edges: [sampleEdge] });
+  });
+});

--- a/packages/core/__tests__/utils/formatGraphContext.test.ts
+++ b/packages/core/__tests__/utils/formatGraphContext.test.ts
@@ -109,4 +109,27 @@ describe('formatGraphContext', () => {
 
     expect(formatGraphContext(build())).toBe(formatGraphContext(build()));
   });
+
+  it('is deterministic when edge_type and connected title tie', () => {
+    const n1 = makeFact({ id: '1', title: 'Root', okf_type: 'x' });
+    const n2 = makeFact({ id: '2', title: 'Same', okf_type: 'x' });
+    const n3 = makeFact({ id: '3', title: 'Same', okf_type: 'x' });
+
+    const a: GraphNeighborhood = {
+      nodes: [n1, n2, n3],
+      edges: [
+        makeEdge({ id: 'e1', source_id: '1', target_id: '2', edge_type: 'rel' }),
+        makeEdge({ id: 'e2', source_id: '1', target_id: '3', edge_type: 'rel' }),
+      ],
+    };
+    const b: GraphNeighborhood = {
+      nodes: [n1, n2, n3],
+      edges: [
+        makeEdge({ id: 'e2', source_id: '1', target_id: '3', edge_type: 'rel' }),
+        makeEdge({ id: 'e1', source_id: '1', target_id: '2', edge_type: 'rel' }),
+      ],
+    };
+
+    expect(formatGraphContext(a)).toBe(formatGraphContext(b));
+  });
 });

--- a/packages/core/__tests__/utils/formatGraphContext.test.ts
+++ b/packages/core/__tests__/utils/formatGraphContext.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { formatGraphContext } from '../../src/utils/formatGraphContext';
+import type { GraphNeighborhood, WikiFact, WikiEdge } from '../../src/types';
+
+function makeFact(overrides: Partial<WikiFact> & { id: string; title: string }): WikiFact {
+  return {
+    entity_id: 'entity1',
+    body: 'body',
+    tags: [],
+    confidence: 'certain',
+    source_type: 'user_stated',
+    source_hash: null,
+    source_ref: null,
+    created_at: 1,
+    updated_at: 1,
+    last_accessed_at: null,
+    access_count: 0,
+    deleted_at: null,
+    okf_type: null,
+    ...overrides,
+  };
+}
+
+function makeEdge(overrides: Partial<WikiEdge> & { id: string; source_id: string; target_id: string; edge_type: string }): WikiEdge {
+  return {
+    entity_id: 'entity1',
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+describe('formatGraphContext', () => {
+  it('returns an empty string for an empty neighborhood', () => {
+    expect(formatGraphContext({ nodes: [], edges: [] })).toBe('');
+  });
+
+  it('renders a node with no edges', () => {
+    const neighborhood: GraphNeighborhood = {
+      nodes: [makeFact({ id: '123', title: 'John Doe', okf_type: 'person' })],
+      edges: [],
+    };
+    expect(formatGraphContext(neighborhood)).toBe('[person] John Doe (ID: 123)');
+  });
+
+  it('defaults the type label to "fact" when okf_type is null', () => {
+    const neighborhood: GraphNeighborhood = {
+      nodes: [makeFact({ id: '123', title: 'Some Note', okf_type: null })],
+      edges: [],
+    };
+    expect(formatGraphContext(neighborhood)).toBe('[fact] Some Note (ID: 123)');
+  });
+
+  it('renders outbound before inbound edges, matching the documented shape', () => {
+    const neighborhood: GraphNeighborhood = {
+      nodes: [
+        makeFact({ id: '123', title: 'John Doe', okf_type: 'person' }),
+        makeFact({ id: '456', title: 'Jane Smith', okf_type: 'person' }),
+        makeFact({ id: '789', title: 'Alpha Rewrite', okf_type: 'project' }),
+      ],
+      edges: [
+        makeEdge({ id: 'e1', source_id: '123', target_id: '456', edge_type: 'reports_to' }),
+        makeEdge({ id: 'e2', source_id: '789', target_id: '123', edge_type: 'contributes_to' }),
+      ],
+    };
+
+    expect(formatGraphContext(neighborhood)).toBe(
+      [
+        '[person] John Doe (ID: 123)',
+        '  -[reports_to]-> [person] Jane Smith',
+        '  <-[contributes_to]- [project] Alpha Rewrite',
+        '[person] Jane Smith (ID: 456)',
+        '[project] Alpha Rewrite (ID: 789)',
+      ].join('\n'),
+    );
+  });
+
+  it('sorts same-direction edges by edge_type then connected title', () => {
+    const neighborhood: GraphNeighborhood = {
+      nodes: [
+        makeFact({ id: 'a', title: 'A', okf_type: 'person' }),
+        makeFact({ id: 'b', title: 'Zed', okf_type: 'person' }),
+        makeFact({ id: 'c', title: 'Bob', okf_type: 'person' }),
+        makeFact({ id: 'd', title: 'Carl', okf_type: 'person' }),
+      ],
+      edges: [
+        makeEdge({ id: 'e1', source_id: 'a', target_id: 'b', edge_type: 'zzz_type' }),
+        makeEdge({ id: 'e2', source_id: 'a', target_id: 'c', edge_type: 'aaa_type' }),
+        makeEdge({ id: 'e3', source_id: 'a', target_id: 'd', edge_type: 'aaa_type' }),
+      ],
+    };
+
+    const lines = formatGraphContext(neighborhood).split('\n');
+    expect(lines).toEqual([
+      '[person] A (ID: a)',
+      '  -[aaa_type]-> [person] Bob',
+      '  -[aaa_type]-> [person] Carl',
+      '  -[zzz_type]-> [person] Zed',
+      '[person] Zed (ID: b)',
+      '[person] Bob (ID: c)',
+      '[person] Carl (ID: d)',
+    ]);
+  });
+
+  it('produces byte-identical output across repeated calls with equivalent (non-identical) input', () => {
+    const build = (): GraphNeighborhood => ({
+      nodes: [makeFact({ id: '1', title: 'A', okf_type: 'x' }), makeFact({ id: '2', title: 'B', okf_type: 'y' })],
+      edges: [makeEdge({ id: 'e1', source_id: '1', target_id: '2', edge_type: 'link' })],
+    });
+
+    expect(formatGraphContext(build())).toBe(formatGraphContext(build()));
+  });
+});

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -27,7 +27,8 @@ import { RetrievalService } from './services/RetrievalService';
 import { WriteService } from './services/WriteService';
 import { PromptService } from './services/PromptService';
 import { OntologyService } from './services/OntologyService';
-import type { OntologyManifest, OntologyMode } from './types';
+import { GraphTraversalService } from './services/GraphTraversalService';
+import type { OntologyManifest, OntologyMode, GraphTraversalOptions, GraphNeighborhood } from './types';
 
 export { WikiBusyError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER } from './types';
 
@@ -43,6 +44,7 @@ export interface WikiMemoryTestAccess {
   searchService: SearchService;
   writeService: WriteService;
   promptService: PromptService;
+  graphTraversalService: GraphTraversalService;
   entryRepo: EntryRepository;
   metadataRepo: MetadataRepository;
   jobManager: JobManager;
@@ -71,6 +73,7 @@ export class WikiMemory {
   private writeService: WriteService;
   private promptService: PromptService;
   private ontologyService: OntologyService;
+  private graphTraversalService: GraphTraversalService;
 
   constructor(db: SQLiteAdapter, options: WikiOptions) {
     this.db = db;
@@ -150,6 +153,11 @@ export class WikiMemory {
       this.jobManager,
       this.maintenanceService,
     );
+    this.graphTraversalService = new GraphTraversalService(
+      this.edgeRepo,
+      this.entryRepo,
+      this.options.config ?? {},
+    );
   }
 
   /**
@@ -178,6 +186,7 @@ export class WikiMemory {
       searchService: this.searchService,
       writeService: this.writeService,
       promptService: this.promptService,
+      graphTraversalService: this.graphTraversalService,
       entryRepo: this.entryRepo,
       metadataRepo: this.metadataRepo,
       jobManager: this.jobManager,
@@ -267,6 +276,10 @@ export class WikiMemory {
 
   async read(entityId: string | string[], query: string, options?: ReadOptions): Promise<MemoryBundle> {
     return this.retrievalService.read(entityId, query, options);
+  }
+
+  async traverseGraph(entityId: string, options: GraphTraversalOptions): Promise<GraphNeighborhood> {
+    return this.graphTraversalService.traverseGraph(entityId, options);
   }
 
   async getMemoryBundle(entityId: string): Promise<MemoryBundle> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export type { WikiOutboxEvent } from './outbox/types';
 export { WikiMemory } from './WikiMemory';
 export type { WikiMemoryTestAccess } from './WikiMemory';
 export { formatContext } from './utils/formatContext';
+export { formatGraphContext } from './utils/formatGraphContext';
 export { formatMemoryDump } from './utils/formatMemoryDump';
 export { formatOkfBundle } from './utils/formatOkfBundle';
 export { parseOkfBundle, type OkfImportOptions } from './utils/parseOkfBundle';

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -122,7 +122,14 @@ export class EdgeRepository extends BaseRepository {
           ON n.id = (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END)
           AND n.entity_id = ?
           AND n.deleted_at IS NULL
-          AND (CASE n.confidence WHEN 'tentative' THEN 0 WHEN 'inferred' THEN 1 ELSE 2 END) >= ?
+          AND (
+            CASE n.confidence
+              WHEN 'tentative' THEN 0
+              WHEN 'inferred' THEN 1
+              WHEN 'certain' THEN 2
+              ELSE -1
+            END
+          ) >= ?
           AND n.source_type NOT IN (${excludeSourceTypesPlaceholders})
         WHERE w.depth < ?
           AND instr(w.visited, ',' || (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END) || ',') = 0

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -157,10 +157,14 @@ export class EdgeRepository extends BaseRepository {
     const nodeIds = rows.map((r) => r.node_id);
     if (nodeIds.length === 0) return { nodeIds: [], edges: [] };
 
-    const idPlaceholders = nodeIds.map(() => '?').join(',');
+    const valueRows = nodeIds.map(() => '(?)').join(', ');
     const edgeRows = await executor.getAllAsync<any>(
-      `SELECT * FROM ${this.prefix}edges WHERE entity_id = ? AND source_id IN (${idPlaceholders}) AND target_id IN (${idPlaceholders})`,
-      [entityId, ...nodeIds, ...nodeIds],
+      `WITH neighborhood(node_id) AS (VALUES ${valueRows})
+       SELECT e.* FROM ${this.prefix}edges e
+       JOIN neighborhood ns ON e.source_id = ns.node_id
+       JOIN neighborhood nt ON e.target_id = nt.node_id
+       WHERE e.entity_id = ?`,
+      [...nodeIds, entityId],
     );
 
     return { nodeIds, edges: edgeRows.map(mapRowToEdge) };

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -1,6 +1,21 @@
 import { BaseRepository } from './BaseRepository';
 import type { WikiEdge, SQLiteAdapter } from '../types';
 
+export interface NeighborhoodQueryOptions {
+  maxDepth: number; // already clamped to [1,3] by the caller (GraphTraversalService)
+  direction: 'inbound' | 'outbound' | 'both';
+  edgeTypes?: string[]; // undefined = no filter; [] = match nothing (short-circuits)
+  minConfidence: 'certain' | 'inferred' | 'tentative';
+  excludeSourceTypes: string[];
+  maxNodes: number;
+}
+
+const CONFIDENCE_RANK: Record<'tentative' | 'inferred' | 'certain', number> = {
+  tentative: 0,
+  inferred: 1,
+  certain: 2,
+};
+
 export class EdgeRepository extends BaseRepository {
   /**
    * Insert an edge, silently skipping on primary-key or uniqueness conflicts.
@@ -46,14 +61,7 @@ export class EdgeRepository extends BaseRepository {
       `SELECT * FROM ${this.prefix}edges WHERE entity_id = ? ORDER BY created_at ASC`,
       [entityId],
     );
-    return rows.map((row) => ({
-      id: String(row.id),
-      entity_id: String(row.entity_id),
-      source_id: String(row.source_id),
-      target_id: String(row.target_id),
-      edge_type: String(row.edge_type),
-      created_at: Number(row.created_at),
-    }));
+    return rows.map(mapRowToEdge);
   }
 
   /** Hard delete — edges have no soft-delete concept, only presence/absence. `tx` is REQUIRED. */
@@ -61,4 +69,104 @@ export class EdgeRepository extends BaseRepository {
     const executor = this.getExecutor(tx);
     await executor.runAsync(`DELETE FROM ${this.prefix}edges WHERE entity_id = ?`, [entityId]);
   }
+
+  /**
+   * Multi-hop traversal from `sourceId` via SQLite `WITH RECURSIVE`. All filtering,
+   * dead-ending, cycle-guarding, capping, and ordering happens in this one query.
+   * The anchor is validated (exists, right entity, not soft-deleted) but never gated
+   * by confidence/source_type — only nodes discovered beyond it are.
+   */
+  async getNeighborhood(
+    entityId: string,
+    sourceId: string,
+    opts: NeighborhoodQueryOptions,
+    tx?: SQLiteAdapter,
+  ): Promise<{ nodeIds: string[]; edges: WikiEdge[] }> {
+    const executor = this.getExecutor(tx);
+
+    if (opts.edgeTypes && opts.edgeTypes.length === 0) {
+      const anchor = await executor.getFirstAsync<{ id: string }>(
+        `SELECT id FROM ${this.prefix}entries WHERE id = ? AND entity_id = ? AND deleted_at IS NULL`,
+        [sourceId, entityId],
+      );
+      return { nodeIds: anchor ? [anchor.id] : [], edges: [] };
+    }
+
+    const edgeTypesClause = opts.edgeTypes
+      ? `e.edge_type IN (${opts.edgeTypes.map(() => '?').join(',')})`
+      : '1=1';
+    const excludeSourceTypesPlaceholders = opts.excludeSourceTypes.map(() => '?').join(',');
+    const minConfidenceRank = CONFIDENCE_RANK[opts.minConfidence];
+
+    const sql = `
+      WITH RECURSIVE walk(node_id, depth, visited) AS (
+        SELECT id, 0, ',' || id || ','
+        FROM ${this.prefix}entries
+        WHERE id = ? AND entity_id = ? AND deleted_at IS NULL
+
+        UNION
+
+        SELECT
+          CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END,
+          w.depth + 1,
+          w.visited || (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END) || ','
+        FROM walk w
+        JOIN ${this.prefix}edges e
+          ON e.entity_id = ?
+          AND (
+            (? != 'inbound'  AND e.source_id = w.node_id) OR
+            (? != 'outbound' AND e.target_id = w.node_id)
+          )
+          AND (${edgeTypesClause})
+        JOIN ${this.prefix}entries n
+          ON n.id = (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END)
+          AND n.entity_id = ?
+          AND n.deleted_at IS NULL
+          AND (CASE n.confidence WHEN 'tentative' THEN 0 WHEN 'inferred' THEN 1 ELSE 2 END) >= ?
+          AND n.source_type NOT IN (${excludeSourceTypesPlaceholders})
+        WHERE w.depth < ?
+          AND instr(w.visited, ',' || (CASE WHEN e.source_id = w.node_id THEN e.target_id ELSE e.source_id END) || ',') = 0
+      )
+      SELECT node_id, MIN(depth) AS depth
+      FROM walk
+      GROUP BY node_id
+      ORDER BY depth ASC, (SELECT updated_at FROM ${this.prefix}entries WHERE id = node_id) DESC
+      LIMIT ?
+    `;
+
+    const params: unknown[] = [
+      sourceId, entityId,
+      entityId,
+      opts.direction, opts.direction,
+      ...(opts.edgeTypes ?? []),
+      entityId,
+      minConfidenceRank,
+      ...opts.excludeSourceTypes,
+      opts.maxDepth,
+      opts.maxNodes,
+    ];
+
+    const rows = await executor.getAllAsync<{ node_id: string; depth: number }>(sql, params);
+    const nodeIds = rows.map((r) => r.node_id);
+    if (nodeIds.length === 0) return { nodeIds: [], edges: [] };
+
+    const idPlaceholders = nodeIds.map(() => '?').join(',');
+    const edgeRows = await executor.getAllAsync<any>(
+      `SELECT * FROM ${this.prefix}edges WHERE entity_id = ? AND source_id IN (${idPlaceholders}) AND target_id IN (${idPlaceholders})`,
+      [entityId, ...nodeIds, ...nodeIds],
+    );
+
+    return { nodeIds, edges: edgeRows.map(mapRowToEdge) };
+  }
+}
+
+function mapRowToEdge(row: any): WikiEdge {
+  return {
+    id: String(row.id),
+    entity_id: String(row.entity_id),
+    source_id: String(row.source_id),
+    target_id: String(row.target_id),
+    edge_type: String(row.edge_type),
+    created_at: Number(row.created_at),
+  };
 }

--- a/packages/core/src/services/GraphTraversalService.ts
+++ b/packages/core/src/services/GraphTraversalService.ts
@@ -14,7 +14,12 @@ export class GraphTraversalService {
   ) {}
 
   async traverseGraph(entityId: string, options: GraphTraversalOptions): Promise<GraphNeighborhood> {
-    const defaultMaxNodes = this.config.maxTraversalNodes ?? 20;
+    const fallbackMaxNodes = 20;
+    const rawConfigDefault = this.config.maxTraversalNodes ?? fallbackMaxNodes;
+    const defaultMaxNodes =
+      Number.isFinite(rawConfigDefault) && rawConfigDefault >= 1
+        ? Math.floor(rawConfigDefault)
+        : fallbackMaxNodes;
     const rawMaxNodes = options.maxTraversalNodes ?? defaultMaxNodes;
     const maxNodes =
       Number.isFinite(rawMaxNodes) && rawMaxNodes >= 1 ? Math.floor(rawMaxNodes) : defaultMaxNodes;

--- a/packages/core/src/services/GraphTraversalService.ts
+++ b/packages/core/src/services/GraphTraversalService.ts
@@ -14,13 +14,18 @@ export class GraphTraversalService {
   ) {}
 
   async traverseGraph(entityId: string, options: GraphTraversalOptions): Promise<GraphNeighborhood> {
+    const defaultMaxNodes = this.config.maxTraversalNodes ?? 20;
+    const rawMaxNodes = options.maxTraversalNodes ?? defaultMaxNodes;
+    const maxNodes =
+      Number.isFinite(rawMaxNodes) && rawMaxNodes >= 1 ? Math.floor(rawMaxNodes) : defaultMaxNodes;
+
     const opts: NeighborhoodQueryOptions = {
       maxDepth: Math.max(1, Math.min(options.maxDepth ?? 1, 3)),
       direction: options.direction ?? this.config.traversalDirection ?? 'both',
       edgeTypes: options.edgeTypes,
       minConfidence: options.minTraversalConfidence ?? this.config.minTraversalConfidence ?? 'tentative',
       excludeSourceTypes: options.excludeSourceTypes ?? this.config.excludeSourceTypes ?? [],
-      maxNodes: options.maxTraversalNodes ?? this.config.maxTraversalNodes ?? 20,
+      maxNodes,
     };
 
     const { nodeIds, edges } = await this.edgeRepo.getNeighborhood(entityId, options.sourceId, opts);
@@ -29,6 +34,10 @@ export class GraphTraversalService {
     // findByIds() returns facts in input-ID order (Map-based lookup,
     // see packages/core/src/repositories/EntryRepository.ts:104-108) — no re-sort needed.
     const nodes = await this.entryRepo.findByIds(nodeIds, [entityId]);
-    return { nodes, edges };
+    const hydratedIds = new Set(nodes.map((node) => node.id));
+    const filteredEdges = edges.filter(
+      (edge) => hydratedIds.has(edge.source_id) && hydratedIds.has(edge.target_id),
+    );
+    return { nodes, edges: filteredEdges };
   }
 }

--- a/packages/core/src/services/GraphTraversalService.ts
+++ b/packages/core/src/services/GraphTraversalService.ts
@@ -1,0 +1,34 @@
+import type { EdgeRepository, NeighborhoodQueryOptions } from '../repositories/EdgeRepository';
+import type { EntryRepository } from '../repositories/EntryRepository';
+import type { GraphTraversalOptions, GraphNeighborhood, WikiConfig } from '../types';
+
+/**
+ * Pure orchestrator — no SQL. Merges WikiConfig defaults with per-call options,
+ * delegates the recursive walk to EdgeRepository, then hydrates node IDs into facts.
+ */
+export class GraphTraversalService {
+  constructor(
+    private edgeRepo: EdgeRepository,
+    private entryRepo: EntryRepository,
+    private config: WikiConfig,
+  ) {}
+
+  async traverseGraph(entityId: string, options: GraphTraversalOptions): Promise<GraphNeighborhood> {
+    const opts: NeighborhoodQueryOptions = {
+      maxDepth: Math.max(1, Math.min(options.maxDepth ?? 1, 3)),
+      direction: options.direction ?? this.config.traversalDirection ?? 'both',
+      edgeTypes: options.edgeTypes,
+      minConfidence: options.minTraversalConfidence ?? this.config.minTraversalConfidence ?? 'tentative',
+      excludeSourceTypes: options.excludeSourceTypes ?? this.config.excludeSourceTypes ?? [],
+      maxNodes: options.maxTraversalNodes ?? this.config.maxTraversalNodes ?? 20,
+    };
+
+    const { nodeIds, edges } = await this.edgeRepo.getNeighborhood(entityId, options.sourceId, opts);
+    if (nodeIds.length === 0) return { nodes: [], edges: [] };
+
+    // findByIds() returns facts in input-ID order (Map-based lookup,
+    // see packages/core/src/repositories/EntryRepository.ts:104-108) — no re-sort needed.
+    const nodes = await this.entryRepo.findByIds(nodeIds, [entityId]);
+    return { nodes, edges };
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,6 +118,14 @@ export interface WikiConfig {
    */
   enableOutbox?: boolean;
   ontology?: OntologyConfig;
+  /** Default node cap for traverseGraph(), unless overridden per-call. Default 20. */
+  maxTraversalNodes?: number;
+  /** Default minimum confidence tier for discovered traversal nodes. Default 'tentative'. */
+  minTraversalConfidence?: 'certain' | 'inferred' | 'tentative';
+  /** Default traversal direction. Default 'both'. */
+  traversalDirection?: 'inbound' | 'outbound' | 'both';
+  /** Default source_type dead-end list for discovered traversal nodes. Default []. */
+  excludeSourceTypes?: Array<WikiFact['source_type']>;
 }
 
 export interface ReadOptions {
@@ -214,6 +222,32 @@ export interface WikiEdge {
   target_id: string;
   edge_type: string;
   created_at: number;
+}
+
+export interface GraphTraversalOptions {
+  sourceId: string;
+  /** Hop count. Default 1. Clamped to [1, 3] regardless of input. */
+  maxDepth?: number;
+  /** Default 'both'. Falls back to WikiConfig.traversalDirection, then 'both'. */
+  direction?: 'inbound' | 'outbound' | 'both';
+  /**
+   * Allowed edge types. `undefined` = no filter (all types).
+   * `[]` (explicit empty array) = match nothing — distinct from `undefined`.
+   */
+  edgeTypes?: string[];
+  /** Total node cap (anchor + neighbors). Default 20 via WikiConfig.maxTraversalNodes. */
+  maxTraversalNodes?: number;
+  /** Minimum confidence tier for *discovered* nodes. Does not gate the anchor. Default 'tentative'. */
+  minTraversalConfidence?: 'certain' | 'inferred' | 'tentative';
+  /** source_type values to dead-end on for *discovered* nodes. Does not gate the anchor. Default []. */
+  excludeSourceTypes?: Array<WikiFact['source_type']>;
+}
+
+export interface GraphNeighborhood {
+  /** Anchor node first, then discovered neighbors ordered by depth ASC, then updated_at DESC. */
+  nodes: WikiFact[];
+  /** Only edges where both endpoints are present in `nodes`. */
+  edges: WikiEdge[];
 }
 
 export interface WikiCheckpoint {

--- a/packages/core/src/utils/formatGraphContext.ts
+++ b/packages/core/src/utils/formatGraphContext.ts
@@ -44,11 +44,14 @@ function edgesByDirection(
       const otherId = e[otherEndpoint];
       const selfIdx = nodeIndex.get(nodeId)!;
       const otherIdx = nodeIndex.get(otherId);
-      return otherIdx === undefined || selfIdx < otherIdx;
+      return otherIdx !== undefined && selfIdx < otherIdx;
     })
     .map((edge) => ({ edge, other: nodeById.get(edge[otherEndpoint])! }))
     .sort(
       (a, b) =>
-        a.edge.edge_type.localeCompare(b.edge.edge_type) || a.other.title.localeCompare(b.other.title),
+        a.edge.edge_type.localeCompare(b.edge.edge_type) ||
+        a.other.title.localeCompare(b.other.title) ||
+        a.other.id.localeCompare(b.other.id) ||
+        a.edge.id.localeCompare(b.edge.id),
     );
 }

--- a/packages/core/src/utils/formatGraphContext.ts
+++ b/packages/core/src/utils/formatGraphContext.ts
@@ -1,0 +1,54 @@
+import type { GraphNeighborhood, WikiEdge } from '../types';
+
+/**
+ * Pure presenter — dense text serialization of a GraphNeighborhood for LLM prompt
+ * injection. Deterministic: same input always produces byte-identical output
+ * (matters for prompt caching).
+ */
+export function formatGraphContext(neighborhood: GraphNeighborhood): string {
+  const { nodes, edges } = neighborhood;
+  if (nodes.length === 0) return '';
+
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  const nodeIndex = new Map(nodes.map((n, i) => [n.id, i]));
+  const lines: string[] = [];
+
+  for (const node of nodes) {
+    lines.push(`[${node.okf_type ?? 'fact'}] ${node.title} (ID: ${node.id})`);
+
+    const outbound = edgesByDirection(edges, node.id, 'source_id', nodeById, nodeIndex);
+    const inbound = edgesByDirection(edges, node.id, 'target_id', nodeById, nodeIndex);
+
+    for (const { edge, other } of outbound) {
+      lines.push(`  -[${edge.edge_type}]-> [${other.okf_type ?? 'fact'}] ${other.title}`);
+    }
+    for (const { edge, other } of inbound) {
+      lines.push(`  <-[${edge.edge_type}]- [${other.okf_type ?? 'fact'}] ${other.title}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function edgesByDirection(
+  edges: WikiEdge[],
+  nodeId: string,
+  endpoint: 'source_id' | 'target_id',
+  nodeById: Map<string, GraphNeighborhood['nodes'][number]>,
+  nodeIndex: Map<string, number>,
+) {
+  const otherEndpoint = endpoint === 'source_id' ? 'target_id' : 'source_id';
+  return edges
+    .filter((e) => e[endpoint] === nodeId)
+    .filter((e) => {
+      const otherId = e[otherEndpoint];
+      const selfIdx = nodeIndex.get(nodeId)!;
+      const otherIdx = nodeIndex.get(otherId);
+      return otherIdx === undefined || selfIdx < otherIdx;
+    })
+    .map((edge) => ({ edge, other: nodeById.get(edge[otherEndpoint])! }))
+    .sort(
+      (a, b) =>
+        a.edge.edge_type.localeCompare(b.edge.edge_type) || a.other.title.localeCompare(b.other.title),
+    );
+}

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -19,7 +19,7 @@ Local-first LLM memory for Expo and React Native. Combines the core semantic sea
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights`
 - **Source provenance** — `WikiFact.source_type` distinguishes immutable document facts (`immutable_document`) from mutable derived/user facts. Immutable document content is protected from librarian/heal rewriting and only changed by `forget()` or re-ingest.
 - **Seeded ontologies** — Enforce strict taxonomies or allow emergent graph relationship extraction (`useOntologyManifest`, `useSetOntologyManifest`; Strict, Emergent, or Off; defaults to Off).
-- **React hooks** — `WikiProvider`, `useMemoryRead`, `useOntologyManifest`, `useSetOntologyManifest`, and all other hooks re-exported from `@equationalapplications/expo-llm-wiki`
+- **React hooks** — `WikiProvider`, `useMemoryRead`, `useOntologyManifest`, `useSetOntologyManifest`, `useWikiTraversal`, and all other hooks re-exported from `@equationalapplications/expo-llm-wiki`
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 - **Interoperability:** Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export.
 
@@ -279,6 +279,27 @@ export function OntologySettings({ entityId }: { entityId: string }) {
 Global defaults and `seedManifests` bootstrap are configured at construction time via `createWiki(..., { config: { ontology: ... } })`. See the [core package README § Per-Entity Seeded Ontology](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#per-entity-seeded-ontology) for mode semantics and manifest schema.
 
 `useSetOntologyManifest` does not automatically refresh `useOntologyManifest` — call `refetch()` after a successful `execute()`, same as `useWikiWrite` + `useMemoryRead`.
+
+### `useWikiTraversal(entityId, options)`
+
+Reactive read — fetches on mount and whenever `entityId` or `options` change. Walks the knowledge graph N hops outward from a fact (`options.sourceId`) using edges written by `runLibrarian()`/`ingestDocument()`'s Seeded Ontology extraction pass:
+
+```typescript
+import { useWikiTraversal, formatGraphContext } from '@equationalapplications/expo-llm-wiki';
+
+const { nodes, edges, isPending, error, refetch } = useWikiTraversal('user-123', {
+  sourceId: 'fact_42',
+  maxDepth: 2,
+  direction: 'both',
+});
+
+const promptContext = formatGraphContext({ nodes, edges });
+```
+
+- `maxDepth` is clamped to `[1, 3]` regardless of input.
+- `edgeTypes: []` (explicit empty array) matches nothing; omitting it matches all edge types.
+- Defaults (`maxTraversalNodes`, `minTraversalConfidence`, `traversalDirection`, `excludeSourceTypes`) can be set globally via `createWiki(..., { config: { maxTraversalNodes: 20, ... } })` and overridden per-call.
+- `formatGraphContext()` is a pure function — call it with the hook's `{ nodes, edges }` to get a dense text block suitable for prompt injection.
 
 ## Component Lifecycle
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -17,6 +17,7 @@ In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., [
 - **Multi-entity reads** — Search across multiple `entity_id` namespaces in one pass with `tierWeights` and optional `includeZeroWeightEntities`
 - **Source provenance** — `WikiFact.source_type` distinguishes immutable document facts (`immutable_document`) from mutable derived/user facts (`librarian_inferred`, `user_stated`, `user_confirmed`). Immutable document facts are preserved from librarian/heal rewriting and only removed by `forget()` or by re-ingesting the source.
 - **Seeded ontologies** — Enforce strict taxonomies or allow emergent graph relationship extraction (`useOntologyManifest`, `useSetOntologyManifest`; Strict, Emergent, or Off; defaults to Off).
+- **Graph traversal** — Walk the knowledge graph N hops from a fact and format the result for LLM prompts (`useWikiTraversal`, `formatGraphContext`).
 - **Reactive reads** — Auto-refetch on `entityId`, query, or `options` changes
 - **Mutation hooks** — `useWikiWrite`, `useWikiIngest`, `useWikiForget`, `useWikiMaintenance`, `useSetOntologyManifest`, etc.
 - **Shared context** — Single `WikiProvider` per app, use anywhere
@@ -400,6 +401,27 @@ export function OntologySettings({ entityId }: { entityId: string }) {
 Global defaults and `seedManifests` bootstrap are configured at construction time via `createWiki(..., { config: { ontology: ... } })`. See the [core package README § Per-Entity Seeded Ontology](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#per-entity-seeded-ontology) for mode semantics and manifest schema.
 
 `useSetOntologyManifest` does not automatically refresh `useOntologyManifest` — call `refetch()` after a successful `execute()`, same as `useWikiWrite` + `useMemoryRead`.
+
+### `useWikiTraversal(entityId, options)`
+
+Reactive read — fetches on mount and whenever `entityId` or `options` change. Walks the knowledge graph N hops outward from a fact (`options.sourceId`) using edges written by `runLibrarian()`/`ingestDocument()`'s Seeded Ontology extraction pass:
+
+```typescript
+import { useWikiTraversal, formatGraphContext } from '@equationalapplications/react-llm-wiki';
+
+const { nodes, edges, isPending, error, refetch } = useWikiTraversal('user-123', {
+  sourceId: 'fact_42',
+  maxDepth: 2,
+  direction: 'both',
+});
+
+const promptContext = formatGraphContext({ nodes, edges });
+```
+
+- `maxDepth` is clamped to `[1, 3]` regardless of input.
+- `edgeTypes: []` (explicit empty array) matches nothing; omitting it matches all edge types.
+- Defaults (`maxTraversalNodes`, `minTraversalConfidence`, `traversalDirection`, `excludeSourceTypes`) can be set globally via `createWiki(..., { config: { maxTraversalNodes: 20, ... } })` and overridden per-call.
+- `formatGraphContext()` is a pure function — call it with the hook's `{ nodes, edges }` to get a dense text block suitable for prompt injection.
 
 ## Multi-Entity Reads
 

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -12,6 +12,7 @@ import { useWikiHasChanged } from '../src/useWikiHasChanged';
 import { useEntityStatus } from '../src/useEntityStatus';
 import { useOntologyManifest } from '../src/useOntologyManifest';
 import { useSetOntologyManifest } from '../src/useSetOntologyManifest';
+import { useWikiTraversal } from '../src/useWikiTraversal';
 import type { ReadOptions, EntityStatus, OntologyManifest } from '@equationalapplications/core-llm-wiki';
 
 /** Minimal mock of WikiMemory — uses the real MemoryBundle shape ({ facts, tasks, events }) */
@@ -34,6 +35,7 @@ function makeMockWiki() {
     }),
     getOntologyManifest: vi.fn().mockResolvedValue(null),
     setOntologyManifest: vi.fn().mockResolvedValue(undefined),
+    traverseGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
   };
 }
 
@@ -1065,5 +1067,127 @@ describe('useEntityStatus', () => {
     expect(wiki.subscribeEntityStatus).toHaveBeenCalledTimes(2);
     expect(wiki.subscribeEntityStatus.mock.calls[1][0]).toBe('e2');
     expect(result.current).toEqual({ ingesting: true, librarian: false, heal: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useWikiTraversal
+// ---------------------------------------------------------------------------
+
+describe('useWikiTraversal', () => {
+  let wiki: MockWiki;
+
+  beforeEach(() => {
+    wiki = makeMockWiki();
+  });
+
+  it('starts with isPending=true and calls traverseGraph on mount', async () => {
+    const sampleResult = { nodes: [{ id: 'a' }] as any, edges: [{ id: 'e1' }] as any };
+    wiki.traverseGraph.mockResolvedValue(sampleResult);
+
+    const { result } = renderHook(
+      () => useWikiTraversal('e1', { sourceId: 'a' }),
+      { wrapper: wrapper(wiki) },
+    );
+
+    expect(result.current.isPending).toBe(true);
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(wiki.traverseGraph).toHaveBeenCalledWith('e1', { sourceId: 'a' });
+    expect(result.current.nodes).toEqual(sampleResult.nodes);
+    expect(result.current.edges).toEqual(sampleResult.edges);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('re-fetches when entityId changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ eid }: { eid: string }) => useWikiTraversal(eid, { sourceId: 'a' }),
+      { initialProps: { eid: 'e1' }, wrapper: wrapper(wiki) },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(1);
+
+    rerender({ eid: 'e2' });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
+    expect(wiki.traverseGraph).toHaveBeenLastCalledWith('e2', { sourceId: 'a' });
+  });
+
+  it('re-fetches when options change in value but not on equivalent re-renders', async () => {
+    const { result, rerender } = renderHook(
+      ({ sourceId }: { sourceId: string }) => useWikiTraversal('e1', { sourceId, maxDepth: 1 }),
+      { initialProps: { sourceId: 'a' }, wrapper: wrapper(wiki) },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(1);
+
+    // Same sourceId, new object reference — should NOT refetch.
+    rerender({ sourceId: 'a' });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(1);
+
+    // Different sourceId — should refetch.
+    rerender({ sourceId: 'b' });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets error when traverseGraph rejects', async () => {
+    const boom = new Error('traversal db error');
+    wiki.traverseGraph.mockRejectedValue(boom);
+
+    const { result } = renderHook(
+      () => useWikiTraversal('e1', { sourceId: 'a' }),
+      { wrapper: wrapper(wiki) },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.error).toBe(boom);
+    expect(result.current.nodes).toEqual([]);
+    expect(result.current.edges).toEqual([]);
+  });
+
+  it('refetch() triggers another traverseGraph call', async () => {
+    const { result } = renderHook(
+      () => useWikiTraversal('e1', { sourceId: 'a' }),
+      { wrapper: wrapper(wiki) },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(1);
+
+    act(() => { result.current.refetch(); });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it('queues a fetch when entityId changes while first fetch is in flight', async () => {
+    let resolveFirst!: (value: { nodes: any[]; edges: any[] }) => void;
+    wiki.traverseGraph
+      .mockReturnValueOnce(new Promise(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce({ nodes: [{ id: 'z' }], edges: [] });
+
+    const { result, rerender } = renderHook(
+      ({ eid }: { eid: string }) => useWikiTraversal(eid, { sourceId: 'a' }),
+      { initialProps: { eid: 'e1' }, wrapper: wrapper(wiki) },
+    );
+
+    expect(result.current.isPending).toBe(true);
+
+    rerender({ eid: 'e2' });
+
+    await act(async () => { resolveFirst({ nodes: [], edges: [] }); });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
+    expect(wiki.traverseGraph).toHaveBeenNthCalledWith(1, 'e1', { sourceId: 'a' });
+    expect(wiki.traverseGraph).toHaveBeenNthCalledWith(2, 'e2', { sourceId: 'a' });
+    expect(result.current.nodes).toEqual([{ id: 'z' }]);
   });
 });

--- a/packages/react/__tests__/hooks.test.tsx
+++ b/packages/react/__tests__/hooks.test.tsx
@@ -1136,6 +1136,21 @@ describe('useWikiTraversal', () => {
     expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
   });
 
+  it('re-fetches when edgeTypes array changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ edgeTypes }: { edgeTypes: string[] }) => useWikiTraversal('e1', { sourceId: 'a', edgeTypes }),
+      { initialProps: { edgeTypes: ['mentions'] }, wrapper: wrapper(wiki) },
+    );
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(1);
+
+    rerender({ edgeTypes: ['reports_to'] });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(wiki.traverseGraph).toHaveBeenCalledTimes(2);
+    expect(wiki.traverseGraph).toHaveBeenLastCalledWith('e1', { sourceId: 'a', edgeTypes: ['reports_to'] });
+  });
+
   it('sets error when traverseGraph rejects', async () => {
     const boom = new Error('traversal db error');
     wiki.traverseGraph.mockRejectedValue(boom);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,3 +12,5 @@ export { useEntityStatus } from './useEntityStatus';
 export { useOntologyManifest } from './useOntologyManifest';
 export type { OntologyManifestState } from './useOntologyManifest';
 export { useSetOntologyManifest } from './useSetOntologyManifest';
+export { useWikiTraversal } from './useWikiTraversal';
+export type { WikiTraversalState } from './useWikiTraversal';

--- a/packages/react/src/useWikiTraversal.ts
+++ b/packages/react/src/useWikiTraversal.ts
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { GraphTraversalOptions, WikiFact, WikiEdge } from '@equationalapplications/core-llm-wiki';
+import { useWiki } from './WikiContext';
+
+export interface WikiTraversalState {
+  nodes: WikiFact[];
+  edges: WikiEdge[];
+  isPending: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+/**
+ * Stable dep key for a GraphTraversalOptions object so inline object literals
+ * (new reference each render) don't cause spurious refetches. Sorted-key
+ * JSON.stringify, mirroring normalizeReadOptionsKey in useMemoryRead.ts.
+ */
+function normalizeTraversalOptionsKey(options: GraphTraversalOptions): string {
+  const normalized: Record<string, unknown> = { sourceId: options.sourceId };
+
+  if (options.maxDepth !== undefined) normalized.maxDepth = options.maxDepth;
+  if (options.direction !== undefined) normalized.direction = options.direction;
+  if (options.edgeTypes !== undefined) normalized.edgeTypes = [...options.edgeTypes].sort();
+  if (options.maxTraversalNodes !== undefined) normalized.maxTraversalNodes = options.maxTraversalNodes;
+  if (options.minTraversalConfidence !== undefined) normalized.minTraversalConfidence = options.minTraversalConfidence;
+  if (options.excludeSourceTypes !== undefined) normalized.excludeSourceTypes = [...options.excludeSourceTypes].sort();
+
+  const sortedKeys = Object.keys(normalized).sort();
+  return JSON.stringify(normalized, sortedKeys);
+}
+
+/**
+ * Reactive read hook for graph traversal. Fetches on mount and whenever
+ * `entityId` or a stable serialization of `options` changes.
+ * Call `refetch()` after mutations that change the underlying edges (e.g. runLibrarian).
+ */
+export function useWikiTraversal(entityId: string, options: GraphTraversalOptions): WikiTraversalState {
+  const wiki = useWiki();
+  const [nodes, setNodes] = useState<WikiFact[]>([]);
+  const [edges, setEdges] = useState<WikiEdge[]>([]);
+  const [isPending, setIsPending] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const wikiRef = useRef(wiki);
+  wikiRef.current = wiki;
+
+  const entityIdRef = useRef(entityId);
+  entityIdRef.current = entityId;
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const optionsKey = normalizeTraversalOptionsKey(options);
+
+  const fetchQueue = useRef<{
+    inFlight: boolean;
+    pending: { entityId: string; options: GraphTraversalOptions } | null;
+  }>({ inFlight: false, pending: null });
+
+  // Stable scheduler: refs keep it from going stale across renders.
+  // In-flight results are never discarded.
+  const scheduleFetch = useRef(function schedule(eid: string, opts: GraphTraversalOptions) {
+    const fq = fetchQueue.current;
+    if (fq.inFlight) {
+      fq.pending = { entityId: eid, options: opts };
+      return;
+    }
+    fq.inFlight = true;
+    setIsPending(true);
+
+    wikiRef.current.traverseGraph(eid, opts).then(
+      (result) => {
+        setNodes(result.nodes);
+        setEdges(result.edges);
+        setError(null);
+      },
+      (e: unknown) => {
+        setError(e instanceof Error ? e : new Error(String(e)));
+      },
+    ).finally(() => {
+      fq.inFlight = false;
+      const next = fq.pending;
+      fq.pending = null;
+      if (next) {
+        scheduleFetch.current(next.entityId, next.options);
+      } else {
+        setIsPending(false);
+      }
+    });
+  });
+
+  useEffect(() => {
+    scheduleFetch.current(entityIdRef.current, optionsRef.current);
+  }, [entityId, optionsKey, wiki]);
+
+  const refetch = useCallback(() => {
+    scheduleFetch.current(entityIdRef.current, optionsRef.current);
+  }, [entityId, optionsKey]);
+
+  return { nodes, edges, isPending, error, refetch };
+}

--- a/packages/react/src/useWikiTraversal.ts
+++ b/packages/react/src/useWikiTraversal.ts
@@ -26,7 +26,13 @@ function normalizeTraversalOptionsKey(options: GraphTraversalOptions): string {
   if (options.excludeSourceTypes !== undefined) normalized.excludeSourceTypes = [...options.excludeSourceTypes].sort();
 
   const sortedKeys = Object.keys(normalized).sort();
-  return JSON.stringify(normalized, sortedKeys);
+  const sorted: Record<string, unknown> = {};
+  for (const k of sortedKeys) {
+    sorted[k] = normalized[k];
+  }
+  // Do not pass sortedKeys as a JSON.stringify replacer — array values would lose
+  // their elements because replacer keys must be object property names, not indices.
+  return JSON.stringify(sorted);
 }
 
 /**

--- a/packages/react/src/useWikiTraversal.ts
+++ b/packages/react/src/useWikiTraversal.ts
@@ -75,6 +75,8 @@ export function useWikiTraversal(entityId: string, options: GraphTraversalOption
         setError(null);
       },
       (e: unknown) => {
+        setNodes([]);
+        setEdges([]);
         setError(e instanceof Error ? e : new Error(String(e)));
       },
     ).finally(() => {


### PR DESCRIPTION
## Summary

- Adds a read-only graph traversal surface on top of existing `llm_wiki_edges` / `entries` data: `EdgeRepository.getNeighborhood()` (recursive SQL), `GraphTraversalService`, `WikiMemory.traverseGraph()`, and `formatGraphContext()` for LLM prompt injection.
- Adds `useWikiTraversal` React hook (mirrors `useMemoryRead` / `useOntologyManifest` fetch contract) and exports it via `@equationalapplications/react-llm-wiki` / `@equationalapplications/expo-llm-wiki`.
- Adds `wiki_get_ontology` and `wiki_traverse_graph` tool manifests to `core-llm-tools` (`memory:read` scope). No schema changes.

Spec: [Knowledge Graph Traversal API](docs/superpowers/specs/2026-06-23-graph-traversal-api-design.md)

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r --filter=!@equationalapplications/integration-llm-wiki test`
- [x] `pnpm -r build`
- [x] `EdgeRepository.getNeighborhood()` — direction, depth, edge-type filter, confidence/source_type dead-ends, cycle guard, node cap/ordering
- [x] `GraphTraversalService` — config defaults, per-call overrides, maxDepth clamping
- [x] `formatGraphContext()` — deterministic output, edge deduplication by node order
- [x] `useWikiTraversal` — mount fetch, refetch, stable options key, in-flight queue
- [x] No changes to `packages/core/src/db/schema.ts` or `CHANGELOG.md`


Made with [Cursor](https://cursor.com)