### PR TITLE
fix(core): preserve OKF edge order and align summary test with profile 1

### DIFF
--- a/packages/core/__tests__/formatOkfBundle.test.ts
+++ b/packages/core/__tests__/formatOkfBundle.test.ts
@@ -262,6 +262,47 @@ describe('formatOkfBundle', () => {
     expect(entityIndex.content.startsWith('Alice loves coffee.\n\n')).toBe(true);
   });
 
+  it('preserves edges array order in ## Related bullets for a single source concept', () => {
+    const dump: MemoryDump = {
+      generatedAt: 0,
+      entities: {
+        alice: {
+          facts: [
+            makeFact({ id: 'fact_a', body: 'Source fact.' }),
+            makeFact({ id: 'fact_b', title: 'Beta', body: 'Beta body.' }),
+          ],
+          tasks: [makeTask({ id: 'task_c' })],
+          events: [],
+          edges: [
+            {
+              id: 'edge_1',
+              entity_id: 'alice',
+              source_id: 'fact_a',
+              target_id: 'fact_b',
+              edge_type: 'references',
+              created_at: 0,
+            },
+            {
+              id: 'edge_2',
+              entity_id: 'alice',
+              source_id: 'fact_a',
+              target_id: 'task_c',
+              edge_type: 'blocks',
+              created_at: 0,
+            },
+          ],
+        },
+      },
+    };
+    const factA = formatOkfBundle(dump).files.find(f => f.path === 'entities/alice/facts/fact_a.md')!;
+    const relatedSection = factA.content.slice(factA.content.indexOf('## Related'));
+    const referencesIdx = relatedSection.indexOf('- [references]');
+    const blocksIdx = relatedSection.indexOf('- [blocks]');
+    expect(referencesIdx).toBeGreaterThan(-1);
+    expect(blocksIdx).toBeGreaterThan(-1);
+    expect(referencesIdx).toBeLessThan(blocksIdx);
+  });
+
   it('emits ## Related from edges array, not inline body links', () => {
     const dump: MemoryDump = {
       generatedAt: 0,

--- a/packages/core/__tests__/parseOkfBundle.test.ts
+++ b/packages/core/__tests__/parseOkfBundle.test.ts
@@ -390,6 +390,7 @@ describe('parseOkfBundle — profile 1', () => {
 
   it('parses entity summary from index.md', () => {
     const files: OkfFile[] = [
+      { path: 'index.md', content: buildRootIndexMd('0.1', [], { profile: 'llm-wiki/1' }) },
       {
         path: 'entities/alice/index.md',
         content: 'Alice summary.\n\n## Facts\n\n[Event log](./log.md)\n',

--- a/packages/core/src/utils/formatOkfBundle.ts
+++ b/packages/core/src/utils/formatOkfBundle.ts
@@ -115,8 +115,7 @@ export function formatOkfBundle(dump: MemoryDump): { files: OkfFile[] } {
           if (!targetPath) return null;
           return { edge_type: edge.edge_type, path: conceptRelativePath(sourcePath, targetPath) };
         })
-        .filter((link): link is { edge_type: string; path: string } => link != null)
-        .sort((a, b) => a.edge_type.localeCompare(b.edge_type) || a.path.localeCompare(b.path));
+        .filter((link): link is { edge_type: string; path: string } => link != null);
     }
 
     const factEntries: OkfIndexEntry[] = bundle.facts.map(f => ({


### PR DESCRIPTION
## Summary
- Stop sorting `## Related` links alphabetically in `formatOkfBundle`, so golden-v1 round-trips preserve edge order (`references` before `blocks`).
- Add a profile-1 root `index.md` to the entity summary parse test fixture, matching the OKF spec requirement that summary prose is only parsed when `profile: llm-wiki/1` is present.

## Test plan
- [x] `pnpm test` passes (676 core tests + integration suite)


Made with [Cursor](https://cursor.com)