### PR TITLE
fix(core): serialize SQLite transactions on the shared connection

### DIFF
--- a/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
+++ b/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
@@ -11,7 +11,7 @@
 Production incident (host app, web, 2026-07-09): concurrent wiki operations on a single
 shared SQLite connection produced:
 
-```
+```text
 Error code 1: cannot start a transaction within a transaction
 Error code 1: cannot rollback - no transaction is active
 ```
@@ -135,12 +135,10 @@ function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
 The queue holds a single promise chain; each resolved link is dropped as the
 tail advances, so V8/JSC reclaims settled transactions over a long-running app.
 
-> **Adapter contract — plain objects only.** The wrapper (and `guardReentrancy`)
-> use object spread (`{ ...db }`), which copies **own enumerable** properties only.
-> The expo adapter and the core test helper are plain object literals, so this is
-> correct. A future adapter authored as a **class instance** would lose its
-> prototype methods and `this` binding through the spread — adapters MUST be plain
-> objects, or the wrapper must be rewritten to delegate each method explicitly.
+> **Adapter contract.** The wrapper (and `guardReentrancy`) use prototype
+> delegation (`Object.create(...)`), not object spread, so inherited methods and
+> `this` binding are preserved — a class-instance adapter keeps its prototype
+> methods through the wrap.
 >
 > **Expo `tx` aliasing.** `packages/expo/src/adapter.ts` passes the outer adapter
 > object itself as the `tx` argument (it wraps `expo-sqlite`'s own
@@ -180,7 +178,7 @@ mutex — strictly worse. Therefore core re-wraps the `tx` handed to callbacks
 > that lived only in the adapter layer would be absent there; injecting it in core
 > covers every adapter uniformly.
 
-```
+```text
 Nested withTransactionAsync is not supported: you are already inside a
 transaction. Pass the current `tx` down instead of opening a new transaction.
 ```

--- a/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
+++ b/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
@@ -1,0 +1,412 @@
+# Spec: Transaction Serialization & Connection-Wedge Hardening
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (adapter + docs)
+
+---
+
+## Problem
+
+Production incident (host app, web, 2026-07-09): concurrent wiki operations on a single
+shared SQLite connection produced:
+
+```
+Error code 1: cannot start a transaction within a transaction
+Error code 1: cannot rollback - no transaction is active
+```
+
+followed by a wedged connection cascade: `importDump timed out after 8000ms`,
+`Sync timeout for entity … after 60000ms`, and endless
+`librarian already running … retrying` loops.
+
+Root cause chain:
+
+1. `WikiMemory` is constructed over **one** `SQLiteAdapter` (one connection). Every
+   write path opens its own transaction via `db.withTransactionAsync(...)`:
+   - `WriteService.write` (`packages/core/src/services/WriteService.ts`)
+   - `ImportExportService.importDump` (`packages/core/src/services/ImportExportService.ts`)
+   - `WikiMemory.setOntologyManifest` (`packages/core/src/WikiMemory.ts`)
+   - `WikiMemory.setup` source-ref migration (`packages/core/src/WikiMemory.ts`)
+   - `IngestionService` (1 site), `MaintenanceService` (5 sites), `db/migrations.ts`
+2. Neither core nor the Expo adapter serializes these calls. The Expo adapter
+   (`packages/expo/src/adapter.ts`) forwards straight to
+   `expo-sqlite`'s `db.withTransactionAsync`.
+3. Two overlapping callers (e.g. a host app syncing two entities concurrently, or a
+   fire-and-forget `setOntologyManifest` racing an `importDump`) issue nested `BEGIN`
+   → SQLite error 1.
+4. The failed transaction's cleanup then issues `ROLLBACK` with no active transaction,
+   producing a *second* error that masks the first and leaves the connection in an
+   inconsistent state for subsequent callers.
+
+The library's implicit contract today is "never call two write APIs concurrently" —
+undocumented, unenforced, and violated by realistic host-app code. For adoption, the
+library must be **safe by construction**: adopters should never need to know SQLite
+forbids nested `BEGIN`.
+
+---
+
+## Solution
+
+Serialize all transactions **inside core** with an internal async mutex, guard
+rollback cleanup so a failed `BEGIN` cannot mask the original error, and document the
+concurrency contract publicly. No public API changes; ship as a `fix:` patch release
+via semantic-release.
+
+---
+
+## Design Decisions
+
+### 1. Core owns serialization (not adapters, not host apps)
+
+A promise-chain mutex wraps `withTransactionAsync` **once**, in the `WikiMemory`
+constructor, before the adapter is handed to any repository or service:
+
+```ts
+// packages/core/src/db/serializedAdapter.ts (new)
+const DEADLOCK_WARN_MS = 10_000;
+
+export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
+  let queue: Promise<unknown> = Promise.resolve();
+  return {
+    ...db,
+    withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+      // Warn if a call waits too long for the lock — the signature of the
+      // closure-capture deadlock in Decision 2 (calling the outer `db` instead
+      // of `tx` inside a callback). Cleared the instant the lock is acquired,
+      // so it measures queue wait only and never trips on a legitimately long
+      // transaction.
+      const warn = setTimeout(() => {
+        console.warn(
+          '[core-llm-wiki] Transaction queued >10s — possible deadlock. ' +
+          'Inside a transaction callback, use the `tx` parameter, never the ' +
+          'outer database handle.'
+        );
+      }, DEADLOCK_WARN_MS);
+
+      // Proceed from a settled state (swallow the previous outcome), then run.
+      const run = queue
+        .catch(() => undefined)
+        .then(() => {
+          clearTimeout(warn);
+          // Re-wrap the tx handed to the callback so a *nested*
+          // withTransactionAsync throws synchronously (Decision 2). The
+          // reentrancy guard lives HERE, not "on the tx" — underlying adapters
+          // decide what `tx` is (the expo adapter passes the outer adapter
+          // itself as `tx`; see below), so core must inject the guard.
+          return db.withTransactionAsync((tx) =>
+            fn(guardReentrancy(tx))
+          );
+        })
+        // Name the failure and lift the SQLite code (Decision 4), but do NOT
+        // re-wrap errors that are already domain errors thrown from inside the
+        // callback (Decision 4, error-passthrough) — those must reach callers
+        // with their original `instanceof` intact.
+        .catch((e) => {
+          throw isDriverError(e)
+            ? new WikiTransactionError('Transaction failed', { cause: e })
+            : e;
+        });
+
+      // Advance the tail. The next caller's leading `.catch()` absorbs any
+      // rejection, so a failed transaction never poisons the queue (see
+      // Decision 3's error-isolation test).
+      queue = run;
+      return run;
+    },
+  };
+}
+
+// Reentrancy guard: same object, withTransactionAsync overridden to throw.
+function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
+  return {
+    ...tx,
+    withTransactionAsync() {
+      throw new Error(
+        'Nested withTransactionAsync is not supported: you are already ' +
+        'inside a transaction. Pass the current `tx` down instead of ' +
+        'opening a new transaction.'
+      );
+    },
+  };
+}
+```
+
+The queue holds a single promise chain; each resolved link is dropped as the
+tail advances, so V8/JSC reclaims settled transactions over a long-running app.
+
+> **Adapter contract — plain objects only.** The wrapper (and `guardReentrancy`)
+> use object spread (`{ ...db }`), which copies **own enumerable** properties only.
+> The expo adapter and the core test helper are plain object literals, so this is
+> correct. A future adapter authored as a **class instance** would lose its
+> prototype methods and `this` binding through the spread — adapters MUST be plain
+> objects, or the wrapper must be rewritten to delegate each method explicitly.
+>
+> **Expo `tx` aliasing.** `packages/expo/src/adapter.ts` passes the outer adapter
+> object itself as the `tx` argument (it wraps `expo-sqlite`'s own
+> `withTransactionAsync`, which supplies no per-tx handle). Core's re-wrap above
+> (`guardReentrancy(tx)`) makes this safe: whatever the adapter hands back, the
+> callback receives a handle whose `withTransactionAsync` throws.
+
+```ts
+// WikiMemory constructor
+this.db = withSerializedTransactions(db);
+```
+
+Rationale:
+
+- **Single chokepoint.** All 11 transaction call sites (services, repos, migrations)
+  receive the wrapped adapter through the constructor — no per-call-site changes.
+- **Fixes every adopter on every platform.** An app-level fix (e.g. dropping sync
+  concurrency to 1) would only fix one app; the race between two library entry points
+  is the library's bug.
+- **Non-transactional reads stay concurrent.** Only `withTransactionAsync` queues;
+  `getAllAsync`/`getFirstAsync` outside transactions are untouched, so read latency
+  is unaffected.
+- Errors propagate to the original caller; the internal chain swallows them only to
+  keep the queue alive (no unhandled-rejection noise, no head-of-line poisoning).
+
+### 2. Reentrancy: nested `withTransactionAsync` throws a clear error
+
+The `tx: SQLiteAdapter` passed to a transaction callback structurally includes
+`withTransactionAsync`. Before this change, calling it inside a callback produced the
+raw SQLite nested-`BEGIN` error; after this change it would deadlock against the
+mutex — strictly worse. Therefore core re-wraps the `tx` handed to callbacks
+(`guardReentrancy` in Decision 1) so its `withTransactionAsync` throws synchronously:
+
+> The guard is injected by `withSerializedTransactions`, **not** assumed to be
+> present on whatever `tx` the underlying adapter supplies. The expo adapter passes
+> the *outer adapter itself* as `tx` (it has no per-transaction handle), so a guard
+> that lived only in the adapter layer would be absent there; injecting it in core
+> covers every adapter uniformly.
+
+```
+Nested withTransactionAsync is not supported: you are already inside a
+transaction. Pass the current `tx` down instead of opening a new transaction.
+```
+
+- Audit confirms no core code nests today; this is a guard for future core code and
+  for adopters composing custom logic.
+- **Residual hazard (documented, not solved):** code inside a callback that calls
+  the *outer* wrapped `db.withTransactionAsync` (captured via closure/`this.db`)
+  rather than `tx` will deadlock — the mutex cannot distinguish a nested caller from
+  a concurrent one without AsyncLocalStorage, which React Native lacks. Mitigations,
+  layered:
+  1. **Reentrancy throw** covers the discoverable path (`tx`).
+  2. **Runtime deadlock warning** (Decision 1): a queued call that waits >10s emits a
+     loud `console.warn` naming the closure footgun — because an async deadlock freezes
+     silently with no thrown error, this is the only signal an adopter gets at runtime.
+     Fires **once per queued call** (the timer is cleared on lock acquisition, never
+     rescheduled), so a genuine multi-hour wedge logs one line, not a flood — the
+     signal is "something is wedged," and one line per stuck call carries it.
+  3. **Docs** state the rule ("inside a transaction callback, only ever use the `tx`
+     parameter").
+  4. **Static enforcement.** For this patch, a strict code-review convention keeps core
+     honest. A custom ESLint rule (`no-outer-db-in-tx-callback`) is authored as a
+     fast-follow to enforce this programmatically in CI — human review will eventually
+     miss a closure capture, and on React Native (no `AsyncLocalStorage`) that means a
+     silent, never-thrown deadlock, the worst class of bug to debug. See Out of Scope.
+
+### 3. Rollback guard: never let cleanup mask the original error
+
+Adapters that implement BEGIN/COMMIT/ROLLBACK manually (the core test helper at
+`packages/core/__tests__/helpers/sqliteAdapter.ts`, and any future Node adapter)
+must guard rollback:
+
+```ts
+} catch (e) {
+  try {
+    db.exec('ROLLBACK');
+  } catch {
+    // Connection may have no active transaction (BEGIN itself failed, or SQLite
+    // auto-rolled-back). Never mask the original error with a rollback error.
+  }
+  throw e;
+}
+```
+
+For `expo-llm-wiki`, BEGIN/ROLLBACK live inside `expo-sqlite`'s own
+`withTransactionAsync` and cannot be patched from the adapter. This is acceptable:
+with core-level serialization (Decision 1), a failed `BEGIN` due to concurrency can
+no longer occur, which removes the trigger for the misleading
+`cannot rollback - no transaction is active` error in practice. The spec makes this
+dependency explicit rather than pretending the adapter can fix it.
+
+### 4. Wedge visibility: name transaction errors
+
+Transaction failures currently surface as raw `Error: Error code 1: …` with no
+indication of which wiki operation opened the transaction. Core wraps transaction
+execution errors in a typed error carrying the original as `cause`:
+
+```ts
+export class WikiTransactionError extends Error {
+  /** Best-effort SQLite code lifted from the driver error, e.g. 'SQLITE_BUSY'. */
+  readonly sqliteErrorCode?: string;
+  constructor(message: string, options: { cause: unknown }) {
+    super(message, options);
+    this.name = 'WikiTransactionError';
+    this.sqliteErrorCode = extractSqliteCode(options.cause);
+  }
+}
+
+// Shared driver-error detection + code extraction. `isDriverError` gates whether
+// the wrapper re-wraps (Decision 4 passthrough); `extractSqliteCode` populates
+// `sqliteErrorCode`. Both are best-effort and driver-specific.
+//
+//   better-sqlite3: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
+//   expo-sqlite:    err.message starts with 'Error code N: …' (numeric)
+function extractSqliteCode(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const { code, message } = err as { code?: unknown; message?: unknown };
+  // better-sqlite3 and node:sqlite expose a string `SQLITE_*` code.
+  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
+  // expo-sqlite embeds a numeric code in the message.
+  if (typeof message === 'string') {
+    const m = /^Error code (\d+):/.exec(message);
+    if (m) return `SQLITE_${m[1]}`;
+  }
+  return undefined;
+}
+
+export function isDriverError(err: unknown): boolean {
+  return extractSqliteCode(err) !== undefined;
+}
+```
+
+`isDriverError` is defined as "a SQLite code could be extracted." This deliberately
+couples the two: an error the wrapper wraps is exactly an error it can attach a
+`sqliteErrorCode` to. A driver error whose code we *cannot* parse (neither shape
+matches) falls through to passthrough — it reaches the caller unwrapped rather than
+being wrapped with an empty `sqliteErrorCode`. Acceptable: the only errors that must be
+wrapped for observability are the ones we can classify anyway.
+
+- Thrown by the serialized wrapper **only when the rejection is a driver error**
+  (nested-`BEGIN`, `SQLITE_BUSY`, constraint violation — anything raised by the SQLite
+  layer). Message includes nothing entity-specific (the wrapper has no context) but
+  gives adopters a stable `instanceof` target, mirroring the existing `WikiBusyError`
+  pattern already consumed by hosts.
+- **Error passthrough for domain errors.** A callback runs arbitrary core logic that
+  may throw its own typed errors (validation failures, `WikiBusyError`, etc.). The
+  wrapper must **not** re-wrap those — they reach the caller with their original
+  `instanceof` intact, or existing suites that catch them break. Discrimination is via
+  `isDriverError(e)`: true only when `e` carries a SQLite code (`cause.code` on
+  better-sqlite3, an `Error code N` prefix on expo-sqlite). Everything else rethrows
+  untouched. This is what keeps "existing suites pass unchanged" true.
+- **Error code lifted to the top level.** The constructor extracts the SQLite code
+  from the driver error (`cause.code` on better-sqlite3, the parsed `Error code N`
+  prefix on expo-sqlite) and exposes it as `sqliteErrorCode` when present. This lets
+  observability pipelines (Sentry/Datadog) group by `SQLITE_BUSY` vs. a constraint
+  violation without brittle recursive `error.cause` inspection. Extraction is
+  driver-specific and best-effort — absent when the code can't be determined.
+- Callers with context (e.g. `setOntologyManifest`) keep their existing
+  message-enrichment behavior; the `cause` chain now bottoms out at the driver error
+  instead of a rollback red herring.
+
+### 5. Docs ship with the code change
+
+Documentation lands in the same commit as the fix — not as a lagging follow-up.
+
+**a. README Concurrency section** (both `core-llm-wiki` and `expo-llm-wiki`):
+
+- "All write APIs are safe to call from concurrent async contexts; transactions are
+  serialized internally on the single database connection."
+- "Inside a transaction callback, only use the provided `tx` — never the outer
+  database handle."
+- One connection per database file per process remains the supported topology
+  (unchanged; now stated).
+
+This is an adoption selling point, not just documentation of a fix.
+
+**b. `WikiTransactionError` in the error-handling docs.** Document alongside the
+existing `WikiBusyError`: the stable `instanceof` target, the `cause` chain (bottoms
+out at the driver error), and the best-effort `sqliteErrorCode`. Adopters wiring
+Sentry/Datadog need this to know what to catch and group on.
+
+**c. JSDoc on `withTransactionAsync`.** The reentrancy rule ("use the `tx` parameter,
+never the outer database handle") goes on the method signature, not just in prose — so
+it surfaces on editor hover, at the exact call site where the closure footgun (Decision
+2) is written.
+
+### 6. Adapter follow-up (out of this patch): `withExclusiveTransactionAsync`
+
+`expo-sqlite` offers `withExclusiveTransactionAsync`, which runs the transaction on
+an isolated connection and would additionally protect against non-wiki writes on the
+shared handle interleaving with wiki transactions. Deliberately **not** in this
+patch:
+
+- Behavior on `expo-sqlite` web (wa-sqlite/OPFS) needs verification first.
+- It changes isolation semantics (separate connection = separate snapshot), which
+  needs its own test pass.
+
+Tracked as a follow-up investigation; Decision 1 alone closes the production defect.
+
+---
+
+## Test Plan
+
+New suite `packages/core/__tests__/transactionSerialization.test.ts`:
+
+1. **Concurrent-writes regression (the production repro).**
+   `Promise.all` of overlapping `importDump`, `setOntologyManifest`, and `write`
+   calls against one `WikiMemory` over the better-sqlite3 test adapter. Without
+   Decision 1 this reproduces `cannot start a transaction within a transaction`
+   (better-sqlite3 raises the same SQLite error 1); with it, all resolve and
+   post-conditions hold (manifest persisted, dump imported, entry written).
+2. **Serialization order.** Instrumented adapter asserts no `BEGIN` is issued while
+   another transaction is open (depth counter never exceeds 1).
+3. **Error isolation / poison pill.** `Promise.all([A, B, C])` enqueued together, where
+   `B` throws a fatal **driver** error mid-callback. Assert: `A` commits, `B` rejects
+   with `WikiTransactionError` (original error as `cause`, `sqliteErrorCode` populated
+   when the driver supplies one), and `C` still executes and commits. Proves a rejection
+   neither stalls the queue nor bleeds into a sibling.
+3b. **Domain-error passthrough.** A callback throws a non-driver error (e.g. a plain
+   `Error` or a `WikiBusyError`). Assert the caller receives it **unwrapped** — same
+   `instanceof`, not a `WikiTransactionError` — and the queue still advances for the
+   next caller. Guards the `isDriverError` discrimination (Decision 4).
+4. **Reentrancy guard.** Calling `tx.withTransactionAsync` inside a callback throws
+   the descriptive error synchronously; outer transaction still rolls back cleanly.
+5. **Rollback guard.** Test-helper adapter: force `BEGIN` to fail; assert the surfaced
+   error is the `BEGIN` failure, not `cannot rollback - no transaction is active`.
+6. **Reads unaffected (interleaving).** Open a transaction whose callback holds open
+   via a `setTimeout`-gated promise; concurrently fire a `getAllAsync` outside any
+   transaction. Assert the read resolves **before** the transaction settles — proving
+   the wrapper serializes `withTransactionAsync` only and has not accidentally queued
+   non-transactional reads. Keep the `setTimeout` gate comfortably long (e.g. ≥50ms)
+   so the ordering assertion can't flake on a slow CI box with the synchronous
+   better-sqlite3 driver.
+
+Existing suites (`WikiMemory.test.ts`, `write.test.ts`, `ingest.test.ts`,
+`okfStorageConformance.test.ts`, integration package) must pass unchanged — the
+wrapper is behavior-preserving for sequential callers.
+
+---
+
+## Release
+
+- Commit `fix(core): serialize transactions on the shared connection` → semantic-release
+  cuts a patch on `core-llm-wiki`; `expo-llm-wiki` picks it up via dependency bump (test
+  helper + README changes ride along). Changelog and version bumps are auto-generated by
+  semantic-release — not hand-edited.
+- Put the production symptom strings (`cannot start a transaction within a transaction`,
+  `cannot rollback - no transaction is active`) in the commit body so they land in the
+  generated changelog and adopters searching the error message find the fix.
+
+---
+
+## Out of Scope
+
+**Fast-follow to this patch:**
+
+- Custom ESLint rule `no-outer-db-in-tx-callback` enforcing transaction closure safety
+  (Decision 2) — flags references to `this.db` / the captured outer adapter inside a
+  `withTransactionAsync` callback. Tracked as a fast-follow chore; ships with the
+  convention + runtime warning in the meantime.
+
+**Handled in host-app specs (not these packages):**
+
+- Host-app fire-and-forget ontology bootstrap races in orchestration code
+  (logical race independent of this fix).
+- Shared Vertex AI text-generation helper (empty-response retry, `finishReason`
+  logging) for `summarizeText` / `wikiLlm` / heal functions.
+- `thinkingBudget` increases for wiki heal and librarian model calls.
+- `wikiLlm` degenerate `responseSchema: {type: OBJECT}`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -846,6 +846,31 @@ const adapter: SQLiteAdapter = {
 };
 ```
 
+## Concurrency
+
+All write APIs are safe to call from concurrent async contexts. Transactions are
+serialized internally on the single database connection — you never need to know that
+SQLite forbids nested `BEGIN`, and you never need to throttle callers yourself.
+
+- One connection per database file per process is the supported topology.
+- Non-transactional reads are **not** serialized, so read latency is unaffected.
+- Inside a transaction callback, use only the provided `tx` handle — never the outer
+  database handle. Using the outer handle deadlocks; opening a nested transaction throws.
+
+### `WikiTransactionError`
+
+Thrown when a SQLite driver error escapes a transaction (nested `BEGIN`,
+`SQLITE_BUSY`, constraint violation). Stable `instanceof` target for observability:
+
+- `error.cause` — the original driver error (the chain bottoms out here, not at a
+  rollback red herring).
+- `error.sqliteErrorCode` — best-effort SQLite code (e.g. `'SQLITE_BUSY'`), present
+  when it can be parsed. Group on this in Sentry/Datadog instead of inspecting
+  `error.cause` recursively.
+
+Domain errors thrown from your own callback logic (validation, `WikiBusyError`)
+pass through unwrapped with their original type intact.
+
 ## How It Works
 
 ```mermaid

--- a/packages/core/__tests__/WikiMemory.test.ts
+++ b/packages/core/__tests__/WikiMemory.test.ts
@@ -108,10 +108,11 @@ describe('WikiMemory (Facade Layer)', () => {
       await wiki.setup();
 
       expect(tableExistsSpy).toHaveBeenCalledWith('test_entries');
+      // this.db is the serialized wrapper (Object.create(mockDb)), not raw mockDb.
       expect(setMetaSpy).toHaveBeenCalledWith(
         'schema_version',
         String(CURRENT_SCHEMA_VERSION),
-        mockDb,
+        (wiki as unknown as { db: SQLiteAdapter }).db,
       );
     });
 

--- a/packages/core/__tests__/helpers/sqliteAdapter.ts
+++ b/packages/core/__tests__/helpers/sqliteAdapter.ts
@@ -33,7 +33,12 @@ export function openTestDatabase(): SQLiteAdapter {
         db.exec('COMMIT');
         return result;
       } catch (e) {
-        db.exec('ROLLBACK');
+        try {
+          db.exec('ROLLBACK');
+        } catch {
+          // Connection may have no active transaction (BEGIN itself failed, or SQLite
+          // auto-rolled-back). Never mask the original error with a rollback error.
+        }
         throw e;
       }
     },

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { extractSqliteCode, isDriverError } from '../src/db/serializedAdapter';
 import { WikiTransactionError } from '../src/types';
+import { guardReentrancy } from '../src/db/serializedAdapter';
+import type { SQLiteAdapter } from '../src/types';
+
+function fakeAdapter(): SQLiteAdapter {
+  return {
+    execAsync: async () => {},
+    runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+    getAllAsync: async () => [],
+    getFirstAsync: async () => null,
+    withTransactionAsync: async (fn) => fn(fakeAdapter()),
+    closeAsync: async () => {},
+  };
+}
 
 describe('extractSqliteCode', () => {
   it('reads the string SQLITE_ code from better-sqlite3 / node:sqlite errors', () => {
@@ -40,5 +53,18 @@ describe('WikiTransactionError', () => {
   it('leaves sqliteErrorCode undefined when the code cannot be parsed', () => {
     const err = new WikiTransactionError('Transaction failed', { cause: new Error('opaque') });
     expect(err.sqliteErrorCode).toBeUndefined();
+  });
+});
+
+describe('guardReentrancy', () => {
+  it('throws synchronously when withTransactionAsync is called on the guarded handle', () => {
+    const guarded = guardReentrancy(fakeAdapter());
+    expect(() => guarded.withTransactionAsync(async () => 1))
+      .toThrow(/Nested withTransactionAsync is not supported/);
+  });
+
+  it('leaves non-transactional methods intact', async () => {
+    const guarded = guardReentrancy(fakeAdapter());
+    await expect(guarded.getAllAsync('SELECT 1')).resolves.toEqual([]);
   });
 });

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -20,9 +20,13 @@ describe('extractSqliteCode', () => {
     expect(extractSqliteCode({ code: 'SQLITE_BUSY' })).toBe('SQLITE_BUSY');
   });
 
-  it('parses the numeric code from an expo-sqlite message', () => {
+  it('parses the numeric code from an expo-sqlite message and normalizes it to a symbolic name', () => {
     expect(extractSqliteCode({ message: 'Error code 1: cannot start a transaction within a transaction' }))
-      .toBe('SQLITE_1');
+      .toBe('SQLITE_ERROR');
+    expect(extractSqliteCode({ message: 'Error code 5: database is locked' }))
+      .toBe('SQLITE_BUSY');
+    expect(extractSqliteCode({ message: 'Error code 9999: unknown code' }))
+      .toBe('SQLITE_9999');
   });
 
   it('returns undefined for a non-driver error', () => {
@@ -188,11 +192,15 @@ describe('rollback guard', () => {
       closeAsync: async () => { db.close(); },
     };
 
-    await expect(adapter.withTransactionAsync(async () => 1))
-      .rejects.toThrow(/within a transaction/);
+    let caught: unknown;
+    try {
+      await adapter.withTransactionAsync(async () => 1);
+    } catch (e) {
+      caught = e;
+    }
+    expect((caught as Error).message).toMatch(/within a transaction/);
     // The masking error must NOT surface:
-    await expect(adapter.withTransactionAsync(async () => 1))
-      .rejects.not.toThrow(/cannot rollback/);
+    expect((caught as Error).message).not.toMatch(/cannot rollback/);
   });
 });
 

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { extractSqliteCode, isDriverError } from '../src/db/serializedAdapter';
+
+describe('extractSqliteCode', () => {
+  it('reads the string SQLITE_ code from better-sqlite3 / node:sqlite errors', () => {
+    expect(extractSqliteCode({ code: 'SQLITE_BUSY' })).toBe('SQLITE_BUSY');
+  });
+
+  it('parses the numeric code from an expo-sqlite message', () => {
+    expect(extractSqliteCode({ message: 'Error code 1: cannot start a transaction within a transaction' }))
+      .toBe('SQLITE_1');
+  });
+
+  it('returns undefined for a non-driver error', () => {
+    expect(extractSqliteCode(new Error('validation failed'))).toBeUndefined();
+    expect(extractSqliteCode(null)).toBeUndefined();
+    expect(extractSqliteCode('nope')).toBeUndefined();
+  });
+});
+
+describe('isDriverError', () => {
+  it('is true only when a SQLite code can be extracted', () => {
+    expect(isDriverError({ code: 'SQLITE_BUSY' })).toBe(true);
+    expect(isDriverError({ message: 'Error code 5: database is locked' })).toBe(true);
+    expect(isDriverError(new Error('validation failed'))).toBe(false);
+  });
+});

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -137,3 +137,28 @@ describe('withSerializedTransactions', () => {
       .rejects.toThrow(/Nested withTransactionAsync is not supported/);
   });
 });
+
+describe('WikiMemory concurrent writes (production repro)', () => {
+  it('resolves overlapping write / setOntologyManifest / write without SQLite error 1', async () => {
+    const { WikiMemory } = await import('../src/WikiMemory');
+    const { openTestDatabase } = await import('./helpers/sqliteAdapter');
+    const wiki = new WikiMemory(openTestDatabase(), {
+      llmProvider: { generateText: async () => '{}' },
+    });
+    await wiki.setup();
+
+    // Overlapping write paths that each open their own transaction.
+    await expect(Promise.all([
+      wiki.write('alice', { event_type: 'observation', summary: 'Alice likes tea' }),
+      wiki.setOntologyManifest('alice', {
+        node_types: [{ type: 'Person', description: 'a person' }],
+        edge_types: [],
+      }),
+      wiki.write('bob', { event_type: 'observation', summary: 'Bob likes coffee' }),
+    ])).resolves.toBeDefined();
+
+    // Post-conditions hold.
+    const manifest = await wiki.getOntologyManifest('alice');
+    expect(manifest?.manifest.node_types.map((n) => n.type)).toContain('Person');
+  });
+});

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -162,3 +162,36 @@ describe('WikiMemory concurrent writes (production repro)', () => {
     expect(manifest?.manifest.node_types.map((n) => n.type)).toContain('Person');
   });
 });
+
+describe('rollback guard', () => {
+  it('surfaces the BEGIN failure, not "cannot rollback - no transaction is active"', async () => {
+    const Database = (await import('better-sqlite3')).default;
+    const db = new Database(':memory:');
+    db.exec('BEGIN'); // leave a transaction already open so the next BEGIN fails
+
+    const adapter: SQLiteAdapter = {
+      execAsync: async (sql) => { db.exec(sql); },
+      runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+      getAllAsync: async () => [],
+      getFirstAsync: async () => null,
+      async withTransactionAsync(fn) {
+        db.exec('BEGIN'); // throws: cannot start a transaction within a transaction
+        try {
+          const r = await fn(adapter);
+          db.exec('COMMIT');
+          return r;
+        } catch (e) {
+          try { db.exec('ROLLBACK'); } catch { /* never mask the original */ }
+          throw e;
+        }
+      },
+      closeAsync: async () => { db.close(); },
+    };
+
+    await expect(adapter.withTransactionAsync(async () => 1))
+      .rejects.toThrow(/within a transaction/);
+    // The masking error must NOT surface:
+    await expect(adapter.withTransactionAsync(async () => 1))
+      .rejects.not.toThrow(/cannot rollback/);
+  });
+});

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { extractSqliteCode, isDriverError } from '../src/db/serializedAdapter';
+import { WikiTransactionError } from '../src/types';
 
 describe('extractSqliteCode', () => {
   it('reads the string SQLITE_ code from better-sqlite3 / node:sqlite errors', () => {
@@ -23,5 +24,21 @@ describe('isDriverError', () => {
     expect(isDriverError({ code: 'SQLITE_BUSY' })).toBe(true);
     expect(isDriverError({ message: 'Error code 5: database is locked' })).toBe(true);
     expect(isDriverError(new Error('validation failed'))).toBe(false);
+  });
+});
+
+describe('WikiTransactionError', () => {
+  it('carries the cause and lifts the SQLite code to the top level', () => {
+    const cause = { code: 'SQLITE_BUSY', message: 'db is busy' };
+    const err = new WikiTransactionError('Transaction failed', { cause });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('WikiTransactionError');
+    expect(err.cause).toBe(cause);
+    expect(err.sqliteErrorCode).toBe('SQLITE_BUSY');
+  });
+
+  it('leaves sqliteErrorCode undefined when the code cannot be parsed', () => {
+    const err = new WikiTransactionError('Transaction failed', { cause: new Error('opaque') });
+    expect(err.sqliteErrorCode).toBeUndefined();
   });
 });

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -195,3 +195,29 @@ describe('rollback guard', () => {
       .rejects.not.toThrow(/cannot rollback/);
   });
 });
+
+describe('reads are not serialized', () => {
+  it('a getAllAsync outside a transaction resolves before a long-held transaction settles', async () => {
+    const order: string[] = [];
+    const base: SQLiteAdapter = {
+      execAsync: async () => {},
+      runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+      getAllAsync: async () => { order.push('read'); return []; },
+      getFirstAsync: async () => null,
+      async withTransactionAsync(fn) { return fn(base); },
+      closeAsync: async () => {},
+    };
+    const db = withSerializedTransactions(base);
+
+    // Long-running transaction gated by a ≥50ms timeout (comfortable margin vs CI jitter).
+    const txDone = db.withTransactionAsync(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      order.push('tx');
+    });
+    // Concurrent read outside any transaction.
+    await db.getAllAsync('SELECT 1');
+
+    await txDone;
+    expect(order).toEqual(['read', 'tx']);
+  });
+});

--- a/packages/core/__tests__/transactionSerialization.test.ts
+++ b/packages/core/__tests__/transactionSerialization.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { extractSqliteCode, isDriverError } from '../src/db/serializedAdapter';
 import { WikiTransactionError } from '../src/types';
-import { guardReentrancy } from '../src/db/serializedAdapter';
+import { guardReentrancy, withSerializedTransactions } from '../src/db/serializedAdapter';
 import type { SQLiteAdapter } from '../src/types';
 
 function fakeAdapter(): SQLiteAdapter {
@@ -66,5 +66,74 @@ describe('guardReentrancy', () => {
   it('leaves non-transactional methods intact', async () => {
     const guarded = guardReentrancy(fakeAdapter());
     await expect(guarded.getAllAsync('SELECT 1')).resolves.toEqual([]);
+  });
+});
+
+/** Adapter that tracks open-transaction depth and runs callbacks with a real BEGIN counter. */
+function instrumentedAdapter() {
+  const state = { depth: 0, maxDepth: 0 };
+  const adapter: SQLiteAdapter = {
+    execAsync: async () => {},
+    runAsync: async () => ({ changes: 0, lastInsertRowId: 0 }),
+    getAllAsync: async () => [],
+    getFirstAsync: async () => null,
+    async withTransactionAsync(fn) {
+      state.depth += 1;
+      state.maxDepth = Math.max(state.maxDepth, state.depth);
+      try {
+        // Yield so overlapping callers would interleave if not serialized.
+        await new Promise((r) => setTimeout(r, 5));
+        return await fn(adapter);
+      } finally {
+        state.depth -= 1;
+      }
+    },
+    closeAsync: async () => {},
+  };
+  return { adapter, state };
+}
+
+describe('withSerializedTransactions', () => {
+  it('never opens two transactions concurrently (depth never exceeds 1)', async () => {
+    const { adapter, state } = instrumentedAdapter();
+    const db = withSerializedTransactions(adapter);
+    await Promise.all([
+      db.withTransactionAsync(async () => 'a'),
+      db.withTransactionAsync(async () => 'b'),
+      db.withTransactionAsync(async () => 'c'),
+    ]);
+    expect(state.maxDepth).toBe(1);
+  });
+
+  it('isolates failures: a rejected transaction does not poison the queue', async () => {
+    const { adapter } = instrumentedAdapter();
+    const db = withSerializedTransactions(adapter);
+    const results = await Promise.allSettled([
+      db.withTransactionAsync(async () => 'A'),
+      db.withTransactionAsync(async () => { throw { code: 'SQLITE_BUSY', message: 'busy' }; }),
+      db.withTransactionAsync(async () => 'C'),
+    ]);
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 'A' });
+    expect(results[1].status).toBe('rejected');
+    expect((results[1] as PromiseRejectedResult).reason.name).toBe('WikiTransactionError');
+    expect((results[1] as PromiseRejectedResult).reason.sqliteErrorCode).toBe('SQLITE_BUSY');
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 'C' });
+  });
+
+  it('passes domain (non-driver) errors through unwrapped', async () => {
+    const { adapter } = instrumentedAdapter();
+    const db = withSerializedTransactions(adapter);
+    class DomainError extends Error {}
+    await expect(db.withTransactionAsync(async () => { throw new DomainError('nope'); }))
+      .rejects.toBeInstanceOf(DomainError);
+    // Queue still advances:
+    await expect(db.withTransactionAsync(async () => 'after')).resolves.toBe('after');
+  });
+
+  it('throws the reentrancy error when the callback opens a nested transaction', async () => {
+    const { adapter } = instrumentedAdapter();
+    const db = withSerializedTransactions(adapter);
+    await expect(db.withTransactionAsync(async (tx) => tx.withTransactionAsync(async () => 1)))
+      .rejects.toThrow(/Nested withTransactionAsync is not supported/);
   });
 });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -1,6 +1,7 @@
 import type { SQLiteAdapter } from './types';
 import type { WikiOutboxEvent } from './outbox/types';
 import { setupDatabase } from './db/schema';
+import { withSerializedTransactions } from './db/serializedAdapter';
 import { MIGRATIONS, CURRENT_SCHEMA_VERSION } from './db/migrations';
 import {
   WikiOptions,
@@ -76,7 +77,9 @@ export class WikiMemory {
   private graphTraversalService: GraphTraversalService;
 
   constructor(db: SQLiteAdapter, options: WikiOptions) {
-    this.db = db;
+    // Serialize transactions on the single shared connection before the adapter
+    // reaches any repository or service. See docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md.
+    this.db = withSerializedTransactions(db);
     this.options = options;
     this.prefix = options.config?.tablePrefix ?? 'llm_wiki_';
     if (!TABLE_PREFIX_PATTERN.test(this.prefix)) {
@@ -85,12 +88,12 @@ export class WikiMemory {
           `Must match ${TABLE_PREFIX_PATTERN} (letter, then alphanumeric/underscore, ending in "_", max 32 chars total).`,
       );
     }
-    this.outboxRepo = new OutboxRepository(db, this.prefix, !!options.config?.enableOutbox);
-    this.entryRepo = new EntryRepository(db, this.prefix, this.outboxRepo);
-    this.taskRepo = new TaskRepository(db, this.prefix, this.outboxRepo);
-    this.eventRepo = new EventRepository(db, this.prefix);
-    this.edgeRepo = new EdgeRepository(db, this.prefix);
-    this.metadataRepo = new MetadataRepository(db, this.prefix);
+    this.outboxRepo = new OutboxRepository(this.db, this.prefix, !!options.config?.enableOutbox);
+    this.entryRepo = new EntryRepository(this.db, this.prefix, this.outboxRepo);
+    this.taskRepo = new TaskRepository(this.db, this.prefix, this.outboxRepo);
+    this.eventRepo = new EventRepository(this.db, this.prefix);
+    this.edgeRepo = new EdgeRepository(this.db, this.prefix);
+    this.metadataRepo = new MetadataRepository(this.db, this.prefix);
     this.ontologyService = new OntologyService(
       this.metadataRepo,
       this.edgeRepo,

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -30,7 +30,7 @@ import { OntologyService } from './services/OntologyService';
 import { GraphTraversalService } from './services/GraphTraversalService';
 import type { OntologyManifest, OntologyMode, GraphTraversalOptions, GraphNeighborhood } from './types';
 
-export { WikiBusyError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER } from './types';
+export { WikiBusyError, WikiTransactionError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER } from './types';
 
 const TABLE_PREFIX_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,30}_$/;
 

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -2,9 +2,31 @@ import type { SQLiteAdapter } from '../types';
 import { WikiTransactionError } from '../types';
 
 /**
+ * SQLite primary result codes → symbolic name (https://sqlite.org/rescode.html),
+ * so a numeric expo-sqlite code normalizes to the same shape as the string codes
+ * better-sqlite3 / node:sqlite already report (e.g. both become 'SQLITE_BUSY').
+ */
+const SQLITE_RESULT_CODE_NAMES: Record<number, string> = {
+  1: 'SQLITE_ERROR', 2: 'SQLITE_INTERNAL', 3: 'SQLITE_PERM', 4: 'SQLITE_ABORT',
+  5: 'SQLITE_BUSY', 6: 'SQLITE_LOCKED', 7: 'SQLITE_NOMEM', 8: 'SQLITE_READONLY',
+  9: 'SQLITE_INTERRUPT', 10: 'SQLITE_IOERR', 11: 'SQLITE_CORRUPT', 12: 'SQLITE_NOTFOUND',
+  13: 'SQLITE_FULL', 14: 'SQLITE_CANTOPEN', 15: 'SQLITE_PROTOCOL', 16: 'SQLITE_EMPTY',
+  17: 'SQLITE_SCHEMA', 18: 'SQLITE_TOOBIG', 19: 'SQLITE_CONSTRAINT', 20: 'SQLITE_MISMATCH',
+  21: 'SQLITE_MISUSE', 22: 'SQLITE_NOLFS', 23: 'SQLITE_AUTH', 24: 'SQLITE_FORMAT',
+  25: 'SQLITE_RANGE', 26: 'SQLITE_NOTADB', 27: 'SQLITE_NOTICE', 28: 'SQLITE_WARNING',
+  100: 'SQLITE_ROW', 101: 'SQLITE_DONE',
+};
+
+/** Falls back to `SQLITE_<n>` for a result code outside the known table. */
+function nameForSqliteResultCode(n: number): string {
+  return SQLITE_RESULT_CODE_NAMES[n] ?? `SQLITE_${n}`;
+}
+
+/**
  * Best-effort SQLite code extraction. Driver-specific:
  *   better-sqlite3 / node:sqlite: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
- *   expo-sqlite:                  err.message starts with 'Error code N: …' (numeric)
+ *   expo-sqlite:                  err.message starts with 'Error code N: …' (numeric,
+ *                                  normalized here to the same symbolic name)
  */
 export function extractSqliteCode(err: unknown): string | undefined {
   if (typeof err !== 'object' || err === null) return undefined;
@@ -12,7 +34,7 @@ export function extractSqliteCode(err: unknown): string | undefined {
   if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
   if (typeof message === 'string') {
     const m = /^Error code (\d+):/.exec(message);
-    if (m) return `SQLITE_${m[1]}`;
+    if (m) return nameForSqliteResultCode(Number(m[1]));
   }
   return undefined;
 }

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -27,21 +27,20 @@ export function isDriverError(err: unknown): boolean {
  * by the serialized wrapper onto the `tx` handed to every callback so a *nested*
  * transaction fails loudly instead of deadlocking against the mutex.
  *
- * Object-spread copies own enumerable properties only — adapters MUST be plain
- * object literals (the expo adapter and the core test helper are). A class-instance
- * adapter would lose its prototype methods here.
+ * Uses prototype delegation (`Object.create`) rather than object-spread so the
+ * override sits on a thin child object and every other method — own OR inherited
+ * from a class prototype — still resolves through the chain to the original adapter.
  */
 export function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
-  return {
-    ...tx,
-    withTransactionAsync() {
-      throw new Error(
-        'Nested withTransactionAsync is not supported: you are already ' +
-        'inside a transaction. Pass the current `tx` down instead of ' +
-        'opening a new transaction.'
-      );
-    },
+  const guarded = Object.create(tx) as SQLiteAdapter;
+  guarded.withTransactionAsync = function () {
+    throw new Error(
+      'Nested withTransactionAsync is not supported: you are already ' +
+      'inside a transaction. Pass the current `tx` down instead of ' +
+      'opening a new transaction.'
+    );
   };
+  return guarded;
 }
 
 const DEADLOCK_WARN_MS = 10_000;
@@ -54,9 +53,11 @@ const DEADLOCK_WARN_MS = 10_000;
  */
 export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
   let queue: Promise<unknown> = Promise.resolve();
-  return {
-    ...db,
-    withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+  // Prototype delegation keeps every non-overridden method (own or inherited from a
+  // class prototype) resolving through to the original adapter — object-spread would
+  // silently drop a class-instance adapter's prototype methods.
+  const wrapped = Object.create(db) as SQLiteAdapter;
+  wrapped.withTransactionAsync = function <T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
       // Warns if a call waits >10s for the lock — the signature of the closure-capture
       // deadlock (calling the outer `db` instead of `tx` inside a callback). Cleared the
       // instant the lock is acquired, so it measures queue wait only.
@@ -73,7 +74,9 @@ export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
         .then(() => {
           clearTimeout(warn);
           // Re-wrap the tx so a nested withTransactionAsync throws synchronously.
-          return db.withTransactionAsync((tx) => fn(guardReentrancy(tx)));
+          // Some adapters invoke the callback with no tx handle; fall back to the
+          // outer db (same connection). The guard still blocks nested transactions.
+          return db.withTransactionAsync((tx) => fn(guardReentrancy(tx ?? db)));
         })
         .catch((e) => {
           // Wrap only driver errors; domain errors reach the caller with instanceof intact.
@@ -84,6 +87,6 @@ export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
 
       queue = run; // advance the tail; next caller's leading .catch() absorbs this rejection
       return run as Promise<T>;
-    },
   };
+  return wrapped;
 }

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -1,43 +1,8 @@
 import type { SQLiteAdapter } from '../types';
 import { WikiTransactionError } from '../types';
+import { extractSqliteCode } from './sqliteCodes';
 
-/**
- * SQLite primary result codes → symbolic name (https://sqlite.org/rescode.html),
- * so a numeric expo-sqlite code normalizes to the same shape as the string codes
- * better-sqlite3 / node:sqlite already report (e.g. both become 'SQLITE_BUSY').
- */
-const SQLITE_RESULT_CODE_NAMES: Record<number, string> = {
-  1: 'SQLITE_ERROR', 2: 'SQLITE_INTERNAL', 3: 'SQLITE_PERM', 4: 'SQLITE_ABORT',
-  5: 'SQLITE_BUSY', 6: 'SQLITE_LOCKED', 7: 'SQLITE_NOMEM', 8: 'SQLITE_READONLY',
-  9: 'SQLITE_INTERRUPT', 10: 'SQLITE_IOERR', 11: 'SQLITE_CORRUPT', 12: 'SQLITE_NOTFOUND',
-  13: 'SQLITE_FULL', 14: 'SQLITE_CANTOPEN', 15: 'SQLITE_PROTOCOL', 16: 'SQLITE_EMPTY',
-  17: 'SQLITE_SCHEMA', 18: 'SQLITE_TOOBIG', 19: 'SQLITE_CONSTRAINT', 20: 'SQLITE_MISMATCH',
-  21: 'SQLITE_MISUSE', 22: 'SQLITE_NOLFS', 23: 'SQLITE_AUTH', 24: 'SQLITE_FORMAT',
-  25: 'SQLITE_RANGE', 26: 'SQLITE_NOTADB', 27: 'SQLITE_NOTICE', 28: 'SQLITE_WARNING',
-  100: 'SQLITE_ROW', 101: 'SQLITE_DONE',
-};
-
-/** Falls back to `SQLITE_<n>` for a result code outside the known table. */
-function nameForSqliteResultCode(n: number): string {
-  return SQLITE_RESULT_CODE_NAMES[n] ?? `SQLITE_${n}`;
-}
-
-/**
- * Best-effort SQLite code extraction. Driver-specific:
- *   better-sqlite3 / node:sqlite: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
- *   expo-sqlite:                  err.message starts with 'Error code N: …' (numeric,
- *                                  normalized here to the same symbolic name)
- */
-export function extractSqliteCode(err: unknown): string | undefined {
-  if (typeof err !== 'object' || err === null) return undefined;
-  const { code, message } = err as { code?: unknown; message?: unknown };
-  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
-  if (typeof message === 'string') {
-    const m = /^Error code (\d+):/.exec(message);
-    if (m) return nameForSqliteResultCode(Number(m[1]));
-  }
-  return undefined;
-}
+export { extractSqliteCode };
 
 /** True when `err` carries a parseable SQLite code — gates whether the wrapper re-wraps. */
 export function isDriverError(err: unknown): boolean {
@@ -45,24 +10,40 @@ export function isDriverError(err: unknown): boolean {
 }
 
 /**
+ * Returns an adapter with the given methods overridden, delegating everything else
+ * (own or class-prototype methods) to `target`.
+ *
+ * Uses a `Proxy` rather than `Object.create`/object-spread: delegated methods are
+ * bound to `target` before being returned, so their receiver (`this`) stays the
+ * original adapter instance. That keeps ES `#private` fields and `instanceof`/identity
+ * checks inside those methods working — `Object.create` would invoke them with the
+ * wrapper as `this` and break both.
+ */
+function withOverrides(target: SQLiteAdapter, overrides: Partial<SQLiteAdapter>): SQLiteAdapter {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (prop in overrides) return Reflect.get(overrides, prop, receiver);
+      const value = Reflect.get(obj, prop, obj);
+      return typeof value === 'function' ? value.bind(obj) : value;
+    },
+  }) as SQLiteAdapter;
+}
+
+/**
  * Returns the same adapter with `withTransactionAsync` overridden to throw. Injected
  * by the serialized wrapper onto the `tx` handed to every callback so a *nested*
  * transaction fails loudly instead of deadlocking against the mutex.
- *
- * Uses prototype delegation (`Object.create`) rather than object-spread so the
- * override sits on a thin child object and every other method — own OR inherited
- * from a class prototype — still resolves through the chain to the original adapter.
  */
 export function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
-  const guarded = Object.create(tx) as SQLiteAdapter;
-  guarded.withTransactionAsync = function () {
-    throw new Error(
-      'Nested withTransactionAsync is not supported: you are already ' +
-      'inside a transaction. Pass the current `tx` down instead of ' +
-      'opening a new transaction.'
-    );
-  };
-  return guarded;
+  return withOverrides(tx, {
+    withTransactionAsync() {
+      throw new Error(
+        'Nested withTransactionAsync is not supported: you are already ' +
+        'inside a transaction. Pass the current `tx` down instead of ' +
+        'opening a new transaction.'
+      );
+    },
+  });
 }
 
 const DEADLOCK_WARN_MS = 10_000;
@@ -75,11 +56,8 @@ const DEADLOCK_WARN_MS = 10_000;
  */
 export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
   let queue: Promise<unknown> = Promise.resolve();
-  // Prototype delegation keeps every non-overridden method (own or inherited from a
-  // class prototype) resolving through to the original adapter — object-spread would
-  // silently drop a class-instance adapter's prototype methods.
-  const wrapped = Object.create(db) as SQLiteAdapter;
-  wrapped.withTransactionAsync = function <T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+  return withOverrides(db, {
+    withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
       // Warns if a call waits >10s for the lock — the signature of the closure-capture
       // deadlock (calling the outer `db` instead of `tx` inside a callback). Cleared the
       // instant the lock is acquired, so it measures queue wait only.
@@ -109,6 +87,6 @@ export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
 
       queue = run; // advance the tail; next caller's leading .catch() absorbs this rejection
       return run as Promise<T>;
-  };
-  return wrapped;
+    },
+  });
 }

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -1,4 +1,5 @@
 import type { SQLiteAdapter } from '../types';
+import { WikiTransactionError } from '../types';
 
 /**
  * Best-effort SQLite code extraction. Driver-specific:
@@ -39,6 +40,50 @@ export function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
         'inside a transaction. Pass the current `tx` down instead of ' +
         'opening a new transaction.'
       );
+    },
+  };
+}
+
+const DEADLOCK_WARN_MS = 10_000;
+
+/**
+ * Wraps `withTransactionAsync` in a promise-chain mutex so transactions on the
+ * single shared connection run one at a time. Non-transactional reads/writes are
+ * untouched. Applied once in the WikiMemory constructor before the adapter reaches
+ * any repository or service.
+ */
+export function withSerializedTransactions(db: SQLiteAdapter): SQLiteAdapter {
+  let queue: Promise<unknown> = Promise.resolve();
+  return {
+    ...db,
+    withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+      // Warns if a call waits >10s for the lock — the signature of the closure-capture
+      // deadlock (calling the outer `db` instead of `tx` inside a callback). Cleared the
+      // instant the lock is acquired, so it measures queue wait only.
+      const warn = setTimeout(() => {
+        console.warn(
+          '[core-llm-wiki] Transaction queued >10s — possible deadlock. ' +
+          'Inside a transaction callback, use the `tx` parameter, never the ' +
+          'outer database handle.'
+        );
+      }, DEADLOCK_WARN_MS);
+
+      const run = queue
+        .catch(() => undefined) // proceed from a settled state; swallow prior outcome
+        .then(() => {
+          clearTimeout(warn);
+          // Re-wrap the tx so a nested withTransactionAsync throws synchronously.
+          return db.withTransactionAsync((tx) => fn(guardReentrancy(tx)));
+        })
+        .catch((e) => {
+          // Wrap only driver errors; domain errors reach the caller with instanceof intact.
+          throw isDriverError(e)
+            ? new WikiTransactionError('Transaction failed', { cause: e })
+            : e;
+        });
+
+      queue = run; // advance the tail; next caller's leading .catch() absorbs this rejection
+      return run as Promise<T>;
     },
   };
 }

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -1,0 +1,20 @@
+/**
+ * Best-effort SQLite code extraction. Driver-specific:
+ *   better-sqlite3 / node:sqlite: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
+ *   expo-sqlite:                  err.message starts with 'Error code N: …' (numeric)
+ */
+export function extractSqliteCode(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const { code, message } = err as { code?: unknown; message?: unknown };
+  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
+  if (typeof message === 'string') {
+    const m = /^Error code (\d+):/.exec(message);
+    if (m) return `SQLITE_${m[1]}`;
+  }
+  return undefined;
+}
+
+/** True when `err` carries a parseable SQLite code — gates whether the wrapper re-wraps. */
+export function isDriverError(err: unknown): boolean {
+  return extractSqliteCode(err) !== undefined;
+}

--- a/packages/core/src/db/serializedAdapter.ts
+++ b/packages/core/src/db/serializedAdapter.ts
@@ -1,3 +1,5 @@
+import type { SQLiteAdapter } from '../types';
+
 /**
  * Best-effort SQLite code extraction. Driver-specific:
  *   better-sqlite3 / node:sqlite: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
@@ -17,4 +19,26 @@ export function extractSqliteCode(err: unknown): string | undefined {
 /** True when `err` carries a parseable SQLite code — gates whether the wrapper re-wraps. */
 export function isDriverError(err: unknown): boolean {
   return extractSqliteCode(err) !== undefined;
+}
+
+/**
+ * Returns the same adapter with `withTransactionAsync` overridden to throw. Injected
+ * by the serialized wrapper onto the `tx` handed to every callback so a *nested*
+ * transaction fails loudly instead of deadlocking against the mutex.
+ *
+ * Object-spread copies own enumerable properties only — adapters MUST be plain
+ * object literals (the expo adapter and the core test helper are). A class-instance
+ * adapter would lose its prototype methods here.
+ */
+export function guardReentrancy(tx: SQLiteAdapter): SQLiteAdapter {
+  return {
+    ...tx,
+    withTransactionAsync() {
+      throw new Error(
+        'Nested withTransactionAsync is not supported: you are already ' +
+        'inside a transaction. Pass the current `tx` down instead of ' +
+        'opening a new transaction.'
+      );
+    },
+  };
 }

--- a/packages/core/src/db/sqliteCodes.ts
+++ b/packages/core/src/db/sqliteCodes.ts
@@ -1,0 +1,40 @@
+/**
+ * SQLite primary result codes → symbolic name (https://sqlite.org/rescode.html),
+ * so a numeric expo-sqlite code normalizes to the same shape as the string codes
+ * better-sqlite3 / node:sqlite already report (e.g. both become 'SQLITE_BUSY').
+ *
+ * Dependency-free leaf module: shared by `db/serializedAdapter.ts` and `types.ts`
+ * (via `WikiTransactionError`) so the mapping has a single source of truth.
+ */
+const SQLITE_RESULT_CODE_NAMES: Record<number, string> = {
+  1: 'SQLITE_ERROR', 2: 'SQLITE_INTERNAL', 3: 'SQLITE_PERM', 4: 'SQLITE_ABORT',
+  5: 'SQLITE_BUSY', 6: 'SQLITE_LOCKED', 7: 'SQLITE_NOMEM', 8: 'SQLITE_READONLY',
+  9: 'SQLITE_INTERRUPT', 10: 'SQLITE_IOERR', 11: 'SQLITE_CORRUPT', 12: 'SQLITE_NOTFOUND',
+  13: 'SQLITE_FULL', 14: 'SQLITE_CANTOPEN', 15: 'SQLITE_PROTOCOL', 16: 'SQLITE_EMPTY',
+  17: 'SQLITE_SCHEMA', 18: 'SQLITE_TOOBIG', 19: 'SQLITE_CONSTRAINT', 20: 'SQLITE_MISMATCH',
+  21: 'SQLITE_MISUSE', 22: 'SQLITE_NOLFS', 23: 'SQLITE_AUTH', 24: 'SQLITE_FORMAT',
+  25: 'SQLITE_RANGE', 26: 'SQLITE_NOTADB', 27: 'SQLITE_NOTICE', 28: 'SQLITE_WARNING',
+  100: 'SQLITE_ROW', 101: 'SQLITE_DONE',
+};
+
+/** Falls back to `SQLITE_<n>` for a result code outside the known table. */
+export function nameForSqliteResultCode(n: number): string {
+  return SQLITE_RESULT_CODE_NAMES[n] ?? `SQLITE_${n}`;
+}
+
+/**
+ * Best-effort SQLite code extraction. Driver-specific:
+ *   better-sqlite3 / node:sqlite: err.code === 'SQLITE_BUSY' (string, SQLITE_-prefixed)
+ *   expo-sqlite:                  err.message starts with 'Error code N: …' (numeric,
+ *                                  normalized here to the same symbolic name)
+ */
+export function extractSqliteCode(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const { code, message } = err as { code?: unknown; message?: unknown };
+  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
+  if (typeof message === 'string') {
+    const m = /^Error code (\d+):/.exec(message);
+    if (m) return nameForSqliteResultCode(Number(m[1]));
+  }
+  return undefined;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,12 @@ export interface SQLiteAdapter {
   runAsync(sql: string, params?: unknown[]): Promise<{ changes: number; lastInsertRowId: number }>;
   getAllAsync<T>(sql: string, params?: unknown[]): Promise<T[]>;
   getFirstAsync<T>(sql: string, params?: unknown[]): Promise<T | null>;
+  /**
+   * Runs `fn` inside a serialized transaction. Inside the callback, use ONLY the
+   * provided `tx` handle — never the outer database handle (captured via closure or
+   * `this.db`). Calling the outer handle deadlocks against the transaction mutex;
+   * calling `tx.withTransactionAsync` throws (nested transactions are unsupported).
+   */
   withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T>;
   closeAsync(): Promise<void>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -533,6 +533,23 @@ export class WikiTransactionError extends Error {
   }
 }
 
+/**
+ * SQLite primary result codes → symbolic name (https://sqlite.org/rescode.html), kept
+ * in sync with `SQLITE_RESULT_CODE_NAMES` in db/serializedAdapter.ts so a numeric
+ * expo-sqlite code normalizes to the same shape as the string codes better-sqlite3 /
+ * node:sqlite already report (e.g. both become 'SQLITE_BUSY').
+ */
+const SQLITE_RESULT_CODE_NAMES: Record<number, string> = {
+  1: 'SQLITE_ERROR', 2: 'SQLITE_INTERNAL', 3: 'SQLITE_PERM', 4: 'SQLITE_ABORT',
+  5: 'SQLITE_BUSY', 6: 'SQLITE_LOCKED', 7: 'SQLITE_NOMEM', 8: 'SQLITE_READONLY',
+  9: 'SQLITE_INTERRUPT', 10: 'SQLITE_IOERR', 11: 'SQLITE_CORRUPT', 12: 'SQLITE_NOTFOUND',
+  13: 'SQLITE_FULL', 14: 'SQLITE_CANTOPEN', 15: 'SQLITE_PROTOCOL', 16: 'SQLITE_EMPTY',
+  17: 'SQLITE_SCHEMA', 18: 'SQLITE_TOOBIG', 19: 'SQLITE_CONSTRAINT', 20: 'SQLITE_MISMATCH',
+  21: 'SQLITE_MISUSE', 22: 'SQLITE_NOLFS', 23: 'SQLITE_AUTH', 24: 'SQLITE_FORMAT',
+  25: 'SQLITE_RANGE', 26: 'SQLITE_NOTADB', 27: 'SQLITE_NOTICE', 28: 'SQLITE_WARNING',
+  100: 'SQLITE_ROW', 101: 'SQLITE_DONE',
+};
+
 /** Local copy of the driver-code extractor to keep types.ts free of a circular import. */
 function extractSqliteCodeForError(err: unknown): string | undefined {
   if (typeof err !== 'object' || err === null) return undefined;
@@ -540,7 +557,7 @@ function extractSqliteCodeForError(err: unknown): string | undefined {
   if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
   if (typeof message === 'string') {
     const m = /^Error code (\d+):/.exec(message);
-    if (m) return `SQLITE_${m[1]}`;
+    if (m) return SQLITE_RESULT_CODE_NAMES[Number(m[1])] ?? `SQLITE_${m[1]}`;
   }
   return undefined;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -510,6 +510,35 @@ export class WikiBusyError extends Error {
   }
 }
 
+/**
+ * Thrown by the serialized transaction wrapper when a SQLite driver error
+ * escapes a transaction callback (nested BEGIN, SQLITE_BUSY, constraint
+ * violation). Domain errors thrown from callback logic pass through unwrapped.
+ * Stable `instanceof` target for observability, mirroring {@link WikiBusyError}.
+ */
+export class WikiTransactionError extends Error {
+  /** Best-effort SQLite code lifted from the driver error, e.g. 'SQLITE_BUSY'. */
+  readonly sqliteErrorCode?: string;
+
+  constructor(message: string, options: { cause: unknown }) {
+    super(message, options);
+    this.name = 'WikiTransactionError';
+    this.sqliteErrorCode = extractSqliteCodeForError(options.cause);
+  }
+}
+
+/** Local copy of the driver-code extractor to keep types.ts free of a circular import. */
+function extractSqliteCodeForError(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null) return undefined;
+  const { code, message } = err as { code?: unknown; message?: unknown };
+  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
+  if (typeof message === 'string') {
+    const m = /^Error code (\d+):/.exec(message);
+    if (m) return `SQLITE_${m[1]}`;
+  }
+  return undefined;
+}
+
 export class PrunePartialFailureError extends Error {
   readonly deleted: number;
   readonly failedAt: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import { extractSqliteCode } from './db/sqliteCodes';
+
 /**
  * Platform-agnostic SQLite driver interface.
  * Each platform package (wiki-expo, wiki-react) provides an adapter
@@ -9,7 +11,10 @@ export interface SQLiteAdapter {
   getAllAsync<T>(sql: string, params?: unknown[]): Promise<T[]>;
   getFirstAsync<T>(sql: string, params?: unknown[]): Promise<T | null>;
   /**
-   * Runs `fn` inside a serialized transaction. Inside the callback, use ONLY the
+   * Runs `fn` inside a transaction. A bare adapter implementation is not required to
+   * serialize concurrent calls itself — `WikiMemory` wraps every adapter it's given in
+   * `withSerializedTransactions` (see `db/serializedAdapter.ts`), which is what makes
+   * transactions serialize in practice. Once wrapped, inside the callback use ONLY the
    * provided `tx` handle — never the outer database handle (captured via closure or
    * `this.db`). Calling the outer handle deadlocks against the transaction mutex;
    * calling `tx.withTransactionAsync` throws (nested transactions are unsupported).
@@ -529,37 +534,8 @@ export class WikiTransactionError extends Error {
   constructor(message: string, options: { cause: unknown }) {
     super(message, options);
     this.name = 'WikiTransactionError';
-    this.sqliteErrorCode = extractSqliteCodeForError(options.cause);
+    this.sqliteErrorCode = extractSqliteCode(options.cause);
   }
-}
-
-/**
- * SQLite primary result codes → symbolic name (https://sqlite.org/rescode.html), kept
- * in sync with `SQLITE_RESULT_CODE_NAMES` in db/serializedAdapter.ts so a numeric
- * expo-sqlite code normalizes to the same shape as the string codes better-sqlite3 /
- * node:sqlite already report (e.g. both become 'SQLITE_BUSY').
- */
-const SQLITE_RESULT_CODE_NAMES: Record<number, string> = {
-  1: 'SQLITE_ERROR', 2: 'SQLITE_INTERNAL', 3: 'SQLITE_PERM', 4: 'SQLITE_ABORT',
-  5: 'SQLITE_BUSY', 6: 'SQLITE_LOCKED', 7: 'SQLITE_NOMEM', 8: 'SQLITE_READONLY',
-  9: 'SQLITE_INTERRUPT', 10: 'SQLITE_IOERR', 11: 'SQLITE_CORRUPT', 12: 'SQLITE_NOTFOUND',
-  13: 'SQLITE_FULL', 14: 'SQLITE_CANTOPEN', 15: 'SQLITE_PROTOCOL', 16: 'SQLITE_EMPTY',
-  17: 'SQLITE_SCHEMA', 18: 'SQLITE_TOOBIG', 19: 'SQLITE_CONSTRAINT', 20: 'SQLITE_MISMATCH',
-  21: 'SQLITE_MISUSE', 22: 'SQLITE_NOLFS', 23: 'SQLITE_AUTH', 24: 'SQLITE_FORMAT',
-  25: 'SQLITE_RANGE', 26: 'SQLITE_NOTADB', 27: 'SQLITE_NOTICE', 28: 'SQLITE_WARNING',
-  100: 'SQLITE_ROW', 101: 'SQLITE_DONE',
-};
-
-/** Local copy of the driver-code extractor to keep types.ts free of a circular import. */
-function extractSqliteCodeForError(err: unknown): string | undefined {
-  if (typeof err !== 'object' || err === null) return undefined;
-  const { code, message } = err as { code?: unknown; message?: unknown };
-  if (typeof code === 'string' && code.startsWith('SQLITE_')) return code;
-  if (typeof message === 'string') {
-    const m = /^Error code (\d+):/.exec(message);
-    if (m) return SQLITE_RESULT_CODE_NAMES[Number(m[1])] ?? `SQLITE_${m[1]}`;
-  }
-  return undefined;
 }
 
 export class PrunePartialFailureError extends Error {

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -409,6 +409,20 @@ const memory = await wiki.read(
 
 For full details on `{{mustache}}` prompt templating and the strict distinction between global auto-runs and runtime overrides, see [Prompt Management & Overrides](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md#prompt-management--overrides) in `@equationalapplications/core-llm-wiki`.
 
+## Concurrency
+
+All write APIs are safe to call from concurrent async contexts. Transactions are
+serialized internally on the single database connection — you never need to know that
+SQLite forbids nested `BEGIN`, and you never need to throttle callers yourself.
+
+- One connection per database file per process is the supported topology.
+- Non-transactional reads are **not** serialized, so read latency is unaffected.
+- Inside a transaction callback, use only the provided `tx` handle — never the outer
+  database handle. Using the outer handle deadlocks; opening a nested transaction throws.
+
+Driver errors that escape a transaction surface as `WikiTransactionError` (re-exported
+from `@equationalapplications/core-llm-wiki`) with a top-level `sqliteErrorCode`.
+
 ## Monorepo Ecosystem
 
 | Package | Purpose |


### PR DESCRIPTION
## Summary
- Wrap the `SQLiteAdapter` in a promise-chain mutex (`withSerializedTransactions`) once in the `WikiMemory` constructor so all 11 transaction call sites serialize with no per-site change. Fixes the concurrent-write cascade: `cannot start a transaction within a transaction` → `cannot rollback - no transaction is active` → wedged connection.
- Inject a reentrancy guard onto every `tx` handle so a nested `withTransactionAsync` throws synchronously instead of deadlocking; a >10s queue wait logs a deadlock warning.
- Wrap escaping driver errors in a typed `WikiTransactionError` (with lifted `sqliteErrorCode`); domain errors pass through unwrapped with `instanceof` intact.
- Guard rollback in the test-helper adapter so a failed `BEGIN` never masks the original error.
- Document the concurrency contract + `WikiTransactionError` in core/expo READMEs and JSDoc.

Uses prototype delegation (`Object.create`) rather than object-spread in the wrapper so class-instance adapters keep their prototype methods.

## Test Plan
- [x] `packages/core` — 709 tests pass (new `transactionSerialization.test.ts` + all pre-existing)
- [x] Concurrent-write regression fails without the fix (`cannot start a transaction within a transaction`), passes with it
- [x] `packages/expo` — build + 10 tests pass
- [x] `packages/integration` — 37 tests pass
- [x] `packages/core` build type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)