### PR TITLE
feat(core): ontology backfill pass for untyped facts

### DIFF
--- a/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
+++ b/docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md
@@ -1,7 +1,7 @@
 # Spec: Transaction Serialization & Connection-Wedge Hardening
 
 **Date:** 2026-07-09
-**Status:** Approved
+**Status:** Implemented
 **Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (adapter + docs)
 
 ---

--- a/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
+++ b/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
@@ -90,8 +90,10 @@ findUntypedByEntityId(entityId: string, limit: number, recheckCutoff: number, tx
   //   AND (ontology_checked_at IS NULL OR ontology_checked_at <= ?)
   // ORDER BY updated_at ASC LIMIT ?
 countUntypedByEntityId(entityId: string, recheckCutoff: number, tx?: SQLiteAdapter): Promise<{ eligible: number; deferred: number }>
-updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter): Promise<void>
+updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter): Promise<{ changes: number }>
   // UPDATE ... SET okf_type = ? WHERE id = ? AND entity_id = ? AND okf_type IS NULL
+  // changes === 0 → the fact was typed concurrently between select and update
+  // (the okf_type IS NULL guard left it untouched); the caller skips it
 markOntologyChecked(ids: string[], entityId: string, now: number, tx: SQLiteAdapter): Promise<void>
   // UPDATE ... SET ontology_checked_at = ? WHERE id IN (…) AND entity_id = ?
   // NEVER touches updated_at — see Decision 3b
@@ -101,13 +103,14 @@ markOntologyChecked(ids: string[], entityId: string, now: number, tx: SQLiteAdap
   via `options.batchSize` for hosts whose LLM provider has tighter context limits.
   One LLM call per run, bounded cost. First-run backlogs (pre-ontology facts)
   converge across repeated triggers rather than bursting.
-- **Payload guard:** after selecting up to `batchSize` facts, drop trailing facts
-  once the accumulated `title + body` length exceeds
+- **Payload guard:** after selecting up to `batchSize` facts, add facts to the
+  batch only while the full serialized prompt (`systemPrompt` + `userPrompt`,
+  including the manifest, ids, tags, JSON syntax, and any override) stays within
   `ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS = 40_000`. Facts can be large (ingestion
   chunks run up to `maxChunkLength` ≈ 12k chars), and 25 dense facts could
   otherwise blow past a provider's context window or degrade instruction
   following. At least one fact is always sent (a single oversized fact is not
-  silently starved; the model sees it alone).
+  silently starved; the model sees it alone, even over the cap).
 - Oldest-first (`updated_at ASC`) so long-neglected facts are typed before recent
   ones and the queue drains deterministically. A useful side effect: facts created
   around the same time — the likely edge partners — cluster into the same batch.

--- a/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
+++ b/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
@@ -95,7 +95,7 @@ updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter):
   // changes === 0 → the fact was typed concurrently between select and update
   // (the okf_type IS NULL guard left it untouched); the caller skips it
 markOntologyChecked(ids: string[], entityId: string, now: number, tx: SQLiteAdapter): Promise<void>
-  // UPDATE ... SET ontology_checked_at = ? WHERE id IN (…) AND entity_id = ?
+  // UPDATE ... SET ontology_checked_at = ? WHERE id IN (…) AND entity_id = ? AND deleted_at IS NULL
   // NEVER touches updated_at — see Decision 3b
 ```
 
@@ -194,16 +194,19 @@ Inside `db.withTransactionAsync`:
 1. `getEffectiveState(entityId, tx)`; in emergent mode with `ontology_updates`
    present → `mergeEmergentUpdates` first (manifest grows before validation, same
    order as the librarian).
-2. Build the title index from **all live facts for the entity** via a new
+2. Build the title index from **all live typed facts for the entity** via a new
    lightweight `EntryRepository.findTitleIndexByEntityId(entityId, tx)` selecting
-   only `id, title, okf_type` (not `SELECT *`). The librarian's
+   only `id, title, okf_type` (not `SELECT *`), filtered to
+   `okf_type IS NOT NULL`. The librarian's
    `findRecentByEntityId(…, 100)` window is wrong here: it returns the 100 most
    *recently updated* facts, while the backfill batch is the *oldest* — an old
    fact's edge targets are its contemporaries, which a recent-100 window would
    miss and silently drop. Three columns across even thousands of local rows is
    cheap in SQLite. (Full breadth helps only *already-typed* targets — an untyped
-   out-of-batch target still fails the target-type check; those edges belong to
-   the deferred edge-backfill in Out of Scope. Oldest-first batching mitigates by
+   out-of-batch target still fails the target-type check, so untyped rows are
+   excluded from the SQL index outright; batch facts typed during the run are
+   re-added to the in-memory index. Deferred edges to untyped targets belong to
+   the edge-backfill in Out of Scope. Oldest-first batching mitigates by
    clustering contemporaries into the same batch.)
 3. Per classification: resolve the fact by `id` against the selected batch (unknown
    ids counted in `failedValidation`); `validateAndNormalizeFact` → canonical

--- a/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
+++ b/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
@@ -55,14 +55,19 @@ operation, not a scheduler, matching `runLibrarian` / `runHeal` / `runPrune`.
 // WikiMemory (delegates to MaintenanceService)
 async runOntologyBackfill(
   entityId: string,
-  options?: { promptOverride?: string },
+  options?: { promptOverride?: string; batchSize?: number },
 ): Promise<OntologyBackfillResult>
 
 export interface OntologyBackfillResult {
-  scanned: number;     // untyped facts sent to the model this run
-  typed: number;       // facts that received an okf_type
-  edgesAdded: number;  // edges persisted
-  remaining: number;   // untyped facts still in the store after this run
+  scanned: number;          // untyped facts sent to the model this run
+  typed: number;            // facts that received an okf_type
+  failedValidation: number; // returned by the model but rejected (unknown id,
+                            // non-manifest type, etc.); omissions are derivable
+                            // as scanned − typed − failedValidation
+  edgesAdded: number;       // edges persisted
+  remaining: number;        // untyped facts still ELIGIBLE after this run —
+                            // safe host convergence signal: loop while > 0
+  deferred: number;         // untyped facts in the recheck cooldown (Decision 3b)
 }
 ```
 
@@ -74,38 +79,80 @@ export interface OntologyBackfillResult {
 - `remaining` lets hosts implement their own convergence policy (re-trigger later,
   show progress) without the library baking in a loop.
 
-### 2. Selection: `okf_type IS NULL`, oldest first, batch of 25
+### 2. Selection: `okf_type IS NULL`, oldest first, bounded batch
 
 New repository methods:
 
 ```ts
 // EntryRepository
-findUntypedByEntityId(entityId: string, limit: number, tx?: SQLiteAdapter): Promise<WikiFact[]>
+findUntypedByEntityId(entityId: string, limit: number, recheckCutoff: number, tx?: SQLiteAdapter): Promise<WikiFact[]>
   // WHERE entity_id = ? AND okf_type IS NULL AND deleted_at IS NULL
+  //   AND (ontology_checked_at IS NULL OR ontology_checked_at <= ?)
   // ORDER BY updated_at ASC LIMIT ?
-countUntypedByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<number>
+countUntypedByEntityId(entityId: string, recheckCutoff: number, tx?: SQLiteAdapter): Promise<{ eligible: number; deferred: number }>
 updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter): Promise<void>
   // UPDATE ... SET okf_type = ? WHERE id = ? AND entity_id = ? AND okf_type IS NULL
+markOntologyChecked(ids: string[], entityId: string, now: number, tx: SQLiteAdapter): Promise<void>
+  // UPDATE ... SET ontology_checked_at = ? WHERE id IN (…) AND entity_id = ?
+  // NEVER touches updated_at — see Decision 3b
 ```
 
-- Batch size is a named constant `ONTOLOGY_BACKFILL_BATCH_SIZE = 25` — one LLM call
-  per run, bounded cost. First-run backlogs (pre-ontology facts) converge across
-  repeated triggers rather than bursting.
+- Batch size defaults to `ONTOLOGY_BACKFILL_BATCH_SIZE = 25`, overridable per call
+  via `options.batchSize` for hosts whose LLM provider has tighter context limits.
+  One LLM call per run, bounded cost. First-run backlogs (pre-ontology facts)
+  converge across repeated triggers rather than bursting.
+- **Payload guard:** after selecting up to `batchSize` facts, drop trailing facts
+  once the accumulated `title + body` length exceeds
+  `ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS = 40_000`. Facts can be large (ingestion
+  chunks run up to `maxChunkLength` ≈ 12k chars), and 25 dense facts could
+  otherwise blow past a provider's context window or degrade instruction
+  following. At least one fact is always sent (a single oversized fact is not
+  silently starved; the model sees it alone).
 - Oldest-first (`updated_at ASC`) so long-neglected facts are typed before recent
-  ones and the queue drains deterministically.
+  ones and the queue drains deterministically. A useful side effect: facts created
+  around the same time — the likely edge partners — cluster into the same batch.
 - `updateOkfType` guards `okf_type IS NULL` in the WHERE clause so a concurrent
   writer can never be overwritten — additive by construction, not by convention.
-- Facts whose type the model omits or that fail validation remain `NULL` and will
-  be re-selected next run. Acceptable: the model gets fresh manifest context each
-  time, and repeated hard failures surface in `scanned − typed` for host telemetry.
+
+### 3b. Recheck cooldown: skipped facts must not clog the queue
+
+Without bookkeeping, a fact the model consistently declines to type (malformed
+synced fact, or genuinely outside a strict manifest) sits at the head of the
+oldest-first queue forever, re-consuming tokens every run and eventually stalling
+the whole pipeline once `batchSize` such facts accumulate.
+
+**Mechanism:** new nullable `ontology_checked_at INTEGER` column on entries
+(migration follows the existing `ALTER TABLE ADD COLUMN` pattern with a
+column-existence guard, outside any explicit transaction — same as the `okf_type`
+migration). Every fact **scanned** in a run — typed or not — gets
+`ontology_checked_at = now` inside the write transaction. Selection skips facts
+checked within `ONTOLOGY_BACKFILL_RECHECK_MS = 7 days`.
+
+- Skipped facts re-enter the queue after the cooldown. In emergent mode this doubles
+  as the retry path for manifest growth: a fact unclassifiable today may fit after
+  new types emerge.
+- `remaining` counts only **eligible** untyped facts, so a host loop
+  (`while remaining > 0`) terminates even when unclassifiable facts exist;
+  `deferred` reports the cooled-down remainder for telemetry.
+
+**Rejected alternatives:**
+
+- *Bump `updated_at` on skip* — actively dangerous, not merely impure:
+  `ImportExportService.doImportEntity` merge resolution is last-write-wins on
+  `updated_at` (`if (merge && safeUpdatedAt <= existing.updated_at) continue`).
+  A backfill bump would make an unchanged local fact beat a genuinely newer
+  remote edit during sync.
+- *Sentinel `okf_type` (e.g. `unclassified`)* — `okf_type` flows into OKF export
+  and into `resolveAndPersistEdges`' manifest type checks; a non-manifest slug
+  breaks the "okf_type is a manifest slug" invariant everywhere it is read.
 
 ### 3. Early exits make the pass free when there is nothing to do
 
-`doRunOntologyBackfill` returns `{scanned: 0, typed: 0, edgesAdded: 0, remaining: 0}`
-without an LLM call when:
+`doRunOntologyBackfill` returns a zeroed result (`deferred` still reported) without
+an LLM call when:
 
 - ontology mode is `'off'` for the entity (via `getEffectiveState`), or
-- `findUntypedByEntityId` returns zero rows.
+- `findUntypedByEntityId` returns zero eligible rows.
 
 This is what makes an unconditional post-sync trigger in host apps viable: the
 common case (no server-agent writes since last sync) costs one SELECT.
@@ -144,23 +191,35 @@ Inside `db.withTransactionAsync`:
 1. `getEffectiveState(entityId, tx)`; in emergent mode with `ontology_updates`
    present → `mergeEmergentUpdates` first (manifest grows before validation, same
    order as the librarian).
-2. Build the title index from `findRecentByEntityId(entityId, 100, tx)` **plus the
-   batch facts themselves**, so edges may target other facts in the same batch.
+2. Build the title index from **all live facts for the entity** via a new
+   lightweight `EntryRepository.findTitleIndexByEntityId(entityId, tx)` selecting
+   only `id, title, okf_type` (not `SELECT *`). The librarian's
+   `findRecentByEntityId(…, 100)` window is wrong here: it returns the 100 most
+   *recently updated* facts, while the backfill batch is the *oldest* — an old
+   fact's edge targets are its contemporaries, which a recent-100 window would
+   miss and silently drop. Three columns across even thousands of local rows is
+   cheap in SQLite. (Full breadth helps only *already-typed* targets — an untyped
+   out-of-batch target still fails the target-type check; those edges belong to
+   the deferred edge-backfill in Out of Scope. Oldest-first batching mitigates by
+   clustering contemporaries into the same batch.)
 3. Per classification: resolve the fact by `id` against the selected batch (unknown
-   ids ignored); `validateAndNormalizeFact` → canonical `okf_type` or null; on
-   success `updateOkfType`, update the title index entry with the new type, and
-   queue edges.
+   ids counted in `failedValidation`); `validateAndNormalizeFact` → canonical
+   `okf_type` (on success `updateOkfType`, update the title index entry with the
+   new type, queue edges) or null (counted in `failedValidation`).
 4. After **all** classifications are applied: `resolveAndPersistEdges` per typed
    fact (existing duplicate-ignoring insert, existing source/target type checks
    against the manifest). Two-phase ordering matters — the target-type check reads
    `okf_type` from the title index, so intra-batch edges only resolve once every
    batch fact has its new type. Same apply-then-link ordering as the librarian's
    `pendingEdges`.
+5. `markOntologyChecked(scannedIds, entityId, now, tx)` — every scanned fact gets
+   its cooldown stamp, typed or not (Decision 3b). Never touches `updated_at`.
 
 After commit: `searchService.evictCache(entityId)`. No re-embed — title/body
 unchanged. No FTS re-sync — `okf_type` is not in the search index.
 
-`countUntypedByEntityId` after the write transaction supplies `remaining`.
+`countUntypedByEntityId` after the write transaction supplies
+`remaining` (eligible) and `deferred` (in cooldown).
 
 ### 6. Failure semantics
 
@@ -210,18 +269,37 @@ New suite `packages/core/__tests__/ontologyBackfill.test.ts`:
    node type used by a classification in the same response — assert merge happens
    first and the classification validates against the grown manifest.
 5. **Strict mode rejects unknown types.** Classification with a non-manifest type →
-   fact stays `NULL`, appears in `remaining`.
+   fact stays `NULL`, counted in `failedValidation`, cooldown-stamped (moves to
+   `deferred`, not `remaining`).
 6. **Batch cap.** 30 untyped facts, model types all it receives → exactly one LLM
    call carrying 25 facts (oldest first), `scanned = 25`, `remaining = 5`.
-7. **Intra-batch edges.** Two untyped facts in one batch, edge from one to the
+7. **Payload guard.** Facts with large bodies exceeding
+   `ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS` → batch truncated below `batchSize`; a
+   single oversized fact is still sent alone.
+8. **Intra-batch edges.** Two untyped facts in one batch, edge from one to the
    other via `target_title` — assert edge persists (title index includes batch).
-8. **Malformed model output.** Unparseable JSON → throws, lock released, no rows
-   changed; unknown fact ids → ignored without error.
-9. **Lock discipline.** Concurrent `runOntologyBackfill` throws `WikiBusyError`;
-   sequential run after completion succeeds.
+9. **Full title index breadth.** Old untyped fact proposes an edge to an old,
+   *already-typed* fact outside the recent-100 window (seed >100 newer facts) —
+   assert edge persists. Guards the recency-trap fix in Decision 5.
+10. **Recheck cooldown.** Run where the model omits a fact → immediate second run
+    selects nothing (`scanned = 0`, `deferred = 1`, no LLM call); after advancing
+    past `ONTOLOGY_BACKFILL_RECHECK_MS`, the fact is selected again. Host
+    convergence loop (`while remaining > 0`) terminates with unclassifiable facts
+    present.
+11. **Cooldown stamp never touches `updated_at`.** After a skip,
+    `updated_at` is byte-identical — guards the import-merge last-write-wins
+    hazard (Decision 3b).
+12. **Malformed model output.** Unparseable JSON → throws, lock released, no rows
+    changed (including no cooldown stamps); unknown fact ids → counted in
+    `failedValidation` without error.
+13. **Lock discipline.** Concurrent `runOntologyBackfill` throws `WikiBusyError`;
+    sequential run after completion succeeds.
 
 Existing suites must pass unchanged — the pass is opt-in and touches no existing
-code paths beyond additive repository methods and a new prompt export.
+code paths beyond additive repository methods, one additive schema migration
+(`ontology_checked_at`, nullable, no backfill of the column itself), and a new
+prompt export. Migration tests follow the existing migrations suite pattern
+(fresh DB + upgrade-from-previous-version both get the column).
 
 ---
 

--- a/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
+++ b/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
@@ -1,7 +1,7 @@
 # Spec: Ontology Backfill — Typing Facts That Bypassed the Librarian
 
 **Date:** 2026-07-13
-**Status:** Proposed
+**Status:** Implemented
 **Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (re-export + docs)
 
 ---

--- a/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
+++ b/docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md
@@ -1,0 +1,253 @@
+# Spec: Ontology Backfill — Typing Facts That Bypassed the Librarian
+
+**Date:** 2026-07-13
+**Status:** Proposed
+**Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (re-export + docs)
+
+---
+
+## Problem
+
+Facts that enter the store without passing through the librarian never receive
+`okf_type` or edges, and nothing ever revisits them. Two populations:
+
+1. **Synced-down remote facts.** Host apps with a server-side agent (e.g. Clanker's
+   cloud-agent `wiki_write`) insert finished facts into the remote store with no
+   ontology fields. `importDump` → `doImportEntity` is a pure transactional upsert —
+   no librarian pass — so these facts land locally untyped and unlinked, permanently.
+2. **Pre-ontology facts.** Every fact created before the ontology feature shipped
+   has `okf_type = NULL`.
+
+Consequence: the knowledge graph is systematically sparser than the fact store.
+`wiki_traverse_graph` cannot reach any of these facts, and the asymmetry grows with
+server-agent usage — the exact memories a cloud escalation deemed worth recording
+are the ones excluded from graph retrieval.
+
+The extraction pipeline itself is complete and proven
+(`MaintenanceService.doRunLibrarian`: `buildPromptContext` →
+`validateAndNormalizeFact` → `resolveAndPersistEdges` → `mergeEmergentUpdates`);
+it simply only runs on the live `write()` path. This spec adds a maintenance pass
+that runs the same typing machinery over already-persisted untyped facts.
+
+Naming note: **"backfill", not "orphan adoption"** — `orphanAfterDays` /
+`markOrphaned` in the heal pass already mean "aged, unaccessed facts", an unrelated
+concept.
+
+---
+
+## Solution
+
+New maintenance operation `runOntologyBackfill(entityId)` in core: select a bounded
+batch of live untyped facts, make one librarian-style LLM call proposing
+`okf_type` + edges per fact (and `ontology_updates` in emergent mode), validate
+through the existing ontology machinery, and update the facts **in place**. Strictly
+additive: never creates, deletes, or rewrites facts; never overwrites an existing
+`okf_type`. Host apps decide when to spend the call — the library provides the
+operation, not a scheduler, matching `runLibrarian` / `runHeal` / `runPrune`.
+
+---
+
+## Design Decisions
+
+### 1. Public API mirrors the existing maintenance surface
+
+```ts
+// WikiMemory (delegates to MaintenanceService)
+async runOntologyBackfill(
+  entityId: string,
+  options?: { promptOverride?: string },
+): Promise<OntologyBackfillResult>
+
+export interface OntologyBackfillResult {
+  scanned: number;     // untyped facts sent to the model this run
+  typed: number;       // facts that received an okf_type
+  edgesAdded: number;  // edges persisted
+  remaining: number;   // untyped facts still in the store after this run
+}
+```
+
+- Lock discipline identical to siblings: `runOntologyBackfill` acquires a JobManager
+  lock (new `OperationType` member `'ontologyBackfill'`), delegates to
+  `doRunOntologyBackfill`, releases in `finally`. Concurrent invocation throws
+  `WikiBusyError`; transactions serialize on the shared connection per the
+  2026-07-09 transaction-serialization spec.
+- `remaining` lets hosts implement their own convergence policy (re-trigger later,
+  show progress) without the library baking in a loop.
+
+### 2. Selection: `okf_type IS NULL`, oldest first, batch of 25
+
+New repository methods:
+
+```ts
+// EntryRepository
+findUntypedByEntityId(entityId: string, limit: number, tx?: SQLiteAdapter): Promise<WikiFact[]>
+  // WHERE entity_id = ? AND okf_type IS NULL AND deleted_at IS NULL
+  // ORDER BY updated_at ASC LIMIT ?
+countUntypedByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<number>
+updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter): Promise<void>
+  // UPDATE ... SET okf_type = ? WHERE id = ? AND entity_id = ? AND okf_type IS NULL
+```
+
+- Batch size is a named constant `ONTOLOGY_BACKFILL_BATCH_SIZE = 25` — one LLM call
+  per run, bounded cost. First-run backlogs (pre-ontology facts) converge across
+  repeated triggers rather than bursting.
+- Oldest-first (`updated_at ASC`) so long-neglected facts are typed before recent
+  ones and the queue drains deterministically.
+- `updateOkfType` guards `okf_type IS NULL` in the WHERE clause so a concurrent
+  writer can never be overwritten — additive by construction, not by convention.
+- Facts whose type the model omits or that fail validation remain `NULL` and will
+  be re-selected next run. Acceptable: the model gets fresh manifest context each
+  time, and repeated hard failures surface in `scanned − typed` for host telemetry.
+
+### 3. Early exits make the pass free when there is nothing to do
+
+`doRunOntologyBackfill` returns `{scanned: 0, typed: 0, edgesAdded: 0, remaining: 0}`
+without an LLM call when:
+
+- ontology mode is `'off'` for the entity (via `getEffectiveState`), or
+- `findUntypedByEntityId` returns zero rows.
+
+This is what makes an unconditional post-sync trigger in host apps viable: the
+common case (no server-agent writes since last sync) costs one SELECT.
+
+### 4. Prompt: dedicated template, same contract as the librarian
+
+New `ONTOLOGY_BACKFILL_SYSTEM_PROMPT` in `prompts.ts` plus
+`PromptService.buildOntologyBackfillPrompt(facts, runtimeOverride?, ontologyContext?)`
+following the existing hydrate/append pattern (`{{facts}}` placeholder support,
+ontology context appended via `buildOntologyPromptAppendix` exactly like
+`buildLibrarianPrompt`).
+
+Task given to the model: for each input fact `{id, title, body, tags}`, return
+
+```json
+{
+  "classifications": [
+    { "id": "fact_…", "okf_type": "slug", "edges": [ { "edge_type": "…", "target_title": "…" } ] }
+  ],
+  "ontology_updates": { "node_types": [...], "edge_types": [...] }
+}
+```
+
+- The strict/emergent split rides on the existing `ontologyModeInstructions`
+  appendix: strict mode instructs manifest-types-only (no `ontology_updates`);
+  emergent mode permits proposals. No new mode logic.
+- The model may omit a fact it cannot classify — omission is the "no suitable type"
+  signal, mirroring the librarian's leniency.
+- `promptOverride` and a `PromptOverrides.ontologyBackfillSystemPrompt` global
+  override are supported, consistent with every other prompt in the package.
+
+### 5. Persistence: one transaction, existing validators, no new semantics
+
+Inside `db.withTransactionAsync`:
+
+1. `getEffectiveState(entityId, tx)`; in emergent mode with `ontology_updates`
+   present → `mergeEmergentUpdates` first (manifest grows before validation, same
+   order as the librarian).
+2. Build the title index from `findRecentByEntityId(entityId, 100, tx)` **plus the
+   batch facts themselves**, so edges may target other facts in the same batch.
+3. Per classification: resolve the fact by `id` against the selected batch (unknown
+   ids ignored); `validateAndNormalizeFact` → canonical `okf_type` or null; on
+   success `updateOkfType`, update the title index entry with the new type, and
+   queue edges.
+4. After **all** classifications are applied: `resolveAndPersistEdges` per typed
+   fact (existing duplicate-ignoring insert, existing source/target type checks
+   against the manifest). Two-phase ordering matters — the target-type check reads
+   `okf_type` from the title index, so intra-batch edges only resolve once every
+   batch fact has its new type. Same apply-then-link ordering as the librarian's
+   `pendingEdges`.
+
+After commit: `searchService.evictCache(entityId)`. No re-embed — title/body
+unchanged. No FTS re-sync — `okf_type` is not in the search index.
+
+`countUntypedByEntityId` after the write transaction supplies `remaining`.
+
+### 6. Failure semantics
+
+- LLM call failure or unparseable JSON → throw (after lock release via `finally`).
+  Hosts treat it like a failed librarian run: non-fatal, report, retry on next
+  trigger. No partial writes — nothing persists outside the transaction.
+- Per-item validation failures never abort the run; they are reflected in counts.
+
+---
+
+## Host adoption (Clanker — documented here, implemented in the Clanker repo)
+
+After each entity sync completes (both sync paths: `characterSyncService`
+`runRemoteSync` items and `useCharacterWiki.sync`), call:
+
+```ts
+try {
+  await wiki.runOntologyBackfill(entityId)
+} catch (err) {
+  reportWikiOpForCharacter(err, `wiki:${entityId}:ontology:backfill`, entityId, 'Ontology backfill failed')
+}
+```
+
+- Runs after `importDump` has landed remote facts, so cloud-agent writes are typed
+  within one sync cycle (≤25/run; `remaining > 0` simply waits for the next sync).
+- `WikiBusyError` is expected under concurrency and safe to swallow silently — the
+  next sync retries.
+- Cost profile: one `wikiLlm` call only when untyped facts exist; otherwise one
+  SELECT (Decision 3).
+
+---
+
+## Test Plan
+
+New suite `packages/core/__tests__/ontologyBackfill.test.ts`:
+
+1. **Types untyped facts.** Seed manifest (strict) + untyped facts; fake
+   `llmProvider` returns valid classifications. Assert `okf_type` persisted, edges
+   created, counts correct.
+2. **No-LLM early exits.** (a) mode `off`, (b) zero untyped facts — assert
+   `llmProvider.generateText` never called and zeroed result returned.
+3. **Additive guarantees.** Fact typed concurrently between select and update
+   (simulate via pre-typed row in the model response): `updateOkfType`'s
+   `okf_type IS NULL` guard leaves it untouched. Existing facts never deleted or
+   rewritten; fact count invariant across the run.
+4. **Emergent merge order.** Model proposes `ontology_updates` introducing a new
+   node type used by a classification in the same response — assert merge happens
+   first and the classification validates against the grown manifest.
+5. **Strict mode rejects unknown types.** Classification with a non-manifest type →
+   fact stays `NULL`, appears in `remaining`.
+6. **Batch cap.** 30 untyped facts, model types all it receives → exactly one LLM
+   call carrying 25 facts (oldest first), `scanned = 25`, `remaining = 5`.
+7. **Intra-batch edges.** Two untyped facts in one batch, edge from one to the
+   other via `target_title` — assert edge persists (title index includes batch).
+8. **Malformed model output.** Unparseable JSON → throws, lock released, no rows
+   changed; unknown fact ids → ignored without error.
+9. **Lock discipline.** Concurrent `runOntologyBackfill` throws `WikiBusyError`;
+   sequential run after completion succeeds.
+
+Existing suites must pass unchanged — the pass is opt-in and touches no existing
+code paths beyond additive repository methods and a new prompt export.
+
+---
+
+## Release
+
+- `feat(core): ontology backfill pass for untyped facts` → semantic-release minor on
+  `core-llm-wiki`; `expo-llm-wiki` picks up via dependency bump. README gains a
+  short "Ontology backfill" subsection under the existing ontology docs (when to
+  call it, cost model, `remaining` convergence contract).
+- Clanker adoption ships separately in the Clanker repo after the package release
+  (dep bump + post-sync trigger + `reportError` tag), per the usual
+  package-first rollout order.
+
+---
+
+## Out of Scope (v1)
+
+- **Edge backfill for already-typed facts.** "Zero edges" is not a defect signal
+  (many facts legitimately relate to nothing), so the work queue never converges
+  without new bookkeeping (e.g. `edges_checked_at`). Revisit if traversal proves
+  sparse for reasons attributable to failed edge resolution.
+- **Multi-call backlog loops.** Hosts can loop on `remaining > 0` themselves; the
+  library stays single-call-per-run. Revisit if convergence over normal sync
+  cadence is too slow in practice.
+- **React hooks.** No component consumer exists; triggers live in host service
+  code. Add a hook when interactive UI (e.g. a "rebuild memory graph" button)
+  needs one.
+- **Server-side extraction in host agents** (Option B from the Clanker
+  investigation) — superseded by this library-level pass.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -541,6 +541,38 @@ In **Strict** and **Emergent** modes, librarian and ingest JSON may include type
 
 See the design spec: [`docs/superpowers/specs/2026-06-23-per-entity-seeded-ontology-design.md`](https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/superpowers/specs/2026-06-23-per-entity-seeded-ontology-design.md).
 
+### Ontology backfill
+
+Facts that enter the store without passing through the librarian (synced-down
+remote facts via `importDump`, or facts created before the ontology feature)
+have `okf_type = NULL` and no edges, so `traverseGraph` cannot reach them.
+`runOntologyBackfill` types them in place:
+
+```ts
+const result = await wiki.runOntologyBackfill(entityId);
+// { scanned, typed, failedValidation, edgesAdded, remaining, deferred }
+```
+
+- **When to call it:** you own the trigger — the library provides the operation,
+  not a scheduler (same as `runLibrarian`/`runHeal`). A good default is after
+  each sync/import completes. `WikiBusyError` under concurrency is safe to
+  swallow; the next trigger retries.
+- **Cost model:** one LLM call only when eligible untyped facts exist; otherwise
+  one SELECT. Each run scans at most 25 facts (override via
+  `options.batchSize`), oldest first, capped at 40k prompt chars.
+- **Convergence:** loop `while (result.remaining > 0)` to drain a backlog.
+  `remaining` counts only *eligible* untyped facts, so the loop terminates even
+  when unclassifiable facts exist; those are cooldown-stamped and retried after
+  7 days (`deferred` reports them). Because of that weekly retry, host
+  dashboards may see small recurring bumps in `scanned`/`failedValidation` as
+  the unclassifiable backlog is re-tested — expected, not a regression.
+- **Strictly additive:** never creates, deletes, or rewrites facts, and never
+  overwrites an existing `okf_type` (guarded in SQL, not just convention).
+  `updated_at` is never touched, so sync merge resolution is unaffected.
+- **Prompt customization:** per-call `options.promptOverride`, or global
+  `config.prompts.ontologyBackfillSystemPrompt` (template may use `{{facts}}`
+  and the ontology placeholders).
+
 ## OKF Import/Export
 
 The core package integrates with `@equationalapplications/core-okf` to seamlessly adapt wiki data dumps to and from Open Knowledge Format (OKF) v0.1 bundles.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -559,7 +559,9 @@ const result = await wiki.runOntologyBackfill(entityId);
   swallow; the next trigger retries.
 - **Cost model:** one LLM call only when eligible untyped facts exist; otherwise
   one SELECT. Each run scans at most 25 facts (override via
-  `options.batchSize`), oldest first, capped at 40k prompt chars.
+  `options.batchSize`), oldest first, with the full serialized prompt
+  (system + user) capped at 40k chars. One exception: a single fact whose
+  prompt alone exceeds the cap is still sent by itself so it is never starved.
 - **Convergence:** loop `while (result.remaining > 0)` to drain a backlog.
   `remaining` counts only *eligible* untyped facts, so the loop terminates even
   when unclassifiable facts exist; those are cooldown-stamped and retried after

--- a/packages/core/__tests__/jobs.test.ts
+++ b/packages/core/__tests__/jobs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { WikiBusyError } from '../src/types';
 import { WikiMemory } from '../src/WikiMemory';
+import { JobManager } from '../src/services/JobManager';
 
 class MockSQLiteDatabase {
     async execAsync(_sql: string): Promise<void> {}
@@ -146,5 +147,27 @@ describe('getEntityStatus', () => {
     expect(wiki.getEntityStatus('e1').librarian).toBe(true);
     expect(wiki.getEntityStatus('e2').librarian).toBe(false);
     await p;
+  });
+});
+
+describe('ontologyBackfill lock', () => {
+  it('self-conflicts per entity and releases cleanly', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('ontologyBackfill', 'e1');
+    expect(() => jm.acquireLock('ontologyBackfill', 'e1')).toThrow(WikiBusyError);
+    jm.acquireLock('ontologyBackfill', 'e2'); // other entity fine
+    jm.releaseLock('ontologyBackfill', 'e1');
+    expect(() => jm.acquireLock('ontologyBackfill', 'e1')).not.toThrow();
+  });
+
+  it('is blocked by prune/reembed/import/forget, and blocks them back', () => {
+    for (const op of ['prune', 'reembed', 'import', 'forget'] as const) {
+      const jm = new JobManager('llm_wiki_');
+      jm.acquireLock(op, 'e1');
+      expect(() => jm.acquireLock('ontologyBackfill', 'e1')).toThrow(WikiBusyError);
+      jm.releaseLock(op, 'e1');
+      jm.acquireLock('ontologyBackfill', 'e1');
+      expect(() => jm.acquireLock(op, 'e1')).toThrow(WikiBusyError);
+    }
   });
 });

--- a/packages/core/__tests__/migration2.test.ts
+++ b/packages/core/__tests__/migration2.test.ts
@@ -60,7 +60,7 @@ async function makeV1Db() {
   return db;
 }
 
-describe('migrations v2–v6: FTS removal, embeddings, outbox, okf edges, entity manifests; setup ends at version 6', () => {
+describe('migrations v2–v6: FTS removal, embeddings, outbox, okf edges, entity manifests; setup ends at version 7', () => {
   it('fresh install: embedding column exists, FTS5 table absent', async () => {
     const db = openTestDatabase();
     const wiki = new WikiMemory(db, stubOptions);
@@ -77,10 +77,10 @@ describe('migrations v2–v6: FTS removal, embeddings, outbox, okf edges, entity
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('6');
+    expect(meta?.value).toBe('7');
   });
 
-  it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 6', async () => {
+  it('v1 DB: FTS5 table + triggers dropped, embedding column added, version becomes 7', async () => {
     const db = await makeV1Db();
     const wiki = new WikiMemory(db, stubOptions);
     await wiki.setup();
@@ -101,7 +101,7 @@ describe('migrations v2–v6: FTS removal, embeddings, outbox, okf edges, entity
     const meta = await db.getFirstAsync<{ value: string }>(
       `SELECT value FROM llm_wiki_meta WHERE key = 'schema_version'`
     );
-    expect(meta?.value).toBe('6');
+    expect(meta?.value).toBe('7');
   });
 
   it('running setup() twice is idempotent: embedding column appears once', async () => {

--- a/packages/core/__tests__/migrations.test.ts
+++ b/packages/core/__tests__/migrations.test.ts
@@ -101,7 +101,7 @@ describe('schema migrations', () => {
     // Should have written schema_version
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '7' || c.args[1] === '7')
     );
     expect(versionWrite).toBeDefined();
 
@@ -122,7 +122,7 @@ describe('schema migrations', () => {
     // Version should have been written
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '7' || c.args[1] === '7')
     );
     expect(versionWrite).toBeDefined();
   });
@@ -145,7 +145,7 @@ describe('schema migrations', () => {
   });
 
   it('already at current version → no migration runs', async () => {
-    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '6' });
+    const db = makeMockDb({ hasEntries: true, hasPorter: true, metaVersion: '7' });
     const wiki = createWiki(db);
     await wiki.setup();
 
@@ -170,7 +170,7 @@ describe('schema migrations', () => {
 
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '7' || c.args[1] === '7')
     );
     expect(versionWrite).toBeDefined();
   });
@@ -187,7 +187,7 @@ describe('schema migrations', () => {
 
     const versionWrite = db.runCalls.find(
       c => (c.sql.includes('schema_version') || c.args[0] === 'schema_version') &&
-           (c.args[0] === '6' || c.args[1] === '6')
+           (c.args[0] === '7' || c.args[1] === '7')
     );
     expect(versionWrite).toBeDefined();
   });

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -40,3 +40,102 @@ describe('migration v7 — ontology_checked_at', () => {
     expect((await entryColumns(db)).filter(c => c === 'ontology_checked_at')).toHaveLength(1);
   });
 });
+
+import { EntryRepository } from '../src/repositories/EntryRepository';
+import { OutboxRepository } from '../src/repositories/OutboxRepository';
+
+function makeRepo(db: SQLiteAdapter): EntryRepository {
+  return new EntryRepository(db, PREFIX, new OutboxRepository(db, PREFIX, false));
+}
+
+async function seedEntry(db: SQLiteAdapter, opts: {
+  id: string; entityId?: string; title?: string; body?: string; updatedAt?: number;
+  okfType?: string | null; checkedAt?: number | null; deletedAt?: number | null;
+}): Promise<void> {
+  await db.runAsync(
+    `INSERT INTO ${PREFIX}entries
+       (id, entity_id, title, body, tags, confidence, source_type, created_at, updated_at,
+        access_count, deleted_at, okf_type, ontology_checked_at)
+     VALUES (?, ?, ?, ?, '[]', 'certain', 'user_stated', ?, ?, 0, ?, ?, ?)`,
+    [opts.id, opts.entityId ?? 'e1', opts.title ?? `title ${opts.id}`, opts.body ?? `body ${opts.id}`,
+     opts.updatedAt ?? 1000, opts.updatedAt ?? 1000,
+     opts.deletedAt ?? null, opts.okfType ?? null, opts.checkedAt ?? null],
+  );
+}
+
+describe('EntryRepository — backfill methods', () => {
+  it('findUntypedByEntityId: untyped, live, past cooldown, oldest first, limited', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 'f_old', updatedAt: 100 });
+    await seedEntry(db, { id: 'f_new', updatedAt: 200 });
+    await seedEntry(db, { id: 'f_typed', updatedAt: 50, okfType: 'person' });
+    await seedEntry(db, { id: 'f_deleted', updatedAt: 60, deletedAt: 999 });
+    await seedEntry(db, { id: 'f_cooling', updatedAt: 70, checkedAt: 5000 });
+    await seedEntry(db, { id: 'f_recheck_due', updatedAt: 80, checkedAt: 400 });
+    await seedEntry(db, { id: 'f_other_entity', entityId: 'e2', updatedAt: 10 });
+
+    const rows = await repo.findUntypedByEntityId('e1', 10, 400);
+    expect(rows.map(r => r.id)).toEqual(['f_recheck_due', 'f_old', 'f_new']);
+
+    const limited = await repo.findUntypedByEntityId('e1', 2, 400);
+    expect(limited.map(r => r.id)).toEqual(['f_recheck_due', 'f_old']);
+  });
+
+  it('countUntypedByEntityId splits eligible vs deferred', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 'a' });
+    await seedEntry(db, { id: 'b', checkedAt: 5000 });
+    await seedEntry(db, { id: 'c', checkedAt: 100 });
+    await seedEntry(db, { id: 'd', okfType: 'person' });
+    expect(await repo.countUntypedByEntityId('e1', 400)).toEqual({ eligible: 2, deferred: 1 });
+  });
+
+  it('updateOkfType only writes when okf_type IS NULL; returns changes', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 'u1' });
+    await seedEntry(db, { id: 'u2', okfType: 'place' });
+    await db.withTransactionAsync(async (tx) => {
+      expect((await repo.updateOkfType('u1', 'e1', 'person', tx)).changes).toBe(1);
+      expect((await repo.updateOkfType('u2', 'e1', 'person', tx)).changes).toBe(0);
+      expect((await repo.updateOkfType('u1', 'wrong-entity', 'place', tx)).changes).toBe(0);
+    });
+    const row = await db.getFirstAsync<{ okf_type: string }>(
+      `SELECT okf_type FROM ${PREFIX}entries WHERE id = 'u2'`);
+    expect(row!.okf_type).toBe('place');
+  });
+
+  it('markOntologyChecked stamps cooldown and never touches updated_at', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 'm1', updatedAt: 111 });
+    await seedEntry(db, { id: 'm2', updatedAt: 222 });
+    await db.withTransactionAsync(tx => repo.markOntologyChecked(['m1', 'm2'], 'e1', 9999, tx));
+    const rows = await db.getAllAsync<{ id: string; updated_at: number; ontology_checked_at: number }>(
+      `SELECT id, updated_at, ontology_checked_at FROM ${PREFIX}entries ORDER BY id`);
+    expect(rows).toEqual([
+      { id: 'm1', updated_at: 111, ontology_checked_at: 9999 },
+      { id: 'm2', updated_at: 222, ontology_checked_at: 9999 },
+    ]);
+  });
+
+  it('findTitleIndexByEntityId returns id/title/okf_type for all live facts', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 't1', title: 'Alpha', okfType: 'person' });
+    await seedEntry(db, { id: 't2', title: 'Beta' });
+    await seedEntry(db, { id: 't3', title: 'Gone', deletedAt: 5 });
+    const rows = await repo.findTitleIndexByEntityId('e1');
+    expect(rows.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+      { id: 't1', title: 'Alpha', okf_type: 'person' },
+      { id: 't2', title: 'Beta', okf_type: null },
+    ]);
+  });
+});

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -131,7 +131,7 @@ describe('EntryRepository — backfill methods', () => {
     ]);
   });
 
-  it('findTitleIndexByEntityId returns id/title/okf_type for all live facts', async () => {
+  it('findTitleIndexByEntityId returns only live typed facts', async () => {
     const db = openTestDatabase();
     await setupDatabase(db, PREFIX);
     const repo = makeRepo(db);
@@ -139,9 +139,23 @@ describe('EntryRepository — backfill methods', () => {
     await seedEntry(db, { id: 't2', title: 'Beta' });
     await seedEntry(db, { id: 't3', title: 'Gone', deletedAt: 5 });
     const rows = await repo.findTitleIndexByEntityId('e1');
-    expect(rows.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+    expect(rows).toEqual([
       { id: 't1', title: 'Alpha', okf_type: 'person' },
-      { id: 't2', title: 'Beta', okf_type: null },
+    ]);
+  });
+
+  it('markOntologyChecked skips soft-deleted facts', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    const repo = makeRepo(db);
+    await seedEntry(db, { id: 'd1', updatedAt: 111 });
+    await seedEntry(db, { id: 'd2', updatedAt: 222, deletedAt: 300 });
+    await db.withTransactionAsync(tx => repo.markOntologyChecked(['d1', 'd2'], 'e1', 9999, tx));
+    const rows = await db.getAllAsync<{ id: string; ontology_checked_at: number | null }>(
+      `SELECT id, ontology_checked_at FROM ${PREFIX}entries ORDER BY id`);
+    expect(rows).toEqual([
+      { id: 'd1', ontology_checked_at: 9999 },
+      { id: 'd2', ontology_checked_at: null },
     ]);
   });
 });

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -284,7 +284,7 @@ describe('runOntologyBackfill', () => {
   });
 
   // Spec test 7
-  it('payload guard: truncates below batchSize; single oversized fact still sent alone', async () => {
+  it('payload guard: truncates below batchSize; documented exception — a single oversized fact is still sent alone', async () => {
     const { db, wiki, generateText } = await makeWiki('strict');
     const big = 'x'.repeat(ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS - 100);
     await seedEntry(db, { id: 'fact_big1', body: big, updatedAt: 100 });
@@ -293,11 +293,47 @@ describe('runOntologyBackfill', () => {
     const r1 = await wiki.runOntologyBackfill('e1');
     expect(r1.scanned).toBe(1); // second fact would blow the char budget
     expect(r1.remaining).toBe(1);
+    // The documented exception: a fact whose prompt alone exceeds the cap is
+    // sent anyway rather than starved (deferring would re-defer forever).
+    const call1 = generateText.mock.calls[0][0];
+    expect(call1.systemPrompt.length + call1.userPrompt.length)
+      .toBeGreaterThan(ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS);
     // second run: the remaining oversized fact is sent alone, never starved
     generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_big2', okf_type: 'person' }] }));
     const r2 = await wiki.runOntologyBackfill('e1');
     expect(r2.scanned).toBe(1);
     expect(r2.typed).toBe(1);
+  });
+
+  it('payload guard measures the full serialized prompt, not just title+body', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    // Each fact's title+body sums to just under half the cap, so a title+body-only
+    // guard would batch both; the full prompt (manifest, ids, tags, JSON syntax)
+    // pushes two facts over the cap.
+    const half = 'x'.repeat(ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS / 2 - 60);
+    await seedEntry(db, { id: 'fact_half1', body: half, updatedAt: 100 });
+    await seedEntry(db, { id: 'fact_half2', body: half, updatedAt: 200 });
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_half1', okf_type: 'person' }] }));
+    const r1 = await wiki.runOntologyBackfill('e1');
+    expect(r1.scanned).toBe(1);
+    const call1 = generateText.mock.calls[0][0];
+    expect(call1.systemPrompt.length + call1.userPrompt.length)
+      .toBeLessThanOrEqual(ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS);
+  });
+
+  it('aborts without writes when ontology is disabled mid-flight (during the LLM call)', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_flip' });
+    generateText.mockImplementation(async () => {
+      // setOntologyManifest is not under the backfill job lock
+      await wiki.setOntologyManifest('e1', MANIFEST, { mode: 'off' });
+      return llmJson({ classifications: [{ id: 'fact_flip', okf_type: 'person' }] });
+    });
+    const r = await wiki.runOntologyBackfill('e1');
+    expect(r).toEqual({ scanned: 0, typed: 0, failedValidation: 0, edgesAdded: 0, remaining: 0, deferred: 0 });
+    const row = await getFactRow(db, 'fact_flip');
+    expect(row!.okf_type).toBeNull();
+    expect(row!.ontology_checked_at).toBeNull(); // abort must not stamp the cooldown
   });
 
   // Spec test 8
@@ -419,13 +455,16 @@ describe('runOntologyBackfill — lock discipline (WikiMemory)', () => {
 
     let releaseLlm!: () => void;
     const gate = new Promise<void>(resolve => { releaseLlm = resolve; });
+    let signalLlmEntered!: () => void;
+    const llmEntered = new Promise<void>(resolve => { signalLlmEntered = resolve; });
     generateText.mockImplementation(async () => {
+      signalLlmEntered();
       await gate;
       return llmJson({ classifications: [{ id: 'fact_lock', okf_type: 'person' }] });
     });
 
     const first = wiki.runOntologyBackfill('e1');
-    await new Promise(r => setTimeout(r, 10)); // let first acquire the lock
+    await llmEntered; // first run inside generateText → lock is held
     await expect(wiki.runOntologyBackfill('e1')).rejects.toThrow(WikiBusyError);
 
     releaseLlm();

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { openTestDatabase } from './helpers/sqliteAdapter';
+import { setupDatabase } from '../src/db/schema';
+import { MIGRATIONS } from '../src/db/migrations';
+import { createWiki, WikiMemory } from '../src/index';
+import type { SQLiteAdapter, WikiFact, OntologyManifest } from '../src/types';
+
+const PREFIX = 'llm_wiki_';
+
+async function entryColumns(db: SQLiteAdapter): Promise<string[]> {
+  const cols = await db.getAllAsync<{ name: string }>(`PRAGMA table_info(${PREFIX}entries)`);
+  return cols.map(c => c.name);
+}
+
+describe('migration v7 — ontology_checked_at', () => {
+  it('fresh install has the column via base schema', async () => {
+    const db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+    expect(await entryColumns(db)).toContain('ontology_checked_at');
+  });
+
+  it('upgrade from v6 adds the column, and re-running is idempotent', async () => {
+    const db = openTestDatabase();
+    // Simulate a pre-v7 install: base schema without the new column.
+    await db.execAsync(`
+      CREATE TABLE ${PREFIX}entries (
+        id TEXT PRIMARY KEY, entity_id TEXT NOT NULL, title TEXT NOT NULL, body TEXT NOT NULL,
+        tags TEXT NOT NULL DEFAULT '[]', confidence TEXT NOT NULL DEFAULT 'inferred',
+        source_type TEXT NOT NULL DEFAULT 'librarian_inferred', source_hash TEXT, source_ref TEXT,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, last_accessed_at INTEGER,
+        access_count INTEGER NOT NULL DEFAULT 0, deleted_at INTEGER,
+        embedding TEXT, embedding_blob BLOB, okf_type TEXT
+      );
+    `);
+    const v7 = MIGRATIONS.find(m => m.version === 7)!;
+    expect(v7).toBeDefined();
+    await v7.run(db, PREFIX);
+    expect(await entryColumns(db)).toContain('ontology_checked_at');
+    await v7.run(db, PREFIX); // idempotent — no throw
+    expect((await entryColumns(db)).filter(c => c === 'ontology_checked_at')).toHaveLength(1);
+  });
+});

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -4,6 +4,11 @@ import { setupDatabase } from '../src/db/schema';
 import { MIGRATIONS } from '../src/db/migrations';
 import { createWiki, WikiMemory } from '../src/index';
 import type { SQLiteAdapter, WikiFact, OntologyManifest } from '../src/types';
+import {
+  ONTOLOGY_BACKFILL_BATCH_SIZE,
+  ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS,
+  ONTOLOGY_BACKFILL_RECHECK_MS,
+} from '../src/services/MaintenanceService';
 
 const PREFIX = 'llm_wiki_';
 
@@ -137,5 +142,271 @@ describe('EntryRepository — backfill methods', () => {
       { id: 't1', title: 'Alpha', okf_type: 'person' },
       { id: 't2', title: 'Beta', okf_type: null },
     ]);
+  });
+});
+
+const MANIFEST: OntologyManifest = {
+  node_types: [
+    { type: 'person', description: 'A person' },
+    { type: 'place', description: 'A place' },
+  ],
+  edge_types: [
+    { type: 'lives_in', source_type: 'person', target_type: 'place', description: 'Person lives in place' },
+  ],
+};
+
+async function makeWiki(mode: 'strict' | 'emergent' | 'off' = 'strict') {
+  const db = openTestDatabase();
+  const generateText = vi.fn<any>();
+  const wiki = createWiki(db, { llmProvider: { generateText } } as any);
+  await wiki.setup();
+  await wiki.setOntologyManifest('e1', MANIFEST, { mode });
+  return { db, wiki, generateText };
+}
+
+const llmJson = (obj: unknown) => JSON.stringify(obj);
+
+async function edgeCount(db: SQLiteAdapter): Promise<number> {
+  const r = await db.getFirstAsync<{ c: number }>(`SELECT COUNT(*) AS c FROM ${PREFIX}edges`);
+  return r!.c;
+}
+
+async function getFactRow(db: SQLiteAdapter, id: string) {
+  return db.getFirstAsync<{ okf_type: string | null; updated_at: number; ontology_checked_at: number | null }>(
+    `SELECT okf_type, updated_at, ontology_checked_at FROM ${PREFIX}entries WHERE id = ?`, [id]);
+}
+
+describe('runOntologyBackfill', () => {
+  // Spec test 1
+  it('types untyped facts, creates edges, reports counts', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_p', title: 'Ada', updatedAt: 100 });
+    await seedEntry(db, { id: 'fact_c', title: 'London', updatedAt: 200 });
+    generateText.mockResolvedValue(llmJson({
+      classifications: [
+        { id: 'fact_c', okf_type: 'place' },
+        { id: 'fact_p', okf_type: 'person', edges: [{ edge_type: 'lives_in', target_title: 'London' }] },
+      ],
+    }));
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(result).toEqual({ scanned: 2, typed: 2, failedValidation: 0, edgesAdded: 1, remaining: 0, deferred: 0 });
+    expect((await getFactRow(db, 'fact_p'))!.okf_type).toBe('person');
+    expect((await getFactRow(db, 'fact_c'))!.okf_type).toBe('place');
+    expect(await edgeCount(db)).toBe(1);
+  });
+
+  // Spec test 2a
+  it('early exit: ontology mode off — no LLM call, remaining 0', async () => {
+    const { db, wiki, generateText } = await makeWiki('off');
+    await seedEntry(db, { id: 'fact_x' });
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(generateText).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, typed: 0, failedValidation: 0, edgesAdded: 0, remaining: 0, deferred: 0 });
+  });
+
+  // Spec test 2b
+  it('early exit: zero untyped facts — no LLM call', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_t', okfType: 'person' });
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(generateText).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, typed: 0, failedValidation: 0, edgesAdded: 0, remaining: 0, deferred: 0 });
+  });
+
+  // Spec test 3
+  it('additive: never overwrites okf_type, never deletes or rewrites facts', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_a', title: 'A', body: 'body A' });
+    await seedEntry(db, { id: 'fact_pre', title: 'P', okfType: 'place' }); // already typed — model responds anyway
+    generateText.mockResolvedValue(llmJson({
+      classifications: [
+        { id: 'fact_a', okf_type: 'person' },
+        { id: 'fact_pre', okf_type: 'person' }, // unknown id (not in batch) → failedValidation
+      ],
+    }));
+    const before = await db.getFirstAsync<{ c: number }>(`SELECT COUNT(*) AS c FROM ${PREFIX}entries`);
+    const result = await wiki.runOntologyBackfill('e1');
+    const after = await db.getFirstAsync<{ c: number }>(`SELECT COUNT(*) AS c FROM ${PREFIX}entries`);
+    expect(after!.c).toBe(before!.c);
+    expect((await getFactRow(db, 'fact_pre'))!.okf_type).toBe('place'); // untouched
+    expect(result.typed).toBe(1);
+    expect(result.failedValidation).toBe(1);
+    const row = await db.getFirstAsync<{ body: string }>(`SELECT body FROM ${PREFIX}entries WHERE id = 'fact_a'`);
+    expect(row!.body).toBe('body A'); // never rewritten
+  });
+
+  // Spec test 4
+  it('emergent: merges ontology_updates before validating classifications', async () => {
+    const { db, wiki, generateText } = await makeWiki('emergent');
+    await seedEntry(db, { id: 'fact_n', title: 'N' });
+    generateText.mockResolvedValue(llmJson({
+      classifications: [{ id: 'fact_n', okf_type: 'project' }],
+      ontology_updates: { node_types: [{ type: 'project', description: 'A project' }] },
+    }));
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(result.typed).toBe(1);
+    expect((await getFactRow(db, 'fact_n'))!.okf_type).toBe('project');
+    const manifest = await wiki.getOntologyManifest('e1');
+    expect(manifest!.manifest.node_types.some(n => n.type === 'project')).toBe(true);
+  });
+
+  // Spec test 5
+  it('strict: non-manifest type rejected, cooldown-stamped, lands in deferred', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_bad' });
+    generateText.mockResolvedValue(llmJson({
+      classifications: [{ id: 'fact_bad', okf_type: 'spaceship' }],
+    }));
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(result).toMatchObject({ scanned: 1, typed: 0, failedValidation: 1, remaining: 0, deferred: 1 });
+    const row = await getFactRow(db, 'fact_bad');
+    expect(row!.okf_type).toBeNull();
+    expect(row!.ontology_checked_at).not.toBeNull();
+  });
+
+  // Spec test 6
+  it('batch cap: 30 untyped → one call with 25 oldest, remaining 5', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    for (let i = 0; i < 30; i++) {
+      await seedEntry(db, { id: `fact_${String(i).padStart(2, '0')}`, updatedAt: 1000 + i });
+    }
+    generateText.mockImplementation(async ({ userPrompt }: { userPrompt: string }) => {
+      const ids = [...userPrompt.matchAll(/fact_\d\d/g)].map(m => m[0]);
+      return llmJson({ classifications: [...new Set(ids)].map(id => ({ id, okf_type: 'person' })) });
+    });
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ scanned: 25, typed: 25, remaining: 5 });
+    // oldest-first: fact_25..fact_29 (newest) are the ones left untyped
+    expect((await getFactRow(db, 'fact_29'))!.okf_type).toBeNull();
+    expect((await getFactRow(db, 'fact_00'))!.okf_type).toBe('person');
+  });
+
+  // Spec test 7
+  it('payload guard: truncates below batchSize; single oversized fact still sent alone', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    const big = 'x'.repeat(ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS - 100);
+    await seedEntry(db, { id: 'fact_big1', body: big, updatedAt: 100 });
+    await seedEntry(db, { id: 'fact_big2', body: big, updatedAt: 200 });
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_big1', okf_type: 'person' }] }));
+    const r1 = await wiki.runOntologyBackfill('e1');
+    expect(r1.scanned).toBe(1); // second fact would blow the char budget
+    expect(r1.remaining).toBe(1);
+    // second run: the remaining oversized fact is sent alone, never starved
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_big2', okf_type: 'person' }] }));
+    const r2 = await wiki.runOntologyBackfill('e1');
+    expect(r2.scanned).toBe(1);
+    expect(r2.typed).toBe(1);
+  });
+
+  // Spec test 8
+  it('intra-batch edges resolve after all types applied', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_who', title: 'Grace', updatedAt: 100 });
+    await seedEntry(db, { id: 'fact_where', title: 'Paris', updatedAt: 200 });
+    generateText.mockResolvedValue(llmJson({
+      classifications: [
+        // edge source listed BEFORE the target is typed — two-phase ordering must handle it
+        { id: 'fact_who', okf_type: 'person', edges: [{ edge_type: 'lives_in', target_title: 'Paris' }] },
+        { id: 'fact_where', okf_type: 'place' },
+      ],
+    }));
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(result.edgesAdded).toBe(1);
+    const edge = await db.getFirstAsync<{ source_id: string; target_id: string; edge_type: string }>(
+      `SELECT source_id, target_id, edge_type FROM ${PREFIX}edges`);
+    expect(edge).toEqual({ source_id: 'fact_who', target_id: 'fact_where', edge_type: 'lives_in' });
+  });
+
+  // Spec test 9
+  it('full title index breadth: edge to already-typed fact outside recent-100 window', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_target', title: 'Old Town', okfType: 'place', updatedAt: 10 });
+    await seedEntry(db, { id: 'fact_source', title: 'Elder', updatedAt: 20 });
+    for (let i = 0; i < 110; i++) {
+      await seedEntry(db, { id: `fact_noise_${i}`, title: `Noise ${i}`, okfType: 'person', updatedAt: 10_000 + i });
+    }
+    generateText.mockResolvedValue(llmJson({
+      classifications: [{ id: 'fact_source', okf_type: 'person', edges: [{ edge_type: 'lives_in', target_title: 'Old Town' }] }],
+    }));
+    const result = await wiki.runOntologyBackfill('e1');
+    expect(result.edgesAdded).toBe(1);
+  });
+
+  // Spec test 10
+  it('recheck cooldown: omitted fact deferred, re-eligible after cooldown; host loop terminates', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_meh' });
+    generateText.mockResolvedValue(llmJson({ classifications: [] })); // model omits it
+    const r1 = await wiki.runOntologyBackfill('e1');
+    expect(r1).toMatchObject({ scanned: 1, typed: 0, failedValidation: 0, remaining: 0, deferred: 1 });
+
+    // Host convergence loop terminates immediately: remaining === 0.
+    generateText.mockClear();
+    const r2 = await wiki.runOntologyBackfill('e1');
+    expect(generateText).not.toHaveBeenCalled();
+    expect(r2).toMatchObject({ scanned: 0, remaining: 0, deferred: 1 });
+
+    // Age the stamp past the cooldown → selected again.
+    await db.runAsync(
+      `UPDATE ${PREFIX}entries SET ontology_checked_at = ? WHERE id = 'fact_meh'`,
+      [Date.now() - ONTOLOGY_BACKFILL_RECHECK_MS - 1000]);
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_meh', okf_type: 'person' }] }));
+    const r3 = await wiki.runOntologyBackfill('e1');
+    expect(r3).toMatchObject({ scanned: 1, typed: 1 });
+  });
+
+  // Spec test 11
+  it('cooldown stamp never touches updated_at', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_skip', updatedAt: 424242 });
+    generateText.mockResolvedValue(llmJson({ classifications: [] }));
+    await wiki.runOntologyBackfill('e1');
+    const row = await getFactRow(db, 'fact_skip');
+    expect(row!.updated_at).toBe(424242);
+    expect(row!.ontology_checked_at).not.toBeNull();
+  });
+
+  // Spec test 12
+  it('malformed output throws with lock released and zero writes; unknown ids counted not thrown', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_j', updatedAt: 777 });
+    generateText.mockResolvedValue('not json at all {');
+    await expect(wiki.runOntologyBackfill('e1')).rejects.toThrow();
+    const row = await getFactRow(db, 'fact_j');
+    expect(row!.okf_type).toBeNull();
+    expect(row!.ontology_checked_at).toBeNull(); // no cooldown stamps outside the tx
+
+    // lock released — next run proceeds
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_ghost', okf_type: 'person' }] }));
+    const r = await wiki.runOntologyBackfill('e1');
+    expect(r).toMatchObject({ scanned: 1, typed: 0, failedValidation: 1 });
+  });
+
+  it('duplicate classification ids: first wins, duplicates counted as failedValidation', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_dup' });
+    generateText.mockResolvedValue(llmJson({
+      classifications: [
+        { id: 'fact_dup', okf_type: 'person' },
+        { id: 'fact_dup', okf_type: 'place' },
+      ],
+    }));
+    const r = await wiki.runOntologyBackfill('e1');
+    expect(r.typed).toBe(1);
+    expect(r.failedValidation).toBe(1);
+    expect((await getFactRow(db, 'fact_dup'))!.okf_type).toBe('person');
+  });
+
+  it('options.batchSize overrides the default; invalid values throw', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_b1', updatedAt: 1 });
+    await seedEntry(db, { id: 'fact_b2', updatedAt: 2 });
+    generateText.mockResolvedValue(llmJson({ classifications: [{ id: 'fact_b1', okf_type: 'person' }] }));
+    const r = await wiki.runOntologyBackfill('e1', { batchSize: 1 });
+    expect(r.scanned).toBe(1);
+    expect(r.remaining).toBe(1);
+    await expect(wiki.runOntologyBackfill('e1', { batchSize: 0 })).rejects.toThrow(/batchSize/);
+    expect(ONTOLOGY_BACKFILL_BATCH_SIZE).toBe(25);
   });
 });

--- a/packages/core/__tests__/ontologyBackfill.test.ts
+++ b/packages/core/__tests__/ontologyBackfill.test.ts
@@ -4,6 +4,7 @@ import { setupDatabase } from '../src/db/schema';
 import { MIGRATIONS } from '../src/db/migrations';
 import { createWiki, WikiMemory } from '../src/index';
 import type { SQLiteAdapter, WikiFact, OntologyManifest } from '../src/types';
+import { WikiBusyError } from '../src/types';
 import {
   ONTOLOGY_BACKFILL_BATCH_SIZE,
   ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS,
@@ -408,5 +409,29 @@ describe('runOntologyBackfill', () => {
     expect(r.remaining).toBe(1);
     await expect(wiki.runOntologyBackfill('e1', { batchSize: 0 })).rejects.toThrow(/batchSize/);
     expect(ONTOLOGY_BACKFILL_BATCH_SIZE).toBe(25);
+  });
+});
+
+describe('runOntologyBackfill — lock discipline (WikiMemory)', () => {
+  it('concurrent invocation throws WikiBusyError; sequential run succeeds', async () => {
+    const { db, wiki, generateText } = await makeWiki('strict');
+    await seedEntry(db, { id: 'fact_lock' });
+
+    let releaseLlm!: () => void;
+    const gate = new Promise<void>(resolve => { releaseLlm = resolve; });
+    generateText.mockImplementation(async () => {
+      await gate;
+      return llmJson({ classifications: [{ id: 'fact_lock', okf_type: 'person' }] });
+    });
+
+    const first = wiki.runOntologyBackfill('e1');
+    await new Promise(r => setTimeout(r, 10)); // let first acquire the lock
+    await expect(wiki.runOntologyBackfill('e1')).rejects.toThrow(WikiBusyError);
+
+    releaseLlm();
+    await expect(first).resolves.toMatchObject({ typed: 1 });
+
+    // sequential run after completion succeeds (early-exits: nothing untyped)
+    await expect(wiki.runOntologyBackfill('e1')).resolves.toMatchObject({ scanned: 0 });
   });
 });

--- a/packages/core/__tests__/services/OntologyService.test.ts
+++ b/packages/core/__tests__/services/OntologyService.test.ts
@@ -13,9 +13,11 @@ const edgeManifest: OntologyManifest = {
   node_types: [
     { type: 'Person', description: 'An individual.' },
     { type: 'project', description: 'A project.' },
+    { type: 'place', description: 'A location.' },
   ],
   edge_types: [
     { type: 'Reports_To', source_type: 'person', target_type: 'Person', description: 'Hierarchy.' },
+    { type: 'lives_in', source_type: 'person', target_type: 'place', description: 'Residency.' },
   ],
 };
 
@@ -190,6 +192,26 @@ describe('OntologyService', () => {
         }),
         tx,
       );
+    });
+
+    it('returns the number of edges actually persisted', async () => {
+      const { metadataRepo, edgeRepo } = makeMocks();
+      const svc = new OntologyService(metadataRepo, edgeRepo);
+      vi.mocked(edgeRepo.addIgnoreDuplicate).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      const titleIndex = new Map([
+        ['alpha', { id: 'fact_a', okf_type: 'place' }],
+        ['beta', { id: 'fact_b', okf_type: 'place' }],
+      ]);
+      const count = await svc.resolveAndPersistEdges(
+        'e1', 'fact_src', 'person',
+        [
+          { edge_type: 'lives_in', target_title: 'Alpha' },
+          { edge_type: 'lives_in', target_title: 'Beta' },
+          { edge_type: 'lives_in', target_title: 'Missing' }, // unresolved target — skipped
+        ],
+        edgeManifest, titleIndex, {} as any, 123,
+      );
+      expect(count).toBe(1); // true + false + skipped
     });
   });
 

--- a/packages/core/__tests__/services/PromptService.test.ts
+++ b/packages/core/__tests__/services/PromptService.test.ts
@@ -4,7 +4,9 @@ import {
   INGEST_SYSTEM_PROMPT,
   LIBRARIAN_SYSTEM_PROMPT,
   HEAL_SYSTEM_PROMPT,
+  ONTOLOGY_BACKFILL_SYSTEM_PROMPT,
 } from '../../src/prompts';
+import { buildOntologyPromptAppendix } from '../../src/prompts/ontology';
 
 describe('PromptService', () => {
   describe('buildIngestPrompt', () => {
@@ -163,6 +165,32 @@ describe('PromptService', () => {
       const { systemPrompt, userPrompt } = svc.buildHealPrompt([], [], [], events, template);
       expect(systemPrompt).toContain('"recent thing"');
       expect(userPrompt).toBe('Please heal the memory graph.');
+    });
+  });
+
+  describe('buildOntologyBackfillPrompt', () => {
+    const facts = [{ id: 'fact_1', title: 'T', body: 'B', tags: [] }];
+
+    it('uses default prompt with facts in userPrompt and ontology context appended', () => {
+      const svc = new PromptService();
+      const ctx = buildOntologyPromptAppendix('strict', '{"node_types":[],"edge_types":[]}');
+      const { systemPrompt, userPrompt } = svc.buildOntologyBackfillPrompt(facts, undefined, ctx);
+      expect(systemPrompt).toContain(ONTOLOGY_BACKFILL_SYSTEM_PROMPT);
+      expect(systemPrompt).toContain(ctx.ontologyModeInstructions);
+      expect(userPrompt).toContain('fact_1');
+    });
+
+    it('runtime override wins over global override', () => {
+      const svc = new PromptService({ ontologyBackfillSystemPrompt: 'GLOBAL' });
+      expect(svc.buildOntologyBackfillPrompt(facts, 'RUNTIME').systemPrompt).toContain('RUNTIME');
+      expect(svc.buildOntologyBackfillPrompt(facts).systemPrompt).toContain('GLOBAL');
+    });
+
+    it('hydrates {{facts}} placeholder into systemPrompt', () => {
+      const svc = new PromptService();
+      const { systemPrompt, userPrompt } = svc.buildOntologyBackfillPrompt(facts, 'Classify: {{facts}}');
+      expect(systemPrompt).toContain('fact_1');
+      expect(userPrompt).toBe('Please classify the facts.');
     });
   });
 });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -29,7 +29,7 @@ import { WriteService } from './services/WriteService';
 import { PromptService } from './services/PromptService';
 import { OntologyService } from './services/OntologyService';
 import { GraphTraversalService } from './services/GraphTraversalService';
-import type { OntologyManifest, OntologyMode, GraphTraversalOptions, GraphNeighborhood } from './types';
+import type { OntologyManifest, OntologyMode, GraphTraversalOptions, GraphNeighborhood, OntologyBackfillResult } from './types';
 
 export { WikiBusyError, WikiTransactionError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER } from './types';
 
@@ -309,6 +309,28 @@ export class WikiMemory {
    */
   async runHeal(entityId: string, options?: { promptOverride?: string }): Promise<void> {
     return this.maintenanceService.runHeal(entityId, options);
+  }
+
+  /**
+   * Types already-persisted untyped facts (okf_type IS NULL) in place via one
+   * librarian-style LLM call. Strictly additive: never creates, deletes, or
+   * rewrites facts; never overwrites an existing okf_type. Free when there is
+   * nothing to do (ontology off, or zero eligible untyped facts).
+   *
+   * Hosts own the trigger cadence (e.g. after each sync); loop `while
+   * result.remaining > 0` for convergence. Throws WikiBusyError when another
+   * backfill (or conflicting maintenance op) is running for the entity.
+   *
+   * @param options.promptOverride - Applies only to this call. For persistent
+   * customization set `options.config.prompts.ontologyBackfillSystemPrompt`.
+   * @param options.batchSize - Facts per run (default 25) for providers with
+   * tighter context limits.
+   */
+  async runOntologyBackfill(
+    entityId: string,
+    options?: { promptOverride?: string; batchSize?: number },
+  ): Promise<OntologyBackfillResult> {
+    return this.maintenanceService.runOntologyBackfill(entityId, options);
   }
 
   async runReembed(entityId?: string, opts?: { force?: boolean; skipExisting?: boolean }): Promise<{ embedded: number; skipped: number; failed: number }> {

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -112,6 +112,23 @@ export const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    version: 7,
+    description: 'Add ontology_checked_at to entries for ontology backfill recheck cooldown',
+    run: async (db, prefix) => {
+      // ALTER TABLE ADD COLUMN must run outside any explicit transaction —
+      // SQLite (and expo-sqlite) do not permit schema alterations inside
+      // a BEGIN...COMMIT block. Same pattern as v2/v3/v5.
+      const cols = await db.getAllAsync<{ name: string }>(
+        `PRAGMA table_info(${prefix}entries)`
+      );
+      if (!cols.some(c => c.name === 'ontology_checked_at')) {
+        await db.execAsync(
+          `ALTER TABLE ${prefix}entries ADD COLUMN ontology_checked_at INTEGER`
+        );
+      }
+    },
+  },
 ];
 
 // Verify MIGRATIONS are in strictly ascending version order at module load time.

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -19,7 +19,8 @@ export async function setupDatabase(db: SQLiteAdapter, prefix: string) {
       deleted_at INTEGER,
       embedding TEXT,
       embedding_blob BLOB,
-      okf_type TEXT
+      okf_type TEXT,
+      ontology_checked_at INTEGER
     );
 
     CREATE INDEX IF NOT EXISTS ${prefix}entries_entity_idx ON ${prefix}entries(entity_id);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,12 @@ export { parseEmbedding } from './utils/embedding';
 export { configureRandomSource } from './utils/ids';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';
+export {
+  ONTOLOGY_BACKFILL_BATCH_SIZE,
+  ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS,
+  ONTOLOGY_BACKFILL_RECHECK_MS,
+} from './services/MaintenanceService';
+export { ONTOLOGY_BACKFILL_SYSTEM_PROMPT } from './prompts';
 
 export function createWiki(db: SQLiteAdapter, options: WikiOptions): WikiMemory {
   return new WikiMemory(db, options);

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -21,3 +21,13 @@ Return ONLY a valid JSON object matching this schema:
   "facts": [{ "title": "string (max 80 chars)", "body": "string (max 800 chars)", "tags": ["string"], "confidence": "certain|inferred|tentative" }]
 }
 Extract verbatim factual content. Do not return markdown, just raw JSON.`;
+
+export const ONTOLOGY_BACKFILL_SYSTEM_PROMPT = `You are a knowledge classification agent. You will receive existing memory facts that currently have no ontology type. For each input fact { "id", "title", "body", "tags" }, assign the best matching okf_type from the ontology manifest and optionally propose edges to related facts by title.
+Return ONLY a valid JSON object matching this schema:
+{
+  "classifications": [
+    { "id": "string (input fact id, copied verbatim)", "okf_type": "string (manifest node type slug)", "edges": [{ "edge_type": "string", "target_title": "string" }] }
+  ]
+}
+If no manifest type fits a fact, omit that fact from "classifications" entirely — do not guess.
+Do not return markdown, just raw JSON.`;

--- a/packages/core/src/repositories/EdgeRepository.ts
+++ b/packages/core/src/repositories/EdgeRepository.ts
@@ -19,9 +19,10 @@ const CONFIDENCE_RANK: Record<'tentative' | 'inferred' | 'certain', number> = {
 export class EdgeRepository extends BaseRepository {
   /**
    * Insert an edge, silently skipping on primary-key or uniqueness conflicts.
+   * Returns true when a row was inserted, false when skipped as a duplicate.
    * Throws when the insert was skipped due to an id collision with a different edge tuple.
    */
-  async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<void> {
+  async addIgnoreDuplicate(edge: WikiEdge, tx?: SQLiteAdapter): Promise<boolean> {
     const executor = this.getExecutor(tx);
     const result = await executor.runAsync(
       `INSERT OR IGNORE INTO ${this.prefix}edges (id, entity_id, source_id, target_id, edge_type, created_at)
@@ -29,7 +30,7 @@ export class EdgeRepository extends BaseRepository {
       [edge.id, edge.entity_id, edge.source_id, edge.target_id, edge.edge_type, edge.created_at],
     );
 
-    if (result.changes > 0) return;
+    if (result.changes > 0) return true;
 
     const existing = await executor.getFirstAsync<{
       entity_id: string;
@@ -41,7 +42,7 @@ export class EdgeRepository extends BaseRepository {
       [edge.id],
     );
 
-    if (!existing) return;
+    if (!existing) return false;
 
     if (
       String(existing.entity_id) !== edge.entity_id ||
@@ -53,6 +54,8 @@ export class EdgeRepository extends BaseRepository {
         `Edge id collision: ${JSON.stringify(edge.id)} already exists with a different (entity_id, source_id, target_id, edge_type) tuple`,
       );
     }
+
+    return false;
   }
 
   async getByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<WikiEdge[]> {

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -929,7 +929,7 @@ export class EntryRepository extends BaseRepository {
       const placeholders = chunk.map(() => '?').join(',');
       await tx.runAsync(
         `UPDATE ${this.prefix}entries SET ontology_checked_at = ?
-         WHERE id IN (${placeholders}) AND entity_id = ?`,
+         WHERE id IN (${placeholders}) AND entity_id = ? AND deleted_at IS NULL`,
         [now, ...chunk, entityId],
       );
     }
@@ -937,13 +937,15 @@ export class EntryRepository extends BaseRepository {
 
   /**
    * Lightweight full-breadth title index (id, title, okf_type) over all live
-   * facts. Used by ontology backfill edge resolution — a recent-N window would
-   * miss an old fact's contemporaries.
+   * typed facts. Used by ontology backfill edge resolution — a recent-N window
+   * would miss an old fact's contemporaries. Untyped rows are excluded: they
+   * can never pass the edge target-type check, and batch facts typed during
+   * the run are re-added to the in-memory index by the caller.
    */
   async findTitleIndexByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<Array<{ id: string; title: string; okf_type: string | null }>> {
     const executor = this.getExecutor(tx);
     const rows = await executor.getAllAsync<{ id: string; title: string; okf_type: string | null }>(
-      `SELECT id, title, okf_type FROM ${this.prefix}entries WHERE entity_id = ? AND deleted_at IS NULL`,
+      `SELECT id, title, okf_type FROM ${this.prefix}entries WHERE entity_id = ? AND deleted_at IS NULL AND okf_type IS NOT NULL`,
       [entityId],
     );
     return rows.map(r => ({ id: r.id, title: r.title, okf_type: r.okf_type ?? null }));

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -872,4 +872,80 @@ export class EntryRepository extends BaseRepository {
     );
     return rows.map(mapRowToFact);
   }
+
+  /**
+   * Live untyped facts eligible for ontology backfill, oldest first.
+   * Skips facts checked within the recheck cooldown (ontology_checked_at > recheckCutoff).
+   */
+  async findUntypedByEntityId(entityId: string, limit: number, recheckCutoff: number, tx?: SQLiteAdapter): Promise<WikiFact[]> {
+    const executor = this.getExecutor(tx);
+    const rows = await executor.getAllAsync<any>(
+      `SELECT * FROM ${this.prefix}entries
+       WHERE entity_id = ? AND okf_type IS NULL AND deleted_at IS NULL
+         AND (ontology_checked_at IS NULL OR ontology_checked_at <= ?)
+       ORDER BY updated_at ASC LIMIT ?`,
+      [entityId, recheckCutoff, limit],
+    );
+    return rows.map(mapRowToFact);
+  }
+
+  /** Counts live untyped facts: eligible (past cooldown) vs deferred (in cooldown). */
+  async countUntypedByEntityId(entityId: string, recheckCutoff: number, tx?: SQLiteAdapter): Promise<{ eligible: number; deferred: number }> {
+    const executor = this.getExecutor(tx);
+    const row = await executor.getFirstAsync<{ eligible: number | null; deferred: number | null }>(
+      `SELECT
+         SUM(CASE WHEN ontology_checked_at IS NULL OR ontology_checked_at <= ? THEN 1 ELSE 0 END) AS eligible,
+         SUM(CASE WHEN ontology_checked_at IS NOT NULL AND ontology_checked_at > ? THEN 1 ELSE 0 END) AS deferred
+       FROM ${this.prefix}entries
+       WHERE entity_id = ? AND okf_type IS NULL AND deleted_at IS NULL`,
+      [recheckCutoff, recheckCutoff, entityId],
+    );
+    return { eligible: Number(row?.eligible ?? 0), deferred: Number(row?.deferred ?? 0) };
+  }
+
+  /**
+   * Sets okf_type only when currently NULL — additive by construction: a
+   * concurrently-typed fact is never overwritten. Returns changes for the caller
+   * to distinguish applied vs skipped.
+   */
+  async updateOkfType(id: string, entityId: string, okfType: string, tx: SQLiteAdapter): Promise<{ changes: number }> {
+    const result = await tx.runAsync(
+      `UPDATE ${this.prefix}entries SET okf_type = ?
+       WHERE id = ? AND entity_id = ? AND okf_type IS NULL AND deleted_at IS NULL`,
+      [okfType, id, entityId],
+    );
+    return { changes: result.changes };
+  }
+
+  /**
+   * Stamps the backfill recheck cooldown. NEVER touches updated_at — import
+   * merge resolution is last-write-wins on updated_at and a bump here would
+   * make an unchanged local fact beat a genuinely newer remote edit.
+   */
+  async markOntologyChecked(ids: string[], entityId: string, now: number, tx: SQLiteAdapter): Promise<void> {
+    if (ids.length === 0) return;
+    for (let i = 0; i < ids.length; i += this.chunkSize) {
+      const chunk = ids.slice(i, i + this.chunkSize);
+      const placeholders = chunk.map(() => '?').join(',');
+      await tx.runAsync(
+        `UPDATE ${this.prefix}entries SET ontology_checked_at = ?
+         WHERE id IN (${placeholders}) AND entity_id = ?`,
+        [now, ...chunk, entityId],
+      );
+    }
+  }
+
+  /**
+   * Lightweight full-breadth title index (id, title, okf_type) over all live
+   * facts. Used by ontology backfill edge resolution — a recent-N window would
+   * miss an old fact's contemporaries.
+   */
+  async findTitleIndexByEntityId(entityId: string, tx?: SQLiteAdapter): Promise<Array<{ id: string; title: string; okf_type: string | null }>> {
+    const executor = this.getExecutor(tx);
+    const rows = await executor.getAllAsync<{ id: string; title: string; okf_type: string | null }>(
+      `SELECT id, title, okf_type FROM ${this.prefix}entries WHERE entity_id = ? AND deleted_at IS NULL`,
+      [entityId],
+    );
+    return rows.map(r => ({ id: r.id, title: r.title, okf_type: r.okf_type ?? null }));
+  }
 }

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -229,13 +229,9 @@ export class JobManager {
 
     switch (operation) {
       case 'librarian':
-        return this.activeMaintenanceJobs.has(this._librarianKey(entityId)) ||
-               this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
-               this._isReembedActive(entityId) ||
-               this._isImportActiveFor(entityId) ||
-               this._isForgetActiveFor(entityId);
       case 'heal':
-        return this.activeMaintenanceJobs.has(this._healKey(entityId)) ||
+      case 'ontologyBackfill':
+        return this.activeMaintenanceJobs.has(this.lockKeyFns[operation](entityId)) ||
                this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
                this._isReembedActive(entityId) ||
                this._isImportActiveFor(entityId) ||
@@ -244,6 +240,7 @@ export class JobManager {
         return this.activeMaintenanceJobs.has(this._pruneKey(entityId)) ||
                this.activeMaintenanceJobs.has(this._librarianKey(entityId)) ||
                this.activeMaintenanceJobs.has(this._healKey(entityId)) ||
+               this.activeMaintenanceJobs.has(this._ontologyBackfillKey(entityId)) ||
                this._isReembedActive(entityId) ||
                this._isIngestActiveFor(entityId) ||
                this._isImportActiveFor(entityId) ||

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -9,7 +9,8 @@ export type OperationType =
   | 'global_reembed'
   | 'import'
   | 'global_import'
-  | 'forget';
+  | 'forget'
+  | 'ontologyBackfill';
 
 export class JobManager {
   private activeMaintenanceJobs = new Set<string>();
@@ -29,6 +30,7 @@ export class JobManager {
   private _forgetKey(entityId: string) { return `${this.prefix}:${entityId}:forget`; }
   private _librarianKey(entityId: string) { return `${this.prefix}:${entityId}:librarian`; }
   private _healKey(entityId: string) { return `${this.prefix}:${entityId}:heal`; }
+  private _ontologyBackfillKey(entityId: string) { return `${this.prefix}:${entityId}:ontologyBackfill`; }
 
   /**
    * Lookup table for acquireLock/releaseLock's dynamic-dispatch branch.
@@ -46,6 +48,7 @@ export class JobManager {
     reembed: (id) => this._reembedKey(id),
     import: (id) => this._importKey(id),
     forget: (id) => this._forgetKey(id),
+    ontologyBackfill: (id) => this._ontologyBackfillKey(id),
   };
 
   private _isReembedActive(entityId: string): boolean {
@@ -110,6 +113,7 @@ export class JobManager {
         if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
         else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
         else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this.activeMaintenanceJobs.has(this._ontologyBackfillKey(entityId))) blockingOperation = 'ontologyBackfill';
         else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
         else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
         else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
@@ -117,8 +121,9 @@ export class JobManager {
         break;
 
       case 'librarian':
-      case 'heal': {
-        const opKey = operation === 'librarian' ? this._librarianKey(entityId) : this._healKey(entityId);
+      case 'heal':
+      case 'ontologyBackfill': {
+        const opKey = this.lockKeyFns[operation](entityId);
         if (this.activeMaintenanceJobs.has(opKey)) blockingOperation = operation;
         else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
         else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
@@ -133,6 +138,7 @@ export class JobManager {
         else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
         else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
         else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this.activeMaintenanceJobs.has(this._ontologyBackfillKey(entityId))) blockingOperation = 'ontologyBackfill';
         else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
         else if (this._isImportActiveFor(entityId)) blockingOperation = 'import';
         else if (this._isForgetActiveFor(entityId)) blockingOperation = 'forget';
@@ -144,6 +150,7 @@ export class JobManager {
         else if (this._isAnyMaintenanceActiveWithSuffix(':prune')) blockingOperation = 'prune';
         else if (this._isAnyMaintenanceActiveWithSuffix(':librarian')) blockingOperation = 'librarian';
         else if (this._isAnyMaintenanceActiveWithSuffix(':heal')) blockingOperation = 'heal';
+        else if (this._isAnyMaintenanceActiveWithSuffix(':ontologyBackfill')) blockingOperation = 'ontologyBackfill';
         else if (this.activeIngestJobs.size > 0) blockingOperation = 'ingest';
         else if (this._isAnyMaintenanceActiveWithSuffix(':import')) blockingOperation = 'import';
         else if (this._isAnyMaintenanceActiveWithSuffix(':forget')) blockingOperation = 'forget';
@@ -155,6 +162,7 @@ export class JobManager {
         if (this.activeMaintenanceJobs.has(selfKey)) blockingOperation = operation;
         else if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) blockingOperation = 'librarian';
         else if (this.activeMaintenanceJobs.has(this._healKey(entityId))) blockingOperation = 'heal';
+        else if (this.activeMaintenanceJobs.has(this._ontologyBackfillKey(entityId))) blockingOperation = 'ontologyBackfill';
         else if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) blockingOperation = 'prune';
         else if (this._isReembedActive(entityId)) blockingOperation = 'reembed';
         else if (this._isIngestActiveFor(entityId)) blockingOperation = 'ingest';
@@ -266,6 +274,7 @@ export class JobManager {
       if (this.activeMaintenanceJobs.has(this._importKey(entityId))) throw new WikiBusyError('import', entityId);
       if (this.activeMaintenanceJobs.has(this._librarianKey(entityId))) throw new WikiBusyError('librarian', entityId);
       if (this.activeMaintenanceJobs.has(this._healKey(entityId))) throw new WikiBusyError('heal', entityId);
+      if (this.activeMaintenanceJobs.has(this._ontologyBackfillKey(entityId))) throw new WikiBusyError('ontologyBackfill', entityId);
       if (this.activeMaintenanceJobs.has(this._pruneKey(entityId))) throw new WikiBusyError('prune', entityId);
       if (this._isReembedActive(entityId)) throw new WikiBusyError('reembed', entityId);
       if (this._isIngestActiveFor(entityId)) throw new WikiBusyError('ingest', entityId);

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -6,7 +6,7 @@ import { generateId } from '../utils/ids';
 import { parseEmbedding } from '../utils/embedding';
 import { PrunePartialFailureError } from '../types';
 import { HOOK_TIMEOUT_MARKER } from '../types';
-import type { WikiOptions, ExtractedFact, ExtractedTask, ExtractedFactWithOntology, WikiFact, WikiTask, OntologyUpdates } from '../types';
+import type { WikiOptions, ExtractedFact, ExtractedFactEdge, ExtractedTask, ExtractedFactWithOntology, WikiFact, WikiTask, OntologyUpdates, OntologyBackfillResult } from '../types';
 import type { SQLiteAdapter } from '../types';
 import type { EntryRepository } from '../repositories/EntryRepository';
 import type { TaskRepository } from '../repositories/TaskRepository';
@@ -18,6 +18,10 @@ import type { EmbeddingService } from './EmbeddingService';
 
 const FUZZY_THRESHOLD = 0.5;
 const MIN_TOKENS_TO_QUALIFY = 3;
+
+export const ONTOLOGY_BACKFILL_BATCH_SIZE = 25;
+export const ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS = 40_000;
+export const ONTOLOGY_BACKFILL_RECHECK_MS = 7 * 24 * 60 * 60 * 1000;
 
 export class MaintenanceService {
   private promptService: PromptService;
@@ -135,6 +139,18 @@ export class MaintenanceService {
       await this.doRunHeal(entityId, options?.promptOverride);
     } finally {
       this.jobManager.releaseLock('heal', entityId);
+    }
+  }
+
+  async runOntologyBackfill(
+    entityId: string,
+    options?: { promptOverride?: string; batchSize?: number },
+  ): Promise<OntologyBackfillResult> {
+    this.jobManager.acquireLock('ontologyBackfill', entityId);
+    try {
+      return await this.doRunOntologyBackfill(entityId, options);
+    } finally {
+      this.jobManager.releaseLock('ontologyBackfill', entityId);
     }
   }
 
@@ -541,6 +557,139 @@ export class MaintenanceService {
     }
 
     this.searchService.evictCache(entityId);
+  }
+
+  /** Core ontology backfill pass (locks handled by {@link runOntologyBackfill}). Package-internal orchestration hook. */
+  async doRunOntologyBackfill(
+    entityId: string,
+    options?: { promptOverride?: string; batchSize?: number },
+  ): Promise<OntologyBackfillResult> {
+    const batchSize = options?.batchSize ?? ONTOLOGY_BACKFILL_BATCH_SIZE;
+    if (!Number.isInteger(batchSize) || batchSize < 1) {
+      throw new Error('Invalid batchSize: must be an integer >= 1');
+    }
+
+    const now = Date.now();
+    const recheckCutoff = now - ONTOLOGY_BACKFILL_RECHECK_MS;
+    const zeroed = { scanned: 0, typed: 0, failedValidation: 0, edgesAdded: 0 };
+
+    const ontologyService = this.ontologyService;
+    if (!ontologyService) {
+      return { ...zeroed, remaining: 0, deferred: 0 };
+    }
+
+    const { mode } = await ontologyService.getEffectiveState(entityId);
+    if (mode === 'off') {
+      // remaining stays 0: with ontology off nothing is eligible for typing, and
+      // a host convergence loop (while remaining > 0) must terminate.
+      const counts = await this.entryRepo.countUntypedByEntityId(entityId, recheckCutoff);
+      return { ...zeroed, remaining: 0, deferred: counts.deferred };
+    }
+
+    const candidates = await this.entryRepo.findUntypedByEntityId(entityId, batchSize, recheckCutoff);
+    if (candidates.length === 0) {
+      const counts = await this.entryRepo.countUntypedByEntityId(entityId, recheckCutoff);
+      return { ...zeroed, remaining: counts.eligible, deferred: counts.deferred };
+    }
+
+    // Payload guard: cap accumulated title+body chars so dense facts cannot blow
+    // a provider's context window; a single oversized fact is still sent alone.
+    const batch: WikiFact[] = [];
+    let promptChars = 0;
+    for (const fact of candidates) {
+      const len = fact.title.length + fact.body.length;
+      if (batch.length > 0 && promptChars + len > ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS) break;
+      batch.push(fact);
+      promptChars += len;
+    }
+
+    const ontologyContext = await ontologyService.buildPromptContext(entityId);
+    const factsForPrompt = batch.map(f => ({ id: f.id, title: f.title, body: f.body, tags: f.tags }));
+
+    const { systemPrompt, userPrompt } = this.promptService.buildOntologyBackfillPrompt(
+      factsForPrompt,
+      options?.promptOverride,
+      ontologyContext,
+    );
+
+    const responseText = await this.options.llmProvider.generateText({ systemPrompt, userPrompt });
+
+    const parsed = parseJsonResponse<{
+      classifications?: Array<{ id?: unknown; okf_type?: unknown; edges?: unknown }>;
+      ontology_updates?: OntologyUpdates;
+    }>(responseText);
+    const classifications = Array.isArray(parsed.classifications) ? parsed.classifications : [];
+
+    let typed = 0;
+    let failedValidation = 0;
+    let edgesAdded = 0;
+
+    await this.db.withTransactionAsync(async (tx) => {
+      let { mode: txMode, manifest } = await ontologyService.getEffectiveState(entityId, tx);
+
+      if (txMode === 'emergent' && parsed.ontology_updates) {
+        manifest = await ontologyService.mergeEmergentUpdates(entityId, parsed.ontology_updates, tx);
+      }
+
+      // Full breadth, three columns only: an old fact's edge targets are its
+      // contemporaries, which a recent-100 window would silently miss.
+      const titleRows = await this.entryRepo.findTitleIndexByEntityId(entityId, tx);
+      const titleIndex = new Map<string, TitleIndexEntry>();
+      for (const row of titleRows) {
+        titleIndex.set(normalizeTitleKey(row.title), { id: row.id, okf_type: row.okf_type });
+      }
+
+      const batchById = new Map(batch.map(f => [f.id, f]));
+      const applied = new Set<string>();
+      const pendingEdges: Array<{ sourceId: string; sourceType: string; edges: ExtractedFactEdge[] }> = [];
+
+      for (const classification of classifications) {
+        const fact = typeof classification.id === 'string' ? batchById.get(classification.id) : undefined;
+        if (!fact || applied.has(fact.id)) {
+          failedValidation++;
+          continue;
+        }
+        applied.add(fact.id);
+
+        const normalized = ontologyService.validateAndNormalizeFact(
+          {
+            title: fact.title, body: fact.body, tags: fact.tags, confidence: fact.confidence,
+            okf_type: classification.okf_type as string | undefined, edges: classification.edges as ExtractedFactEdge[] | undefined,
+          } as ExtractedFactWithOntology,
+          manifest,
+        );
+        if (!normalized.okf_type) {
+          failedValidation++;
+          continue;
+        }
+
+        const result = await this.entryRepo.updateOkfType(fact.id, entityId, normalized.okf_type, tx);
+        // changes === 0 → typed concurrently between select and update; the
+        // okf_type IS NULL guard left it untouched. Counted as an omission.
+        if (result.changes === 0) continue;
+
+        typed++;
+        titleIndex.set(normalizeTitleKey(fact.title), { id: fact.id, okf_type: normalized.okf_type });
+        if (normalized.edges.length > 0) {
+          pendingEdges.push({ sourceId: fact.id, sourceType: normalized.okf_type, edges: normalized.edges });
+        }
+      }
+
+      // Two-phase: edges resolve only after every batch fact has its new type,
+      // so intra-batch targets pass the target-type check.
+      for (const item of pendingEdges) {
+        edgesAdded += await ontologyService.resolveAndPersistEdges(
+          entityId, item.sourceId, item.sourceType, item.edges, manifest, titleIndex, tx, now,
+        );
+      }
+
+      await this.entryRepo.markOntologyChecked(batch.map(f => f.id), entityId, now, tx);
+    });
+
+    this.searchService.evictCache(entityId);
+
+    const counts = await this.entryRepo.countUntypedByEntityId(entityId, recheckCutoff);
+    return { scanned: batch.length, typed, failedValidation, edgesAdded, remaining: counts.eligible, deferred: counts.deferred };
   }
 
   private _validatePruneDuration(value: number | null | undefined, name: string): void {

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -592,25 +592,30 @@ export class MaintenanceService {
       return { ...zeroed, remaining: counts.eligible, deferred: counts.deferred };
     }
 
-    // Payload guard: cap accumulated title+body chars so dense facts cannot blow
-    // a provider's context window; a single oversized fact is still sent alone.
-    const batch: WikiFact[] = [];
-    let promptChars = 0;
-    for (const fact of candidates) {
-      const len = fact.title.length + fact.body.length;
-      if (batch.length > 0 && promptChars + len > ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS) break;
-      batch.push(fact);
-      promptChars += len;
-    }
-
     const ontologyContext = await ontologyService.buildPromptContext(entityId);
-    const factsForPrompt = batch.map(f => ({ id: f.id, title: f.title, body: f.body, tags: f.tags }));
 
-    const { systemPrompt, userPrompt } = this.promptService.buildOntologyBackfillPrompt(
-      factsForPrompt,
+    // Payload guard: cap the full serialized prompt (system + user — manifest,
+    // ids, tags, JSON syntax, overrides all counted) so dense facts cannot blow
+    // a provider's context window. A single fact whose prompt alone exceeds the
+    // cap is still sent by itself: deferring it would just re-defer forever and
+    // starve it (spec Decision 2).
+    const toPromptShape = (f: WikiFact) => ({ id: f.id, title: f.title, body: f.body, tags: f.tags });
+    const buildPrompt = (facts: WikiFact[]) => this.promptService.buildOntologyBackfillPrompt(
+      facts.map(toPromptShape),
       options?.promptOverride,
       ontologyContext,
     );
+
+    const batch: WikiFact[] = [candidates[0]];
+    let built = buildPrompt(batch);
+    for (let i = 1; i < candidates.length; i++) {
+      const next = buildPrompt([...batch, candidates[i]]);
+      if (next.systemPrompt.length + next.userPrompt.length > ONTOLOGY_BACKFILL_MAX_PROMPT_CHARS) break;
+      batch.push(candidates[i]);
+      built = next;
+    }
+
+    const { systemPrompt, userPrompt } = built;
 
     const responseText = await this.options.llmProvider.generateText({ systemPrompt, userPrompt });
 
@@ -624,8 +629,18 @@ export class MaintenanceService {
     let failedValidation = 0;
     let edgesAdded = 0;
 
+    let abortedOntologyOff = false;
+
     await this.db.withTransactionAsync(async (tx) => {
       let { mode: txMode, manifest } = await ontologyService.getEffectiveState(entityId, tx);
+
+      // setOntologyManifest is not under this job lock, so ontology can be
+      // disabled while generateText was in flight. Abort without typing facts
+      // or stamping cooldowns.
+      if (txMode === 'off') {
+        abortedOntologyOff = true;
+        return;
+      }
 
       if (txMode === 'emergent' && parsed.ontology_updates) {
         manifest = await ontologyService.mergeEmergentUpdates(entityId, parsed.ontology_updates, tx);
@@ -685,6 +700,13 @@ export class MaintenanceService {
 
       await this.entryRepo.markOntologyChecked(batch.map(f => f.id), entityId, now, tx);
     });
+
+    if (abortedOntologyOff) {
+      // Mirror the mode === 'off' early path: remaining stays 0 so a host
+      // convergence loop (while remaining > 0) still terminates.
+      const counts = await this.entryRepo.countUntypedByEntityId(entityId, recheckCutoff);
+      return { ...zeroed, remaining: 0, deferred: counts.deferred };
+    }
 
     this.searchService.evictCache(entityId);
 

--- a/packages/core/src/services/OntologyService.ts
+++ b/packages/core/src/services/OntologyService.ts
@@ -114,9 +114,10 @@ export class OntologyService {
     titleIndex: Map<string, TitleIndexEntry>,
     tx: SQLiteAdapter,
     now: number,
-  ): Promise<void> {
-    if (!sourceType || edges.length === 0) return;
+  ): Promise<number> {
+    if (!sourceType || edges.length === 0) return 0;
 
+    let persisted = 0;
     for (const edge of edges) {
       const def = resolveEdgeDefinition(edge.edge_type, manifest);
       if (!def || def.source_type.toLowerCase() !== sourceType.toLowerCase()) continue;
@@ -135,7 +136,9 @@ export class OntologyService {
         edge_type: def.type,
         created_at: now,
       };
-      await this.edgeRepo.addIgnoreDuplicate(wikiEdge, tx);
+      const inserted = await this.edgeRepo.addIgnoreDuplicate(wikiEdge, tx);
+      if (inserted) persisted++;
     }
+    return persisted;
   }
 }

--- a/packages/core/src/services/PromptService.ts
+++ b/packages/core/src/services/PromptService.ts
@@ -1,4 +1,9 @@
-import { INGEST_SYSTEM_PROMPT, LIBRARIAN_SYSTEM_PROMPT, HEAL_SYSTEM_PROMPT } from '../prompts';
+import {
+  INGEST_SYSTEM_PROMPT,
+  LIBRARIAN_SYSTEM_PROMPT,
+  HEAL_SYSTEM_PROMPT,
+  ONTOLOGY_BACKFILL_SYSTEM_PROMPT,
+} from '../prompts';
 import type { PromptOverrides, OntologyPromptContext } from '../types';
 
 export class PromptService {
@@ -105,6 +110,25 @@ export class PromptService {
     return {
       systemPrompt: template,
       userPrompt: `Heal Candidates:\n${JSON.stringify(healCandidates, null, 2)}\nDocument Anchors (DO NOT MODIFY OR DELETE):\n${JSON.stringify(documentAnchors, null, 2)}\nAll Tasks:\n${JSON.stringify(allTasks, null, 2)}\nRecent Events:\n${JSON.stringify(recentEvents, null, 2)}\nThe following document anchors are provided for contradiction detection only. Do not include them in \`downgraded\`, \`deleted\`, or \`newFacts\`.`,
+    };
+  }
+
+  buildOntologyBackfillPrompt(
+    facts: unknown[],
+    runtimeOverride?: string,
+    ontologyContext?: OntologyPromptContext | null,
+  ): { systemPrompt: string; userPrompt: string } {
+    const template = runtimeOverride ?? this.globalOverrides?.ontologyBackfillSystemPrompt ?? ONTOLOGY_BACKFILL_SYSTEM_PROMPT;
+    const hasFacts = /\{\{\s*facts\s*\}\}/.test(template);
+    if (hasFacts || this.hasOntologyPlaceholders(template)) {
+      return {
+        systemPrompt: this.buildSystemPrompt(template, { facts }, ontologyContext),
+        userPrompt: hasFacts ? 'Please classify the facts.' : `Facts:\n${JSON.stringify(facts, null, 2)}`,
+      };
+    }
+    return {
+      systemPrompt: this.appendOntology(template, ontologyContext),
+      userPrompt: `Facts:\n${JSON.stringify(facts, null, 2)}`,
     };
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,7 @@ export interface PromptOverrides {
   ingestSystemPrompt?: string;
   librarianSystemPrompt?: string;
   healSystemPrompt?: string;
+  ontologyBackfillSystemPrompt?: string;
 }
 
 export type OntologyMode = 'strict' | 'emergent' | 'off';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,6 +86,23 @@ export interface OntologyPromptContext {
   ontologyModeInstructions: string;
 }
 
+/** Result of a single ontology backfill run. Omissions (facts the model declined
+ * to classify) are derivable as scanned − typed − failedValidation. */
+export interface OntologyBackfillResult {
+  /** Untyped facts sent to the model this run. */
+  scanned: number;
+  /** Facts that received an okf_type. */
+  typed: number;
+  /** Model classifications rejected (unknown/duplicate id, non-manifest type). */
+  failedValidation: number;
+  /** Edges persisted. */
+  edgesAdded: number;
+  /** Untyped facts still eligible after this run — safe host convergence signal: loop while > 0. */
+  remaining: number;
+  /** Untyped facts inside the recheck cooldown. */
+  deferred: number;
+}
+
 export interface WikiConfig {
   /**
    * Prefix applied to every SQL table/index/trigger name. Must match

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,7 +97,9 @@ export interface OntologyBackfillResult {
   failedValidation: number;
   /** Edges persisted. */
   edgesAdded: number;
-  /** Untyped facts still eligible after this run — safe host convergence signal: loop while > 0. */
+  /** Untyped facts still eligible after this run — safe host convergence signal: loop while > 0.
+   * Always 0 when ontology mode is 'off' (nothing is eligible for typing while
+   * disabled), so 0 does not imply queue exhaustion in that mode. */
   remaining: number;
   /** Untyped facts inside the recheck cooldown. */
   deferred: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -495,8 +495,9 @@ export interface EntityStatus {
  *
  * @remarks **Breaking change from v2.x** — the union previously only contained
  * `'ingest' | 'librarian' | 'heal' | 'prune' | 'reembed'`. The values `'import'`
- * and `'forget'` were added in v3.0. Exhaustive `switch` / narrowing on this type
- * must be updated (or given a `default` arm) to compile without errors.
+ * and `'forget'` were added in v3.0. `'ontologyBackfill'` was added afterward.
+ * Exhaustive `switch` / narrowing on this type must be updated (or given a
+ * `default` arm) to compile without errors.
  */
 export type WikiBusyOperation =
   | 'ingest'
@@ -505,7 +506,8 @@ export type WikiBusyOperation =
   | 'prune'
   | 'reembed'
   | 'import'
-  | 'forget';
+  | 'forget'
+  | 'ontologyBackfill';
 
 /**
  * Thrown when a background mutator is already running for the requested entity.


### PR DESCRIPTION
## Summary
- Adds `runOntologyBackfill(entityId, options?)` to `@equationalapplications/core-llm-wiki`: types already-persisted facts whose `okf_type IS NULL` (synced-down remote facts, pre-ontology facts) in place via one librarian-style LLM call per run.
- Strictly additive: never creates/deletes/rewrites facts, never overwrites an existing `okf_type` (guarded in SQL), never touches `updated_at`. Bounded batch (25 facts default, 40k char cap), 7-day recheck cooldown via new `ontology_checked_at` column (migration v7).
- New `ontologyBackfill` JobManager lock, symmetric with prune/reembed/import/forget/global_reembed. Two-phase edge resolution so intra-batch edge targets resolve correctly regardless of ordering.

## Test plan
- [x] Full suite: 738/738 tests passing (62 files)
- [x] `npm run typecheck` clean
- [x] Implemented via superpowers subagent-driven-development: each of the 8 plan tasks passed spec-compliance review + code-quality review individually, plus a final holistic integration review across the whole branch (no critical/important issues found)
- [x] Spec: `docs/superpowers/specs/2026-07-13-ontology-backfill-spec.md` (13 scenarios, all covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)