### PR TITLE
feat: polymorphic ontology edges + schema.org warm-agent manifest package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
           # Workspace package versions are already set by semantic-release's prepare phase.
           publish_if_needed "./packages/core-llm-tools/package.json" pnpm --filter "./packages/core-llm-tools" publish --no-git-checks --access public
           publish_if_needed "./packages/core/package.json" pnpm --filter "./packages/core" publish --no-git-checks --access public
+          publish_if_needed "./packages/schema-org/package.json" pnpm --filter "./packages/schema-org" publish --no-git-checks --access public
           publish_if_needed "./packages/react/package.json" pnpm --filter "./packages/react" publish --no-git-checks --access public
           publish_if_needed "./packages/expo/package.json" pnpm --filter "./packages/expo" publish --no-git-checks --access public
           publish_if_needed "./packages/prisma-outbox/package.json" pnpm --filter "./packages/prisma-outbox" publish --no-git-checks --access public

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,11 +11,11 @@
       "npmPublish": false
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox','core-llm-tools','okf'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
+      "prepareCmd": "node -e \"const fs=require('fs'); ['core','react','expo','prisma-outbox','core-llm-tools','okf','schema-org'].forEach(pkg => { const p=JSON.parse(fs.readFileSync('packages/'+pkg+'/package.json')); p.version='${nextRelease.version}'; fs.writeFileSync('packages/'+pkg+'/package.json', JSON.stringify(p,null,2)+'\\n'); });\""
     }],
     "@semantic-release/github",
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json", "packages/core-llm-tools/package.json", "packages/okf/package.json"],
+      "assets": ["CHANGELOG.md", "package.json", "packages/core/package.json", "packages/react/package.json", "packages/expo/package.json", "packages/prisma-outbox/package.json", "packages/core-llm-tools/package.json", "packages/okf/package.json", "packages/schema-org/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }]
   ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Freact-llm-wiki?label=@equationalapplications/react-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Freact-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/react-llm-wiki)<br>
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-wiki?label=@equationalapplications/core-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-wiki)<br>
 [![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-llm-tools?label=@equationalapplications/core-llm-tools)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-llm-tools?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-llm-tools)<br>
-[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-okf?label=@equationalapplications/core-okf)](https://www.npmjs.com/package/@equationalapplications/core-okf) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-okf?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-okf)
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fcore-okf?label=@equationalapplications/core-okf)](https://www.npmjs.com/package/@equationalapplications/core-okf) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fcore-okf?label=downloads)](https://www.npmjs.com/package/@equationalapplications/core-okf)<br>
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fschema-org-llm-wiki?label=@equationalapplications/schema-org-llm-wiki)](https://www.npmjs.com/package/@equationalapplications/schema-org-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fschema-org-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/schema-org-llm-wiki)
 
 **[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[ScopeLab](https://equationalapplications.github.io/expo-llm-wiki/scopelab/)** · **[WikiDemo](https://equationalapplications.github.io/expo-llm-wiki/wiki-demo/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
 
@@ -99,7 +100,7 @@ flowchart TB
 
 ## Monorepo Ecosystem
 
-`expo-llm-wiki` is organized as a monorepo with six packages:
+`expo-llm-wiki` is organized as a monorepo with seven packages:
 
 | Package | Purpose | Platform |
 |---------|---------|----------|
@@ -109,6 +110,7 @@ flowchart TB
 | **`@equationalapplications/prisma-outbox`** | Sync SQLite outbox events to Prisma-backed database (transactional outbox pattern) | Node.js |
 | **`@equationalapplications/core-llm-tools`** | Platform-agnostic Gemini tool schemas and capability-based scope injector | Node.js, browser, React Native |
 | **`@equationalapplications/core-okf`** | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. | Node.js, browser, React Native |
+| **`@equationalapplications/schema-org-llm-wiki`** | Curated schema.org warm-agent ontology manifest — 9 node types, 28 polymorphic edges, data-only | Node.js, browser, React Native |
 
 **Choose your package:**
 - **Expo/React Native app?** → `@equationalapplications/expo-llm-wiki`

--- a/docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md
+++ b/docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md
@@ -1,8 +1,14 @@
 # Polymorphic Edge Triples + `@equationalapplications/schema-org-llm-wiki` — Spec
 
 **Date:** 2026-07-14
-**Status:** Design Complete (Pending Implementation)
+**Status:** Implemented (branch `feat/polymorphic-edge-triples`, 2026-07-14)
 **Packages:** `@equationalapplications/core-llm-wiki` (validation change), `@equationalapplications/schema-org-llm-wiki` (new)
+
+> **Implementation record.** This spec was implemented as designed with three
+> deliberate deviations, recorded in
+> [Deviations discovered during implementation](#deviations-discovered-during-implementation).
+> One semantic technicality in the manifest is recorded in
+> [Known semantic technicality](#known-semantic-technicality-suborganization).
 
 ---
 
@@ -48,7 +54,11 @@ fix is in the library, and it benefits every consumer of the packages.
   (each part trimmed + lowercased).
 - Error message for a true duplicate:
   `Duplicate edge definition: ${type} (${source_type} → ${target_type})`.
-- Node-type validation unchanged. Unknown source/target node check unchanged.
+- Node-type validation unchanged. Unknown source/target node check unchanged
+  in condition and message, but it now runs **before** the duplicate check
+  (the triple key requires non-empty source/target). A manifest failing both
+  checks now reports the unknown-node error instead of the duplicate error.
+  No consumer or test relied on the old ordering.
 
 **`mergeOntologyUpdates`** (emergent mode)
 - Skip-existing check uses the same triple key. An emergent update may now add
@@ -57,7 +67,13 @@ fix is in the library, and it benefits every consumer of the packages.
 **`resolveEdgeDefinition` → `resolveEdgeDefinitions`**
 - Returns **all** case-insensitive name matches (`OntologyEdgeType[]`) instead
   of the first. Internal utility — not exported from the package index, so no
-  public API break.
+  public API break. The singular `resolveEdgeDefinition` was deleted once its
+  last caller (`OntologyService`) migrated.
+
+**`validateManifest` export** (added during implementation)
+- Newly exported from `packages/core/src/index.ts`. Required so the
+  schema-org package's tests (and any consumer) can validate a manifest
+  across the package boundary before seeding. Additive — no API break.
 
 **`validateInlineEdges`**
 - An extracted edge is kept if **any** definition matches its name and the
@@ -109,17 +125,26 @@ Manifest JSON injection is otherwise unchanged.
 packages/schema-org/
   package.json          # name @equationalapplications/schema-org-llm-wiki
   tsconfig.json         # same pattern as sibling packages
+  tsup.config.ts        # cjs+esm+dts; core-llm-wiki external
+  vitest.config.ts      # node environment, __tests__/**/*.test.ts
+  LICENSE               # copy of core's MIT license
   src/index.ts          # manifest constant + re-exported types
   __tests__/manifest.test.ts
+  __tests__/__snapshots__/manifest.test.ts.snap
   README.md
 ```
 
 - **Data-only** — no runtime logic.
 - `dependencies`: `@equationalapplications/core-llm-wiki: workspace:*`
   (types only; matches sibling-package convention, e.g. `packages/react`).
-- Build: same tsup setup as siblings; picked up by root `pnpm -r build` and
-  the existing release workflow with no workflow changes.
-- Versioning/changelog: semantic-release lockstep — nothing manual.
+- Build: same tsup setup as siblings; picked up by root `pnpm -r build`.
+- Release: the pipeline hardcodes its package list, so schema-org was added
+  to `.releaserc.json` (prepareCmd array + git assets) and to
+  `.github/workflows/release.yml` (`publish_if_needed` line, placed after
+  core since schema-org depends only on core). See
+  [deviations](#deviations-discovered-during-implementation).
+- Versioning/changelog: semantic-release lockstep — nothing manual beyond
+  the initial scaffold version matching the then-current lockstep value.
 
 ### Exports
 
@@ -151,7 +176,9 @@ const wiki = createWiki(db, {
 `creativework`, `review`, `product`.
 
 Changes vs. the Clanker draft spec (all in service of full schema.org
-standardness — zero deviations, exact JSON-LD mapping):
+standardness — every type and property name is schema.org-standard, with one
+recorded semantic technicality on `subOrganization`; see
+[below](#known-semantic-technicality-suborganization)):
 
 | Draft | Final | Why |
 |-------|-------|-----|
@@ -206,6 +233,17 @@ Casing: property names keep schema.org camelCase (`worksFor`,
 `itemReviewed`). Validation compares lowercase but stores the given casing,
 so camelCase survives to storage and future JSON-LD export.
 
+### Known semantic technicality: `subOrganization`
+
+The manifest applies `subOrganization` as `project → project`. Schema.org
+defines the property's domain/range as Organization → Organization; the
+mapping here leans on Project ⊂ Organization subclassing. This is technically
+valid RDF/JSON-LD — a parser accepts a Project at either end — but it treats
+a Project as an entity structure rather than a pure task container, so the
+"exact JSON-LD mapping" claim is a stretch for this one row. Recorded as a
+deliberate pragmatic compromise: `subProject` does not exist in schema.org,
+and `subOrganization` is the closest standard hierarchy property.
+
 ### README contents
 
 - What the package is; why curated (prompt size, classification accuracy).
@@ -216,6 +254,27 @@ so camelCase survives to storage and future JSON-LD export.
 - Requires a core version with triple-keyed edge validation (same release).
 
 ---
+
+## Deviations discovered during implementation
+
+Three deliberate deviations from this spec as originally written, all made
+during implementation and reviewed:
+
+1. **Release pipeline changes were required** (spec originally claimed "no
+   workflow changes"). `.releaserc.json` hardcodes the package list in its
+   `@semantic-release/exec` prepareCmd and `@semantic-release/git` assets,
+   and `.github/workflows/release.yml` hardcodes one `publish_if_needed`
+   line per package. `schema-org` was added to all three; without this the
+   package would never be version-bumped or published.
+2. **`validateManifest` is exported from core's package index.** The spec's
+   own test plan ("Manifest passes `validateManifest`" in the schema-org
+   package) requires the function across the package boundary. Additive
+   export, no API break, useful to any consumer validating a custom
+   manifest before seeding.
+3. **Edge validation check ordering changed.** The unknown-node check in
+   `validateManifest` now runs before the duplicate check, because the
+   triple key requires non-empty source/target. Condition and message are
+   unchanged; only which error wins when a manifest fails both differs.
 
 ## Data Flow (unchanged paths, new behavior)
 
@@ -255,6 +314,9 @@ check) → `resolveAndPersistEdges` (target-type selection among rows) →
 - Exactly 9 node types, 28 edges; every edge's source/target exists in the
   node list.
 - Snapshot test to catch accidental content drift.
+- (Added during implementation) 19 unique property names with expected
+  polymorphic counts (`location` ×2, `organizer` ×2, `about` ×4,
+  `itemReviewed` ×5); every node and edge has a non-empty description.
 
 ### Integration — `packages/integration`
 - Seed the full manifest; librarian round-trip classifies facts into

--- a/docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md
+++ b/docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md
@@ -1,0 +1,285 @@
+# Polymorphic Edge Triples + `@equationalapplications/schema-org-llm-wiki` — Spec
+
+**Date:** 2026-07-14
+**Status:** Design Complete (Pending Implementation)
+**Packages:** `@equationalapplications/core-llm-wiki` (validation change), `@equationalapplications/schema-org-llm-wiki` (new)
+
+---
+
+## Executive Summary
+
+Two coupled deliverables:
+
+1. **Core library change:** ontology edge definitions become unique by the
+   `(type, source_type, target_type)` triple instead of by `type` alone, so one
+   schema.org property name (`about`, `itemReviewed`, `location`, `organizer`)
+   can appear as multiple manifest rows with different source/target types —
+   mirroring schema.org's own polymorphic domain/range model.
+2. **New data-only package** `@equationalapplications/schema-org-llm-wiki`
+   shipping a curated, fully schema.org-standard warm-agent ontology manifest
+   (9 node types, 28 edges) that any consumer can drop into `OntologyConfig`.
+
+The `OntologyEdgeType` wire format is unchanged. Every manifest that validates
+today still validates. The change is strictly permissive.
+
+---
+
+## Problem Statement
+
+`validateManifest` in `packages/core/src/utils/ontology.ts` dedupes edges by
+lowercased `type` alone and throws `Duplicate edge type` on the second
+occurrence of a name. Schema.org properties are polymorphic — `about` legally
+targets Person, Organization, Place, and Event. A curated schema.org manifest
+(Clanker spec `2026-07-14-curated-schema-ontology-design.md`) needs 28 edges
+but only 19 unique property names; it is rejected at load today.
+
+Flattening names (`aboutPerson`, `aboutPlace`, …) would leak non-standard
+vocabulary into prompts, stored edges, and future JSON-LD export. The right
+fix is in the library, and it benefits every consumer of the packages.
+
+---
+
+## Part 1 — Core: Triple-Keyed Edge Definitions
+
+### `packages/core/src/utils/ontology.ts`
+
+**`validateManifest`**
+- Edge uniqueness key: `` `${type}|${source_type}|${target_type}` ``
+  (each part trimmed + lowercased).
+- Error message for a true duplicate:
+  `Duplicate edge definition: ${type} (${source_type} → ${target_type})`.
+- Node-type validation unchanged. Unknown source/target node check unchanged.
+
+**`mergeOntologyUpdates`** (emergent mode)
+- Skip-existing check uses the same triple key. An emergent update may now add
+  a new source/target variant of an existing property name.
+
+**`resolveEdgeDefinition` → `resolveEdgeDefinitions`**
+- Returns **all** case-insensitive name matches (`OntologyEdgeType[]`) instead
+  of the first. Internal utility — not exported from the package index, so no
+  public API break.
+
+**`validateInlineEdges`**
+- An extracted edge is kept if **any** definition matches its name and the
+  fact's source type (target type is unknown at extraction time —
+  `target_title` is not yet resolved to a typed fact).
+- The emitted `edge_type` uses the canonical casing of a matching definition.
+  When multiple rows share the name, casing is identical by construction
+  (same property name), so which match supplies casing is immaterial.
+
+### `packages/core/src/services/OntologyService.ts`
+
+**`resolveAndPersistEdges`**
+- Current code resolves one definition by name, then rejects when the actual
+  target's `okf_type` differs from `def.target_type` (line 129). New behavior:
+  among definitions matching name + source type, **select** the one whose
+  `target_type` equals the resolved target's `okf_type` (case-insensitive).
+- No matching row → edge skipped (same outcome as today).
+- Untyped target (`okf_type` null) → skipped, unchanged.
+- Persisted `WikiEdge.edge_type` stores the property name only, as today —
+  source/target types live on the nodes themselves.
+
+### `packages/core/src/prompts/ontology.ts`
+
+Append one line to `FACT_ONTOLOGY_FIELDS`:
+
+> An edge_type may appear in the manifest multiple times with different
+> source_type/target_type; use the row whose types match your fact and target.
+
+Manifest JSON injection is otherwise unchanged.
+
+### Backward compatibility
+
+- `OntologyEdgeType` shape unchanged; stored manifests untouched; no
+  migration.
+- Any manifest valid before this change remains valid (name-unique implies
+  triple-unique).
+- Backfill (`runOntologyBackfill`) reuses these same code paths; no backfill
+  changes.
+- Ships as a `feat:` commit — semantic-release derives the version bump and
+  changelog (no manual version edits anywhere in this work).
+
+---
+
+## Part 2 — New Package: `@equationalapplications/schema-org-llm-wiki`
+
+### Layout
+
+```
+packages/schema-org/
+  package.json          # name @equationalapplications/schema-org-llm-wiki
+  tsconfig.json         # same pattern as sibling packages
+  src/index.ts          # manifest constant + re-exported types
+  __tests__/manifest.test.ts
+  README.md
+```
+
+- **Data-only** — no runtime logic.
+- `dependencies`: `@equationalapplications/core-llm-wiki: workspace:*`
+  (types only; matches sibling-package convention, e.g. `packages/react`).
+- Build: same tsup setup as siblings; picked up by root `pnpm -r build` and
+  the existing release workflow with no workflow changes.
+- Versioning/changelog: semantic-release lockstep — nothing manual.
+
+### Exports
+
+```ts
+import type { OntologyManifest } from '@equationalapplications/core-llm-wiki';
+
+/** Curated schema.org warm-agent ontology: 9 node types, 28 edges. */
+export const schemaOrgWarmAgentManifest: OntologyManifest = { ... };
+```
+
+Consumer adoption:
+
+```ts
+import { schemaOrgWarmAgentManifest } from '@equationalapplications/schema-org-llm-wiki';
+
+const wiki = createWiki(db, {
+  ontology: {
+    mode: 'strict',
+    seedManifests: { [entityId]: { mode: 'strict', manifest: schemaOrgWarmAgentManifest } },
+  },
+});
+```
+
+(Exact `OntologyConfig` wiring per core's interface; snippet in README.)
+
+### Manifest content — 9 node types
+
+`person`, `organization`, `place`, `event`, `project`, `action`,
+`creativework`, `review`, `product`.
+
+Changes vs. the Clanker draft spec (all in service of full schema.org
+standardness — zero deviations, exact JSON-LD mapping):
+
+| Draft | Final | Why |
+|-------|-------|-----|
+| `rating` node | `review` node | `itemReviewed` domain is Review/AggregateRating, not Rating (schema.org) |
+| `participant` edge | `attendee` edge | `participant` domain is Action; Event's standard property is `attendee` |
+| `subProject` edge | `subOrganization` edge | `subProject` is not a schema.org property; Project ⊂ Organization, so `subOrganization` is the standard hierarchy property |
+| `object` (loose description) | `object` (tightened description) | Kept — standard Action property with range Thing; description reads "Project this task belongs to; the object the action advances" to steer the LLM |
+| `parent` (ambiguous direction) | `parent` (direction stated) | Description states: source = child, target = parent ("a parent of this person") |
+
+Node descriptions follow the Clanker draft spec, with `review` description
+adapted from `rating` (implicit subject remains the owning character;
+`reviewRating` value stays inside fact content per the literal-property rule).
+
+### Manifest content — 28 edges
+
+| # | type | source | target |
+|---|------|--------|--------|
+| 1 | `knows` | person | person |
+| 2 | `spouse` | person | person |
+| 3 | `parent` | person | person |
+| 4 | `worksFor` | person | organization |
+| 5 | `memberOf` | person | organization |
+| 6 | `homeLocation` | person | place |
+| 7 | `workLocation` | person | place |
+| 8 | `location` | event | place |
+| 9 | `location` | organization | place |
+| 10 | `containedInPlace` | place | place |
+| 11 | `subOrganization` | project | project |
+| 12 | `object` | action | project |
+| 13 | `agent` | action | person |
+| 14 | `attendee` | event | person |
+| 15 | `organizer` | event | person |
+| 16 | `organizer` | event | organization |
+| 17 | `author` | creativework | person |
+| 18 | `publisher` | creativework | organization |
+| 19 | `about` | creativework | person |
+| 20 | `about` | creativework | organization |
+| 21 | `about` | creativework | place |
+| 22 | `about` | creativework | event |
+| 23 | `itemReviewed` | review | creativework |
+| 24 | `itemReviewed` | review | organization |
+| 25 | `itemReviewed` | review | place |
+| 26 | `itemReviewed` | review | event |
+| 27 | `itemReviewed` | review | product |
+| 28 | `owns` | person | product |
+
+19 unique property names; polymorphic rows: `location` ×2, `organizer` ×2,
+`about` ×4, `itemReviewed` ×5. Edge descriptions follow the Clanker draft
+spec, adjusted for the renames above.
+
+Casing: property names keep schema.org camelCase (`worksFor`,
+`itemReviewed`). Validation compares lowercase but stores the given casing,
+so camelCase survives to storage and future JSON-LD export.
+
+### README contents
+
+- What the package is; why curated (prompt size, classification accuracy).
+- Adoption snippet (above).
+- Schema.org alignment table (types + properties, all standard).
+- JSON-LD export notes (camelCase preserved; literal properties like
+  `birthDate`/`startTime` live in fact content, not edges).
+- Requires a core version with triple-keyed edge validation (same release).
+
+---
+
+## Data Flow (unchanged paths, new behavior)
+
+Librarian/ingest prompt carries manifest JSON (now with polymorphic rows) →
+LLM emits `okf_type` + `edges` → `validateAndNormalizeFact` (name + source
+check) → `resolveAndPersistEdges` (target-type selection among rows) →
+`wiki_edges`. Backfill uses the same path.
+
+## Error Handling
+
+- True duplicate triple in a manifest → throw at `setOntologyManifest`/seed
+  load (same failure point as today, narrower condition).
+- LLM emits an edge whose name matches but no row fits source/target →
+  silently dropped; the existing prompt fallback rule already instructs the
+  model to omit rather than invent.
+
+---
+
+## Testing
+
+### Unit — `packages/core/__tests__` (utils)
+- `validateManifest` accepts a manifest with `about` ×4 (distinct triples).
+- `validateManifest` rejects an exact duplicate triple with the new message.
+- `mergeOntologyUpdates` adds a new source/target variant of an existing
+  name; skips an exact-triple duplicate.
+- `resolveEdgeDefinitions` returns all name matches, case-insensitive.
+- `validateInlineEdges` keeps an edge when any row matches name + source;
+  drops it when only the name matches (wrong source).
+
+### Unit — `OntologyService`
+- `resolveAndPersistEdges` picks the correct row among 4 `about` rows based
+  on target `okf_type`; persists one edge.
+- Skips when target's `okf_type` matches no row; skips untyped target.
+
+### Package — `packages/schema-org/__tests__`
+- Manifest passes `validateManifest`.
+- Exactly 9 node types, 28 edges; every edge's source/target exists in the
+  node list.
+- Snapshot test to catch accidental content drift.
+
+### Integration — `packages/integration`
+- Seed the full manifest; librarian round-trip classifies facts into
+  polymorphic edges (e.g. one `about` → place, one `itemReviewed` → product).
+
+---
+
+## Out of Scope
+
+- Type hierarchy/inheritance, emergent-mode guardrails, multi-property edge
+  aliases, literal-valued properties — unchanged from the Clanker draft spec.
+- **Clanker adoption** (follow-up in Clanker repo): bump to the release
+  carrying this work, import the package manifest instead of an inline
+  constant, and revise Clanker's
+  `2026-07-14-curated-schema-ontology-design.md` (rating→review,
+  participant→attendee, subProject→subOrganization, duplicate-name section,
+  and the `OntologyConfig` reference — the interface lives in core-llm-wiki,
+  not Clanker's `src/database/schema.ts`).
+
+---
+
+## References
+
+- Clanker draft spec: `clanker/docs/superpowers/specs/2026-07-14-curated-schema-ontology-design.md`
+- Prior spec: `2026-07-13-ontology-backfill-spec.md`
+- Validation code: `packages/core/src/utils/ontology.ts`,
+  `packages/core/src/services/OntologyService.ts`
+- Schema.org: https://schema.org/

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -133,6 +133,7 @@ but is deprecated in favor of `buildAuthorizedToolsArray`.
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [**@equationalapplications/core-llm-tools**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -951,6 +951,7 @@ The flowchart shows:
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## License
 

--- a/packages/core/__tests__/services/OntologyService.test.ts
+++ b/packages/core/__tests__/services/OntologyService.test.ts
@@ -21,6 +21,23 @@ const edgeManifest: OntologyManifest = {
   ],
 };
 
+const polyManifest: OntologyManifest = {
+  node_types: [
+    { type: 'creativework', description: 'Content.' },
+    { type: 'person', description: 'An individual.' },
+    { type: 'organization', description: 'An org.' },
+    { type: 'place', description: 'A location.' },
+    { type: 'event', description: 'An event.' },
+    { type: 'product', description: 'A product.' },
+  ],
+  edge_types: [
+    { type: 'about', source_type: 'creativework', target_type: 'person', description: 'a' },
+    { type: 'about', source_type: 'creativework', target_type: 'organization', description: 'b' },
+    { type: 'about', source_type: 'creativework', target_type: 'place', description: 'c' },
+    { type: 'about', source_type: 'creativework', target_type: 'event', description: 'd' },
+  ],
+};
+
 function makeMocks() {
   const metadataRepo = {
     getManifest: vi.fn(),
@@ -212,6 +229,56 @@ describe('OntologyService', () => {
         edgeManifest, titleIndex, {} as any, 123,
       );
       expect(count).toBe(1); // true + false + skipped
+    });
+
+    it('selects the definition whose target_type matches the resolved target okf_type', async () => {
+      const { metadataRepo, edgeRepo } = makeMocks();
+      vi.mocked(edgeRepo.addIgnoreDuplicate).mockResolvedValue(true);
+      const svc = new OntologyService(metadataRepo, edgeRepo);
+      const titleIndex = new Map([
+        ['yosemite valley', { id: 'fact_place', okf_type: 'place' }],
+      ]);
+      const count = await svc.resolveAndPersistEdges(
+        'e1', 'fact_doc', 'creativework',
+        [{ edge_type: 'about', target_title: 'Yosemite Valley' }],
+        polyManifest, titleIndex, {} as any, 1,
+      );
+      expect(count).toBe(1);
+      expect(edgeRepo.addIgnoreDuplicate).toHaveBeenCalledTimes(1);
+      expect(edgeRepo.addIgnoreDuplicate).toHaveBeenCalledWith(
+        expect.objectContaining({ source_id: 'fact_doc', target_id: 'fact_place', edge_type: 'about' }),
+        expect.anything(),
+      );
+    });
+
+    it('skips the edge when the target okf_type matches no definition', async () => {
+      const { metadataRepo, edgeRepo } = makeMocks();
+      const svc = new OntologyService(metadataRepo, edgeRepo);
+      const titleIndex = new Map([
+        ['widget', { id: 'fact_prod', okf_type: 'product' }],
+      ]);
+      const count = await svc.resolveAndPersistEdges(
+        'e1', 'fact_doc', 'creativework',
+        [{ edge_type: 'about', target_title: 'Widget' }],
+        polyManifest, titleIndex, {} as any, 1,
+      );
+      expect(count).toBe(0);
+      expect(edgeRepo.addIgnoreDuplicate).not.toHaveBeenCalled();
+    });
+
+    it('skips the edge when the target is untyped', async () => {
+      const { metadataRepo, edgeRepo } = makeMocks();
+      const svc = new OntologyService(metadataRepo, edgeRepo);
+      const titleIndex = new Map([
+        ['mystery', { id: 'fact_m', okf_type: null }],
+      ]);
+      const count = await svc.resolveAndPersistEdges(
+        'e1', 'fact_doc', 'creativework',
+        [{ edge_type: 'about', target_title: 'Mystery' }],
+        polyManifest, titleIndex, {} as any, 1,
+      );
+      expect(count).toBe(0);
+      expect(edgeRepo.addIgnoreDuplicate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/__tests__/services/OntologyService.test.ts
+++ b/packages/core/__tests__/services/OntologyService.test.ts
@@ -140,6 +140,16 @@ describe('OntologyService', () => {
       expect(ctx).not.toBeNull();
       expect(ctx!.ontologyModeInstructions).toContain('STRICT MODE');
     });
+
+    it('appendix explains polymorphic edge rows', async () => {
+      const { metadataRepo, edgeRepo } = makeMocks();
+      vi.mocked(metadataRepo.getManifest).mockResolvedValue({ mode: 'strict', manifest });
+      const svc = new OntologyService(metadataRepo, edgeRepo);
+      const ctx = await svc.buildPromptContext('entity1');
+      expect(ctx!.ontologyModeInstructions).toContain(
+        'An edge_type may appear in the manifest multiple times',
+      );
+    });
   });
 
   describe('validateAndNormalizeFact', () => {

--- a/packages/core/__tests__/utils/ontology.test.ts
+++ b/packages/core/__tests__/utils/ontology.test.ts
@@ -126,6 +126,36 @@ describe('ontology utils', () => {
     })).toThrow('Duplicate edge definition: About (CreativeWork → Person)');
   });
 
+  it('validateManifest rejects one edge name spelled with different casing across triples', () => {
+    expect(() => validateManifest({
+      node_types: polyManifest.node_types,
+      edge_types: [
+        { type: 'about', source_type: 'creativework', target_type: 'person', description: 'a' },
+        { type: 'About', source_type: 'creativework', target_type: 'place', description: 'b' },
+      ],
+    })).toThrow('Inconsistent casing for edge type: About conflicts with about');
+  });
+
+  it('mergeOntologyUpdates canonicalizes a new triple to the existing edge name casing', () => {
+    const merged = mergeOntologyUpdates(manifest, {
+      edge_types: [{ type: 'Reports_To', source_type: 'person', target_type: 'project', description: 'Project lead.' }],
+    });
+    expect(merged.edge_types).toHaveLength(2);
+    expect(merged.edge_types[1].type).toBe('reports_to');
+    expect(() => validateManifest(merged)).not.toThrow();
+  });
+
+  it('mergeOntologyUpdates canonicalizes casing within a single batch of new edges', () => {
+    const merged = mergeOntologyUpdates(manifest, {
+      edge_types: [
+        { type: 'ownedBy', source_type: 'project', target_type: 'person', description: 'a' },
+        { type: 'ownedby', source_type: 'person', target_type: 'project', description: 'b' },
+      ],
+    });
+    expect(merged.edge_types.filter(e => e.type === 'ownedBy')).toHaveLength(2);
+    expect(() => validateManifest(merged)).not.toThrow();
+  });
+
   it('emptyManifest returns empty arrays', () => {
     expect(emptyManifest()).toEqual({ node_types: [], edge_types: [] });
   });

--- a/packages/core/__tests__/utils/ontology.test.ts
+++ b/packages/core/__tests__/utils/ontology.test.ts
@@ -6,6 +6,7 @@ import {
   validateManifest,
   mergeOntologyUpdates,
   validateInlineEdges,
+  resolveEdgeDefinitions,
 } from '../../src/utils/ontology';
 import type { OntologyManifest } from '../../src/types';
 
@@ -32,6 +33,19 @@ const polyManifest: OntologyManifest = {
     { type: 'about', source_type: 'creativework', target_type: 'organization', description: 'b' },
     { type: 'about', source_type: 'creativework', target_type: 'place', description: 'c' },
     { type: 'about', source_type: 'creativework', target_type: 'event', description: 'd' },
+  ],
+};
+
+const locationManifest: OntologyManifest = {
+  node_types: [
+    { type: 'person', description: 'x' },
+    { type: 'event', description: 'x' },
+    { type: 'organization', description: 'x' },
+    { type: 'place', description: 'x' },
+  ],
+  edge_types: [
+    { type: 'location', source_type: 'event', target_type: 'place', description: 'x' },
+    { type: 'location', source_type: 'organization', target_type: 'place', description: 'x' },
   ],
 };
 
@@ -133,5 +147,33 @@ describe('ontology utils', () => {
       mixedCaseManifest,
     );
     expect(edges).toEqual([{ edge_type: 'Reports_To', target_title: 'Bob Smith' }]);
+  });
+
+  it('resolveEdgeDefinitions returns all case-insensitive name matches', () => {
+    const defs = resolveEdgeDefinitions('About', polyManifest);
+    expect(defs).toHaveLength(4);
+    expect(defs.every(d => d.type === 'about')).toBe(true);
+    expect(resolveEdgeDefinitions('missing', polyManifest)).toEqual([]);
+    expect(resolveEdgeDefinitions('  ', polyManifest)).toEqual([]);
+  });
+
+  it('validateInlineEdges keeps an edge when any definition matches name + source', () => {
+    const edges = validateInlineEdges(
+      'Organization',
+      null,
+      [{ edge_type: 'Location', target_title: 'HQ Building' }],
+      locationManifest,
+    );
+    expect(edges).toEqual([{ edge_type: 'location', target_title: 'HQ Building' }]);
+  });
+
+  it('validateInlineEdges drops an edge when only the name matches (wrong source)', () => {
+    const edges = validateInlineEdges(
+      'person',
+      null,
+      [{ edge_type: 'location', target_title: 'HQ Building' }],
+      locationManifest,
+    );
+    expect(edges).toEqual([]);
   });
 });

--- a/packages/core/__tests__/utils/ontology.test.ts
+++ b/packages/core/__tests__/utils/ontology.test.ts
@@ -81,6 +81,23 @@ describe('ontology utils', () => {
     expect(merged.node_types.find(n => n.type === 'vendor')).toBeDefined();
   });
 
+  it('mergeOntologyUpdates adds a new source/target variant of an existing edge name', () => {
+    const merged = mergeOntologyUpdates(manifest, {
+      edge_types: [{ type: 'reports_to', source_type: 'person', target_type: 'project', description: 'Project lead.' }],
+    });
+    expect(merged.edge_types).toHaveLength(2);
+    expect(merged.edge_types[1]).toEqual({
+      type: 'reports_to', source_type: 'person', target_type: 'project', description: 'Project lead.',
+    });
+  });
+
+  it('mergeOntologyUpdates skips an exact-triple duplicate case-insensitively', () => {
+    const merged = mergeOntologyUpdates(manifest, {
+      edge_types: [{ type: 'Reports_To', source_type: 'Person', target_type: 'PERSON', description: 'dup' }],
+    });
+    expect(merged.edge_types).toHaveLength(1);
+  });
+
   it('validateManifest accepts one property name with distinct source/target triples', () => {
     expect(() => validateManifest(polyManifest)).not.toThrow();
   });

--- a/packages/core/__tests__/utils/ontology.test.ts
+++ b/packages/core/__tests__/utils/ontology.test.ts
@@ -19,6 +19,22 @@ const manifest: OntologyManifest = {
   ],
 };
 
+const polyManifest: OntologyManifest = {
+  node_types: [
+    { type: 'creativework', description: 'Content.' },
+    { type: 'person', description: 'An individual.' },
+    { type: 'organization', description: 'An org.' },
+    { type: 'place', description: 'A location.' },
+    { type: 'event', description: 'An event.' },
+  ],
+  edge_types: [
+    { type: 'about', source_type: 'creativework', target_type: 'person', description: 'a' },
+    { type: 'about', source_type: 'creativework', target_type: 'organization', description: 'b' },
+    { type: 'about', source_type: 'creativework', target_type: 'place', description: 'c' },
+    { type: 'about', source_type: 'creativework', target_type: 'event', description: 'd' },
+  ],
+};
+
 describe('ontology utils', () => {
   it('normalizeTitleKey lowercases and collapses whitespace', () => {
     expect(normalizeTitleKey('  Jane   Doe ')).toBe('jane doe');
@@ -63,6 +79,20 @@ describe('ontology utils', () => {
     expect(merged.node_types).toHaveLength(3);
     expect(merged.node_types.find(n => n.type === 'person')?.description).toBe('An individual.');
     expect(merged.node_types.find(n => n.type === 'vendor')).toBeDefined();
+  });
+
+  it('validateManifest accepts one property name with distinct source/target triples', () => {
+    expect(() => validateManifest(polyManifest)).not.toThrow();
+  });
+
+  it('validateManifest rejects an exact duplicate triple case-insensitively with the triple message', () => {
+    expect(() => validateManifest({
+      node_types: polyManifest.node_types,
+      edge_types: [
+        { type: 'about', source_type: 'creativework', target_type: 'person', description: 'a' },
+        { type: 'About', source_type: 'CreativeWork', target_type: 'Person', description: 'b' },
+      ],
+    })).toThrow('Duplicate edge definition: About (CreativeWork → Person)');
   });
 
   it('emptyManifest returns empty arrays', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export { formatMemoryDump } from './utils/formatMemoryDump';
 export { formatOkfBundle } from './utils/formatOkfBundle';
 export { parseOkfBundle, type OkfImportOptions } from './utils/parseOkfBundle';
 export { parseEmbedding } from './utils/embedding';
+export { validateManifest } from './utils/ontology';
 export { configureRandomSource } from './utils/ids';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';

--- a/packages/core/src/prompts/ontology.ts
+++ b/packages/core/src/prompts/ontology.ts
@@ -3,7 +3,8 @@ import type { OntologyMode } from '../types';
 const FACT_ONTOLOGY_FIELDS = `
 Each fact may optionally include:
 - "okf_type": string — must be one of the node_types in the manifest
-- "edges": [{ "edge_type": string, "target_title": string }] — target_title must match another fact's title in this response or existing memory`;
+- "edges": [{ "edge_type": string, "target_title": string }] — target_title must match another fact's title in this response or existing memory
+- An edge_type may appear in the manifest multiple times with different source_type/target_type; use the row whose types match your fact and target.`;
 
 const EMERGENT_EXTRA = `
 You may also return "ontology_updates" to propose new types:

--- a/packages/core/src/services/OntologyService.ts
+++ b/packages/core/src/services/OntologyService.ts
@@ -16,7 +16,7 @@ import {
   emptyManifest,
   normalizeTitleKey,
   resolveNodeType,
-  resolveEdgeDefinition,
+  resolveEdgeDefinitions,
   validateInlineEdges,
 } from '../utils/ontology';
 import { generateId } from '../utils/ids';
@@ -119,14 +119,18 @@ export class OntologyService {
 
     let persisted = 0;
     for (const edge of edges) {
-      const def = resolveEdgeDefinition(edge.edge_type, manifest);
-      if (!def || def.source_type.toLowerCase() !== sourceType.toLowerCase()) continue;
+      const candidates = resolveEdgeDefinitions(edge.edge_type, manifest)
+        .filter(d => d.source_type.toLowerCase() === sourceType.toLowerCase());
+      if (candidates.length === 0) continue;
 
       const targetKey = normalizeTitleKey(edge.target_title);
       const target = titleIndex.get(targetKey);
       if (!target) continue;
 
-      if (def.target_type.toLowerCase() !== (target.okf_type ?? '').toLowerCase()) continue;
+      const def = candidates.find(
+        d => d.target_type.toLowerCase() === (target.okf_type ?? '').toLowerCase(),
+      );
+      if (!def) continue;
 
       const wikiEdge: WikiEdge = {
         id: generateId(),

--- a/packages/core/src/utils/ontology.ts
+++ b/packages/core/src/utils/ontology.ts
@@ -42,6 +42,7 @@ export function validateManifest(manifest: OntologyManifest): void {
     nodeSlugs.add(key);
   }
   const edgeKeys = new Set<string>();
+  const edgeNames = new Map<string, string>();
   for (const edge of manifest.edge_types ?? []) {
     const edgeType = edge.type?.trim();
     const sourceType = edge.source_type?.trim();
@@ -55,6 +56,14 @@ export function validateManifest(manifest: OntologyManifest): void {
       throw new Error(`Duplicate edge definition: ${edgeType} (${sourceType} → ${targetType})`);
     }
     edgeKeys.add(edgeKey);
+    // Persisted edge_type values come from def.type verbatim, so every triple
+    // sharing a name must agree on casing or storage ends up mixed.
+    const canonical = edgeNames.get(edgeType.toLowerCase());
+    if (canonical === undefined) {
+      edgeNames.set(edgeType.toLowerCase(), edgeType);
+    } else if (canonical !== edgeType) {
+      throw new Error(`Inconsistent casing for edge type: ${edgeType} conflicts with ${canonical}`);
+    }
   }
 }
 
@@ -66,6 +75,7 @@ export function mergeOntologyUpdates(
   const edge_types = [...current.edge_types];
   const nodeSlugs = new Set(node_types.map(n => n.type.trim().toLowerCase()));
   const edgeKeys = new Set(edge_types.map(e => edgeTripleKey(e.type, e.source_type, e.target_type)));
+  const edgeNames = new Map(edge_types.map(e => [e.type.trim().toLowerCase(), e.type.trim()]));
 
   for (const node of updates.node_types ?? []) {
     const type = node?.type?.trim();
@@ -76,13 +86,17 @@ export function mergeOntologyUpdates(
     nodeSlugs.add(key);
   }
   for (const edge of updates.edge_types ?? []) {
-    const edgeType = edge?.type?.trim();
+    const rawEdgeType = edge?.type?.trim();
     const sourceType = edge?.source_type?.trim();
     const targetType = edge?.target_type?.trim();
-    if (!edgeType || !sourceType || !targetType) continue;
+    if (!rawEdgeType || !sourceType || !targetType) continue;
+    // First-seen casing wins for a given edge name, as with node types, so a
+    // later triple spelled differently cannot make the manifest fail validation.
+    const edgeType = edgeNames.get(rawEdgeType.toLowerCase()) ?? rawEdgeType;
     const edgeKey = edgeTripleKey(edgeType, sourceType, targetType);
     if (edgeKeys.has(edgeKey)) continue;
     if (!nodeSlugs.has(sourceType.toLowerCase()) || !nodeSlugs.has(targetType.toLowerCase())) continue;
+    edgeNames.set(edgeType.toLowerCase(), edgeType);
     edge_types.push({
       type: edgeType,
       source_type: sourceType,

--- a/packages/core/src/utils/ontology.ts
+++ b/packages/core/src/utils/ontology.ts
@@ -28,6 +28,15 @@ export function resolveEdgeDefinition(
   return manifest.edge_types.find(e => e.type.toLowerCase() === slug.toLowerCase()) ?? null;
 }
 
+export function resolveEdgeDefinitions(
+  rawEdgeType: string,
+  manifest: OntologyManifest,
+): OntologyManifest['edge_types'][number][] {
+  const slug = rawEdgeType.trim();
+  if (!slug) return [];
+  return manifest.edge_types.filter(e => e.type.toLowerCase() === slug.toLowerCase());
+}
+
 function edgeTripleKey(type: string, sourceType: string, targetType: string): string {
   return `${type.trim().toLowerCase()}|${sourceType.trim().toLowerCase()}|${targetType.trim().toLowerCase()}`;
 }
@@ -104,10 +113,10 @@ export function validateInlineEdges(
   const valid: ExtractedFactEdge[] = [];
   for (const edge of edges) {
     if (typeof edge?.edge_type !== 'string' || typeof edge?.target_title !== 'string') continue;
-    const def = resolveEdgeDefinition(edge.edge_type, manifest);
-    if (!def) continue;
-    if (def.source_type.toLowerCase() !== sourceType.toLowerCase()) continue;
-    valid.push({ edge_type: def.type, target_title: edge.target_title });
+    const defs = resolveEdgeDefinitions(edge.edge_type, manifest);
+    const match = defs.find(d => d.source_type.toLowerCase() === sourceType.toLowerCase());
+    if (!match) continue;
+    valid.push({ edge_type: match.type, target_title: edge.target_title });
   }
   return valid;
 }

--- a/packages/core/src/utils/ontology.ts
+++ b/packages/core/src/utils/ontology.ts
@@ -28,6 +28,10 @@ export function resolveEdgeDefinition(
   return manifest.edge_types.find(e => e.type.toLowerCase() === slug.toLowerCase()) ?? null;
 }
 
+function edgeTripleKey(type: string, sourceType: string, targetType: string): string {
+  return `${type.trim().toLowerCase()}|${sourceType.trim().toLowerCase()}|${targetType.trim().toLowerCase()}`;
+}
+
 export function validateManifest(manifest: OntologyManifest): void {
   const nodeSlugs = new Set<string>();
   for (const node of manifest.node_types ?? []) {
@@ -37,18 +41,20 @@ export function validateManifest(manifest: OntologyManifest): void {
     if (nodeSlugs.has(key)) throw new Error(`Duplicate node type: ${type}`);
     nodeSlugs.add(key);
   }
-  const edgeSlugs = new Set<string>();
+  const edgeKeys = new Set<string>();
   for (const edge of manifest.edge_types ?? []) {
     const edgeType = edge.type?.trim();
     const sourceType = edge.source_type?.trim();
     const targetType = edge.target_type?.trim();
     if (!edgeType) throw new Error('Ontology edge type slug must be non-empty');
-    const edgeKey = edgeType.toLowerCase();
-    if (edgeSlugs.has(edgeKey)) throw new Error(`Duplicate edge type: ${edgeType}`);
-    edgeSlugs.add(edgeKey);
     if (!sourceType || !targetType || !nodeSlugs.has(sourceType.toLowerCase()) || !nodeSlugs.has(targetType.toLowerCase())) {
       throw new Error(`Edge type ${edgeType} references unknown node type`);
     }
+    const edgeKey = edgeTripleKey(edgeType, sourceType, targetType);
+    if (edgeKeys.has(edgeKey)) {
+      throw new Error(`Duplicate edge definition: ${edgeType} (${sourceType} → ${targetType})`);
+    }
+    edgeKeys.add(edgeKey);
   }
 }
 

--- a/packages/core/src/utils/ontology.ts
+++ b/packages/core/src/utils/ontology.ts
@@ -65,7 +65,7 @@ export function mergeOntologyUpdates(
   const node_types = [...current.node_types];
   const edge_types = [...current.edge_types];
   const nodeSlugs = new Set(node_types.map(n => n.type.trim().toLowerCase()));
-  const edgeSlugs = new Set(edge_types.map(e => e.type.trim().toLowerCase()));
+  const edgeKeys = new Set(edge_types.map(e => edgeTripleKey(e.type, e.source_type, e.target_type)));
 
   for (const node of updates.node_types ?? []) {
     const type = node?.type?.trim();
@@ -80,8 +80,8 @@ export function mergeOntologyUpdates(
     const sourceType = edge?.source_type?.trim();
     const targetType = edge?.target_type?.trim();
     if (!edgeType || !sourceType || !targetType) continue;
-    const edgeKey = edgeType.toLowerCase();
-    if (edgeSlugs.has(edgeKey)) continue;
+    const edgeKey = edgeTripleKey(edgeType, sourceType, targetType);
+    if (edgeKeys.has(edgeKey)) continue;
     if (!nodeSlugs.has(sourceType.toLowerCase()) || !nodeSlugs.has(targetType.toLowerCase())) continue;
     edge_types.push({
       type: edgeType,
@@ -89,7 +89,7 @@ export function mergeOntologyUpdates(
       target_type: targetType,
       description: String(edge.description ?? ''),
     });
-    edgeSlugs.add(edgeKey);
+    edgeKeys.add(edgeKey);
   }
   return { node_types, edge_types };
 }

--- a/packages/core/src/utils/ontology.ts
+++ b/packages/core/src/utils/ontology.ts
@@ -19,15 +19,6 @@ export function resolveNodeType(raw: string, manifest: OntologyManifest): string
   return hit?.type ?? null;
 }
 
-export function resolveEdgeDefinition(
-  rawEdgeType: string,
-  manifest: OntologyManifest,
-): OntologyManifest['edge_types'][number] | null {
-  const slug = rawEdgeType.trim();
-  if (!slug) return null;
-  return manifest.edge_types.find(e => e.type.toLowerCase() === slug.toLowerCase()) ?? null;
-}
-
 export function resolveEdgeDefinitions(
   rawEdgeType: string,
   manifest: OntologyManifest,

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -433,6 +433,7 @@ from `@equationalapplications/core-llm-wiki`) with a top-level `sqliteErrorCode`
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## License
 

--- a/packages/integration/__tests__/ontologySchemaOrg.test.ts
+++ b/packages/integration/__tests__/ontologySchemaOrg.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { WikiMemory } from '@equationalapplications/core-llm-wiki';
+import { schemaOrgWarmAgentManifest } from '@equationalapplications/schema-org-llm-wiki';
+import { openTestDatabase } from '../helpers/db';
+import { scriptedLLM } from '../helpers/llm';
+
+describe('schema.org manifest — polymorphic edge round-trip', () => {
+  it('librarian classifies facts into polymorphic edges by target type', async () => {
+    const db = openTestDatabase();
+    const librarianResponse = JSON.stringify({
+      facts: [
+        {
+          title: 'Yosemite Valley',
+          body: 'A glacial valley in California.',
+          tags: [],
+          confidence: 'certain',
+          okf_type: 'place',
+        },
+        {
+          title: 'Yosemite Guide',
+          body: 'A guidebook about Yosemite Valley.',
+          tags: [],
+          confidence: 'certain',
+          okf_type: 'creativework',
+          edges: [{ edge_type: 'about', target_title: 'Yosemite Valley' }],
+        },
+        {
+          title: 'Blender X100',
+          body: 'A kitchen blender.',
+          tags: [],
+          confidence: 'certain',
+          okf_type: 'product',
+        },
+        {
+          title: 'Blender X100 review',
+          body: 'Loves the blender. Five stars.',
+          tags: [],
+          confidence: 'certain',
+          okf_type: 'review',
+          edges: [{ edge_type: 'itemReviewed', target_title: 'Blender X100' }],
+        },
+      ],
+      tasks: [],
+    });
+
+    const wiki = new WikiMemory(db, {
+      llmProvider: scriptedLLM([librarianResponse]),
+      config: { ontology: { mode: 'strict' } },
+    });
+    await wiki.setup();
+    await wiki.setOntologyManifest('user-1', schemaOrgWarmAgentManifest, { mode: 'strict' });
+
+    await wiki.write('user-1', {
+      event_type: 'observation',
+      summary: 'Read a Yosemite guidebook and reviewed the new blender.',
+    });
+    await wiki.runLibrarian('user-1');
+
+    const bundle = await wiki.getMemoryBundle('user-1');
+    const guide = bundle.facts.find(f => f.title === 'Yosemite Guide');
+    const valley = bundle.facts.find(f => f.title === 'Yosemite Valley');
+    const review = bundle.facts.find(f => f.title === 'Blender X100 review');
+    const blender = bundle.facts.find(f => f.title === 'Blender X100');
+
+    expect(guide?.okf_type).toBe('creativework');
+    expect(valley?.okf_type).toBe('place');
+    expect(review?.okf_type).toBe('review');
+    expect(blender?.okf_type).toBe('product');
+
+    expect(bundle.edges).toHaveLength(2);
+
+    const about = bundle.edges!.find(e => e.edge_type === 'about');
+    expect(about?.source_id).toBe(guide?.id);
+    expect(about?.target_id).toBe(valley?.id);
+
+    const reviewed = bundle.edges!.find(e => e.edge_type === 'itemReviewed');
+    expect(reviewed?.edge_type).toBe('itemReviewed');
+    expect(reviewed?.source_id).toBe(review?.id);
+    expect(reviewed?.target_id).toBe(blender?.id);
+  });
+});

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@equationalapplications/core-llm-wiki": "workspace:*"
+    "@equationalapplications/core-llm-wiki": "workspace:*",
+    "@equationalapplications/schema-org-llm-wiki": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/okf/README.md
+++ b/packages/okf/README.md
@@ -74,3 +74,4 @@ const links = extractMarkdownLinks('See [preferences](facts/fact_abc.md) for mor
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [**@equationalapplications/core-okf**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -104,6 +104,7 @@ worker.stop();
 | [**@equationalapplications/prisma-outbox**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ---
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -539,6 +539,7 @@ The flowchart shows:
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
 | [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## License
 

--- a/packages/schema-org/LICENSE
+++ b/packages/schema-org/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Equational Applications
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/schema-org/README.md
+++ b/packages/schema-org/README.md
@@ -1,0 +1,79 @@
+# @equationalapplications/schema-org-llm-wiki
+
+Curated [schema.org](https://schema.org/) warm-agent ontology manifest for
+[LLM Wiki Memory](https://github.com/equationalapplications/expo-llm-wiki):
+**9 node types, 28 edges**, all schema.org-standard. Data-only — no runtime code.
+
+## Why curated?
+
+Full schema.org has ~800 types and ~1,400 properties. Injecting that into every
+librarian/ingest prompt would blow token budgets and collapse LLM classification
+accuracy. This manifest selects the high-value warm-agent subset (~2 KB serialized,
+9-way classification) while keeping every type and property standard, so stored
+facts and edges map 1:1 onto schema.org for future JSON-LD export.
+
+## Requirements
+
+Requires `@equationalapplications/core-llm-wiki` at the same release or newer —
+this manifest uses polymorphic edge rows (one property name with several
+source/target types), which core validates by the `(type, source_type, target_type)`
+triple.
+
+## Usage
+
+```ts
+import { createWiki } from '@equationalapplications/core-llm-wiki';
+import { schemaOrgWarmAgentManifest } from '@equationalapplications/schema-org-llm-wiki';
+
+const wiki = createWiki(db, {
+  llmProvider,
+  config: {
+    ontology: {
+      mode: 'strict',
+      seedManifests: {
+        [entityId]: { mode: 'strict', manifest: schemaOrgWarmAgentManifest },
+      },
+    },
+  },
+});
+```
+
+Or seed an existing entity directly:
+
+```ts
+await wiki.setOntologyManifest(entityId, schemaOrgWarmAgentManifest, { mode: 'strict' });
+```
+
+## Node types
+
+| Type | schema.org | Covers |
+|------|-----------|--------|
+| `person` | [Person](https://schema.org/Person) | Friends, family, colleagues, public figures |
+| `organization` | [Organization](https://schema.org/Organization) | Companies, schools, clubs, teams, institutions |
+| `place` | [Place](https://schema.org/Place) | Cities, venues, landmarks, addresses |
+| `event` | [Event](https://schema.org/Event) | Meetings, conferences, concerts, celebrations |
+| `project` | [Project](https://schema.org/Project) | Multi-step initiatives and goals |
+| `action` | [Action](https://schema.org/Action) | Individual tasks, chores, steps |
+| `creativework` | [CreativeWork](https://schema.org/CreativeWork) | Books, movies, articles, songs, recipes |
+| `review` | [Review](https://schema.org/Review) | Personal opinions and evaluations |
+| `product` | [Product](https://schema.org/Product) | Owned items, devices, software |
+
+## Edge properties (19 names, 28 rows)
+
+All standard schema.org properties: `knows`, `spouse`, `parent`, `worksFor`,
+`memberOf`, `homeLocation`, `workLocation`, `location` (×2), `containedInPlace`,
+`subOrganization`, `object`, `agent`, `attendee`, `organizer` (×2), `author`,
+`publisher`, `about` (×4), `itemReviewed` (×5), `owns`.
+
+Polymorphic properties appear as multiple rows with distinct source/target
+types, mirroring schema.org's own domain/range definitions — e.g. `about`
+targets `person`, `organization`, `place`, and `event`.
+
+## JSON-LD export notes
+
+- Property names keep schema.org camelCase (`worksFor`, `itemReviewed`); core
+  validation compares case-insensitively but stores the given casing, so names
+  survive to storage and future JSON-LD export unchanged.
+- Literal-valued properties (`birthDate`, `startTime`, `reviewRating` values, …)
+  live inside fact content, not as edges. Only object-valued properties
+  (pointing at other facts) are edges.

--- a/packages/schema-org/README.md
+++ b/packages/schema-org/README.md
@@ -1,8 +1,14 @@
 # @equationalapplications/schema-org-llm-wiki
 
-Curated [schema.org](https://schema.org/) warm-agent ontology manifest for
-[LLM Wiki Memory](https://github.com/equationalapplications/expo-llm-wiki):
-**9 node types, 28 edges**, all schema.org-standard. Data-only — no runtime code.
+Curated [schema.org](https://schema.org/) warm-agent ontology manifest for hybrid LLM memory. Seeds a knowledge graph with 9 standard node types and 28 polymorphic edges — token-efficient, JSON-LD-ready, data-only with no runtime code.
+
+[![npm version](https://img.shields.io/npm/v/%40equationalapplications%2Fschema-org-llm-wiki?label=schema-org)](https://www.npmjs.com/package/@equationalapplications/schema-org-llm-wiki) [![npm downloads](https://img.shields.io/npm/dm/%40equationalapplications%2Fschema-org-llm-wiki?label=downloads)](https://www.npmjs.com/package/@equationalapplications/schema-org-llm-wiki)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/LICENSE)
+
+**[GitHub](https://github.com/equationalapplications/expo-llm-wiki)** · **[ScopeLab](https://equationalapplications.github.io/expo-llm-wiki/scopelab/)** · **[WikiDemo](https://equationalapplications.github.io/expo-llm-wiki/wiki-demo/)** · **[Changelog](https://github.com/equationalapplications/expo-llm-wiki/blob/main/CHANGELOG.md)** · **[Issues](https://github.com/equationalapplications/expo-llm-wiki/issues)**
+
+> Ontology manifest for [LLM Wiki Memory](https://github.com/equationalapplications/expo-llm-wiki), inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
 ## Why curated?
 
@@ -18,6 +24,12 @@ Requires `@equationalapplications/core-llm-wiki` at the same release or newer �
 this manifest uses polymorphic edge rows (one property name with several
 source/target types), which core validates by the `(type, source_type, target_type)`
 triple.
+
+## Installation
+
+```bash
+npm install @equationalapplications/schema-org-llm-wiki
+```
 
 ## Usage
 
@@ -77,3 +89,23 @@ targets `person`, `organization`, `place`, and `event`.
 - Literal-valued properties (`birthDate`, `startTime`, `reviewRating` values, …)
   live inside fact content, not as edges. Only object-valued properties
   (pointing at other facts) are edges.
+
+## Monorepo Ecosystem
+
+| Package | Purpose |
+| ----- | ----- |
+| [**@equationalapplications/schema-org-llm-wiki**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
+| [@equationalapplications/core-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core/README.md) | Persistent episodic memory |
+| [@equationalapplications/expo-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/expo/README.md) | Persistent episodic memory for Expo/React Native |
+| [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
+| [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
+| [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+
+## License
+
+MIT
+
+---
+
+Made with ❤️ by Equational Applications LLC. [https://equationalapplications.com/](https://equationalapplications.com/)

--- a/packages/schema-org/__tests__/__snapshots__/manifest.test.ts.snap
+++ b/packages/schema-org/__tests__/__snapshots__/manifest.test.ts.snap
@@ -1,0 +1,214 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`schemaOrgWarmAgentManifest > matches snapshot (content drift guard) 1`] = `
+{
+  "edge_types": [
+    {
+      "description": "Friendship, acquaintance, or general connection between two people.",
+      "source_type": "person",
+      "target_type": "person",
+      "type": "knows",
+    },
+    {
+      "description": "Spousal or long-term partner relationship.",
+      "source_type": "person",
+      "target_type": "person",
+      "type": "spouse",
+    },
+    {
+      "description": "A parent of this person: the source is the child, the target is the parent.",
+      "source_type": "person",
+      "target_type": "person",
+      "type": "parent",
+    },
+    {
+      "description": "Employment or primary professional affiliation.",
+      "source_type": "person",
+      "target_type": "organization",
+      "type": "worksFor",
+    },
+    {
+      "description": "Membership in clubs, associations, or communities.",
+      "source_type": "person",
+      "target_type": "organization",
+      "type": "memberOf",
+    },
+    {
+      "description": "Primary residence.",
+      "source_type": "person",
+      "target_type": "place",
+      "type": "homeLocation",
+    },
+    {
+      "description": "Workplace or primary work location.",
+      "source_type": "person",
+      "target_type": "place",
+      "type": "workLocation",
+    },
+    {
+      "description": "Venue or geographic location of an event.",
+      "source_type": "event",
+      "target_type": "place",
+      "type": "location",
+    },
+    {
+      "description": "Physical headquarters or primary location.",
+      "source_type": "organization",
+      "target_type": "place",
+      "type": "location",
+    },
+    {
+      "description": "Hierarchical location: the source place is inside the target place (e.g., Paris is contained in France).",
+      "source_type": "place",
+      "target_type": "place",
+      "type": "containedInPlace",
+    },
+    {
+      "description": "Nested project hierarchy: the target is a sub-project contained in the source project.",
+      "source_type": "project",
+      "target_type": "project",
+      "type": "subOrganization",
+    },
+    {
+      "description": "Project this task belongs to; the object the action advances.",
+      "source_type": "action",
+      "target_type": "project",
+      "type": "object",
+    },
+    {
+      "description": "Person responsible for or performing the action.",
+      "source_type": "action",
+      "target_type": "person",
+      "type": "agent",
+    },
+    {
+      "description": "Person attending or participating in the event.",
+      "source_type": "event",
+      "target_type": "person",
+      "type": "attendee",
+    },
+    {
+      "description": "Person who organized the event.",
+      "source_type": "event",
+      "target_type": "person",
+      "type": "organizer",
+    },
+    {
+      "description": "Organization hosting the event.",
+      "source_type": "event",
+      "target_type": "organization",
+      "type": "organizer",
+    },
+    {
+      "description": "Author, creator, artist, or filmmaker.",
+      "source_type": "creativework",
+      "target_type": "person",
+      "type": "author",
+    },
+    {
+      "description": "Publisher, platform, studio, or distributor.",
+      "source_type": "creativework",
+      "target_type": "organization",
+      "type": "publisher",
+    },
+    {
+      "description": "Content centered on a specific person.",
+      "source_type": "creativework",
+      "target_type": "person",
+      "type": "about",
+    },
+    {
+      "description": "Content centered on a company, institution, or group.",
+      "source_type": "creativework",
+      "target_type": "organization",
+      "type": "about",
+    },
+    {
+      "description": "Content centered on a location (travel guide, history).",
+      "source_type": "creativework",
+      "target_type": "place",
+      "type": "about",
+    },
+    {
+      "description": "Content centered on an event (documentary, article).",
+      "source_type": "creativework",
+      "target_type": "event",
+      "type": "about",
+    },
+    {
+      "description": "The book, movie, article, or other work this review evaluates.",
+      "source_type": "review",
+      "target_type": "creativework",
+      "type": "itemReviewed",
+    },
+    {
+      "description": "The business, restaurant, or institution this review evaluates.",
+      "source_type": "review",
+      "target_type": "organization",
+      "type": "itemReviewed",
+    },
+    {
+      "description": "The venue, park, or location this review evaluates.",
+      "source_type": "review",
+      "target_type": "place",
+      "type": "itemReviewed",
+    },
+    {
+      "description": "The event this review evaluates.",
+      "source_type": "review",
+      "target_type": "event",
+      "type": "itemReviewed",
+    },
+    {
+      "description": "The tool, device, or product this review evaluates.",
+      "source_type": "review",
+      "target_type": "product",
+      "type": "itemReviewed",
+    },
+    {
+      "description": "Item owned by the person (electronics, vehicles, etc.).",
+      "source_type": "person",
+      "target_type": "product",
+      "type": "owns",
+    },
+  ],
+  "node_types": [
+    {
+      "description": "A person—friend, family member, colleague, or public figure. Use this for any individual in the user's social, professional, or knowledge network.",
+      "type": "person",
+    },
+    {
+      "description": "A company, nonprofit, club, sports team, or institution. Covers businesses, schools, local shops, and communities.",
+      "type": "organization",
+    },
+    {
+      "description": "A geographic location, address, landmark, or venue. Use for cities, buildings, parks, restaurants, or any physical or conceptual location.",
+      "type": "place",
+    },
+    {
+      "description": "A scheduled or past gathering, meeting, conference, concert, or celebration. Links attendees and organizers to the event.",
+      "type": "event",
+    },
+    {
+      "description": "A multi-step initiative, goal, or endeavor. Use for personal projects, learning goals, business initiatives, or long-term objectives.",
+      "type": "project",
+    },
+    {
+      "description": "An individual task, chore, step, or completed action. Links to a parent Project and assigns responsibility to a Person.",
+      "type": "action",
+    },
+    {
+      "description": "A book, movie, article, song, recipe, blog post, or other creative content. Captures media the user consumes, learns from, or creates.",
+      "type": "creativework",
+    },
+    {
+      "description": "A personal review, opinion, or evaluation. The implicit subject is always the owning character—use to review a book, restaurant, place, product, or experience. Rating values stay inside the fact content.",
+      "type": "review",
+    },
+    {
+      "description": "A physical item, software tool, or device owned or under consideration. Covers electronics, vehicles, household items, and software.",
+      "type": "product",
+    },
+  ],
+}
+`;

--- a/packages/schema-org/__tests__/manifest.test.ts
+++ b/packages/schema-org/__tests__/manifest.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { validateManifest } from '@equationalapplications/core-llm-wiki';
+import { schemaOrgWarmAgentManifest } from '../src/index';
+
+describe('schemaOrgWarmAgentManifest', () => {
+  it('passes core validateManifest', () => {
+    expect(() => validateManifest(schemaOrgWarmAgentManifest)).not.toThrow();
+  });
+
+  it('has exactly 9 node types and 28 edges', () => {
+    expect(schemaOrgWarmAgentManifest.node_types).toHaveLength(9);
+    expect(schemaOrgWarmAgentManifest.edge_types).toHaveLength(28);
+  });
+
+  it('has 19 unique property names with the expected polymorphic counts', () => {
+    const counts = new Map<string, number>();
+    for (const e of schemaOrgWarmAgentManifest.edge_types) {
+      counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+    }
+    expect(counts.size).toBe(19);
+    expect(counts.get('location')).toBe(2);
+    expect(counts.get('organizer')).toBe(2);
+    expect(counts.get('about')).toBe(4);
+    expect(counts.get('itemReviewed')).toBe(5);
+  });
+
+  it('every edge endpoint exists in the node list', () => {
+    const nodes = new Set(schemaOrgWarmAgentManifest.node_types.map(n => n.type));
+    for (const e of schemaOrgWarmAgentManifest.edge_types) {
+      expect(nodes.has(e.source_type), `${e.type} source ${e.source_type}`).toBe(true);
+      expect(nodes.has(e.target_type), `${e.type} target ${e.target_type}`).toBe(true);
+    }
+  });
+
+  it('every node and edge has a non-empty description', () => {
+    for (const n of schemaOrgWarmAgentManifest.node_types) {
+      expect(n.description.length, n.type).toBeGreaterThan(0);
+    }
+    for (const e of schemaOrgWarmAgentManifest.edge_types) {
+      expect(e.description.length, e.type).toBeGreaterThan(0);
+    }
+  });
+
+  it('matches snapshot (content drift guard)', () => {
+    expect(schemaOrgWarmAgentManifest).toMatchSnapshot();
+  });
+});

--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@equationalapplications/schema-org-llm-wiki",
+  "version": "4.21.0",
+  "description": "Curated schema.org warm-agent ontology manifest for LLM Wiki Memory: 9 node types, 28 edges, fully schema.org-standard. Data-only.",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "schema-org",
+    "ontology",
+    "knowledge-graph",
+    "llm-memory",
+    "ai-memory",
+    "json-ld",
+    "typescript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/equationalapplications/expo-llm-wiki.git",
+    "directory": "packages/schema-org"
+  },
+  "bugs": {
+    "url": "https://github.com/equationalapplications/expo-llm-wiki/issues"
+  },
+  "homepage": "https://github.com/equationalapplications/expo-llm-wiki/tree/main/packages/schema-org#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "dependencies": {
+    "@equationalapplications/core-llm-wiki": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/schema-org/src/index.ts
+++ b/packages/schema-org/src/index.ts
@@ -1,3 +1,54 @@
 import type { OntologyManifest } from '@equationalapplications/core-llm-wiki';
 
 export type { OntologyManifest, OntologyNodeType, OntologyEdgeType } from '@equationalapplications/core-llm-wiki';
+
+/**
+ * Curated schema.org warm-agent ontology: 9 node types, 28 edges.
+ * All types and properties are schema.org-standard; polymorphic properties
+ * (`location`, `organizer`, `about`, `itemReviewed`) appear as multiple rows
+ * with distinct source/target types, exactly as schema.org defines their
+ * domain/range. Requires a core version with triple-keyed edge validation.
+ */
+export const schemaOrgWarmAgentManifest: OntologyManifest = {
+  node_types: [
+    { type: 'person', description: "A person—friend, family member, colleague, or public figure. Use this for any individual in the user's social, professional, or knowledge network." },
+    { type: 'organization', description: 'A company, nonprofit, club, sports team, or institution. Covers businesses, schools, local shops, and communities.' },
+    { type: 'place', description: 'A geographic location, address, landmark, or venue. Use for cities, buildings, parks, restaurants, or any physical or conceptual location.' },
+    { type: 'event', description: 'A scheduled or past gathering, meeting, conference, concert, or celebration. Links attendees and organizers to the event.' },
+    { type: 'project', description: 'A multi-step initiative, goal, or endeavor. Use for personal projects, learning goals, business initiatives, or long-term objectives.' },
+    { type: 'action', description: 'An individual task, chore, step, or completed action. Links to a parent Project and assigns responsibility to a Person.' },
+    { type: 'creativework', description: 'A book, movie, article, song, recipe, blog post, or other creative content. Captures media the user consumes, learns from, or creates.' },
+    { type: 'review', description: 'A personal review, opinion, or evaluation. The implicit subject is always the owning character—use to review a book, restaurant, place, product, or experience. Rating values stay inside the fact content.' },
+    { type: 'product', description: 'A physical item, software tool, or device owned or under consideration. Covers electronics, vehicles, household items, and software.' },
+  ],
+  edge_types: [
+    { type: 'knows', source_type: 'person', target_type: 'person', description: 'Friendship, acquaintance, or general connection between two people.' },
+    { type: 'spouse', source_type: 'person', target_type: 'person', description: 'Spousal or long-term partner relationship.' },
+    { type: 'parent', source_type: 'person', target_type: 'person', description: 'A parent of this person: the source is the child, the target is the parent.' },
+    { type: 'worksFor', source_type: 'person', target_type: 'organization', description: 'Employment or primary professional affiliation.' },
+    { type: 'memberOf', source_type: 'person', target_type: 'organization', description: 'Membership in clubs, associations, or communities.' },
+    { type: 'homeLocation', source_type: 'person', target_type: 'place', description: 'Primary residence.' },
+    { type: 'workLocation', source_type: 'person', target_type: 'place', description: 'Workplace or primary work location.' },
+    { type: 'location', source_type: 'event', target_type: 'place', description: 'Venue or geographic location of an event.' },
+    { type: 'location', source_type: 'organization', target_type: 'place', description: 'Physical headquarters or primary location.' },
+    { type: 'containedInPlace', source_type: 'place', target_type: 'place', description: 'Hierarchical location: the source place is inside the target place (e.g., Paris is contained in France).' },
+    { type: 'subOrganization', source_type: 'project', target_type: 'project', description: 'Nested project hierarchy: the target is a sub-project contained in the source project.' },
+    { type: 'object', source_type: 'action', target_type: 'project', description: 'Project this task belongs to; the object the action advances.' },
+    { type: 'agent', source_type: 'action', target_type: 'person', description: 'Person responsible for or performing the action.' },
+    { type: 'attendee', source_type: 'event', target_type: 'person', description: 'Person attending or participating in the event.' },
+    { type: 'organizer', source_type: 'event', target_type: 'person', description: 'Person who organized the event.' },
+    { type: 'organizer', source_type: 'event', target_type: 'organization', description: 'Organization hosting the event.' },
+    { type: 'author', source_type: 'creativework', target_type: 'person', description: 'Author, creator, artist, or filmmaker.' },
+    { type: 'publisher', source_type: 'creativework', target_type: 'organization', description: 'Publisher, platform, studio, or distributor.' },
+    { type: 'about', source_type: 'creativework', target_type: 'person', description: 'Content centered on a specific person.' },
+    { type: 'about', source_type: 'creativework', target_type: 'organization', description: 'Content centered on a company, institution, or group.' },
+    { type: 'about', source_type: 'creativework', target_type: 'place', description: 'Content centered on a location (travel guide, history).' },
+    { type: 'about', source_type: 'creativework', target_type: 'event', description: 'Content centered on an event (documentary, article).' },
+    { type: 'itemReviewed', source_type: 'review', target_type: 'creativework', description: 'The book, movie, article, or other work this review evaluates.' },
+    { type: 'itemReviewed', source_type: 'review', target_type: 'organization', description: 'The business, restaurant, or institution this review evaluates.' },
+    { type: 'itemReviewed', source_type: 'review', target_type: 'place', description: 'The venue, park, or location this review evaluates.' },
+    { type: 'itemReviewed', source_type: 'review', target_type: 'event', description: 'The event this review evaluates.' },
+    { type: 'itemReviewed', source_type: 'review', target_type: 'product', description: 'The tool, device, or product this review evaluates.' },
+    { type: 'owns', source_type: 'person', target_type: 'product', description: 'Item owned by the person (electronics, vehicles, etc.).' },
+  ],
+};

--- a/packages/schema-org/src/index.ts
+++ b/packages/schema-org/src/index.ts
@@ -1,0 +1,3 @@
+import type { OntologyManifest } from '@equationalapplications/core-llm-wiki';
+
+export type { OntologyManifest, OntologyNodeType, OntologyEdgeType } from '@equationalapplications/core-llm-wiki';

--- a/packages/schema-org/tsconfig.json
+++ b/packages/schema-org/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/schema-org/tsup.config.ts
+++ b/packages/schema-org/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  external: ['@equationalapplications/core-llm-wiki'],
+});

--- a/packages/schema-org/vitest.config.ts
+++ b/packages/schema-org/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@equationalapplications/core-llm-wiki':
         specifier: workspace:*
         version: link:../core
+      '@equationalapplications/schema-org-llm-wiki':
+        specifier: workspace:*
+        version: link:../schema-org
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,22 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
+  packages/schema-org:
+    dependencies:
+      '@equationalapplications/core-llm-wiki':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
 packages:
 
   '@actions/core@3.0.1':


### PR DESCRIPTION
## Summary
- Ontology edge definitions are now unique by `(type, source_type, target_type)` instead of `type` alone, so one schema.org property name (`about`, `location`, `organizer`, `itemReviewed`) can appear as multiple manifest rows with different source/target types — strictly permissive, no wire-format or migration changes.
- New data-only package `@equationalapplications/schema-org-llm-wiki` shipping a curated schema.org warm-agent manifest (9 node types, 28 edges).
- Wired the new package into the semantic-release pipeline (`.releaserc.json`, `.github/workflows/release.yml` hardcode package lists).
- `validateManifest` now exported from `packages/core`'s public index.

Spec: [`docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md`](docs/superpowers/specs/2026-07-14-polymorphic-edge-triples-schema-org-package-spec.md) (updated post-implementation with recorded deviations and one semantic technicality on `subOrganization`).

## Test plan
- [x] `pnpm -r build` — all packages build, including schema-org
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test` — all green (core 752, schema-org 6, integration 38, others unaffected)
- [x] Integration round-trip test proves polymorphic edges resolve by target type end-to-end through the real librarian pipeline, including camelCase casing surviving to storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)