### PR TITLE
feat(core): export chunkText, safeSlice, and default chunking constants

### DIFF
--- a/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
+++ b/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
@@ -113,7 +113,10 @@ As implemented, `packages/core/README.md` also gained a "Chunking Utilities" sec
 documenting `chunkText`/`safeSlice`/the two constants for external consumers, including a
 note that `chunkText`'s per-chunk overlap is a maximum (a chunk repeats fewer than `overlap`
 characters when the previous chunk was shorter than that), and that `ingestDocument`'s
-overlap-clamp (Decision 2) still applies only to non-default configs.
+overlap-clamp (Decision 2) is evaluated on every call, including when only `maxChunkLength`
+is customized — it's a no-op for the shipped defaults, but reduces the effective overlap to
+`maxChunkLength - 1` whenever the resolved overlap (default or caller-supplied) would
+otherwise be too large.
 
 ## Minor Considerations
 
@@ -133,11 +136,12 @@ prefix change.
 
 `chunkText`, `safeSlice`, and the two new constants are moving from internal-only to public
 API surface consumed by at least one external package (aws-cloud-agent). Add JSDoc comments
-to all four at their definition sites (`packages/core/src/utils/pure.ts` for the functions,
-`packages/core/src/index.ts` for the constants) covering: what each does, parameter/return
-semantics for the functions, and — for the constants — that they are the values
-`IngestionService` uses when a caller doesn't override `maxChunkLength`/`chunkOverlap`. This
-is documentation only; no behavior or signature change.
+to all four at their definition sites (`packages/core/src/utils/pure.ts` for the functions;
+`packages/core/src/utils/chunkingDefaults.ts` for the constants — relocated there from
+`IngestionService.ts` so importing them doesn't pull in `IngestionService`'s runtime import
+graph) covering: what each does, parameter/return semantics for the functions, and — for the
+constants — that they are the values `IngestionService` uses when a caller doesn't override
+`maxChunkLength`/`chunkOverlap`. This is documentation only; no behavior or signature change.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
+++ b/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
@@ -1,9 +1,10 @@
 # Spec: Export `chunkText` / `safeSlice` from the Public API
 
 **Date:** 2026-08-06
-**Status:** Draft
+**Status:** Implemented
 **Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (re-export, no code change needed)
 **Issue:** [equationalapplications/expo-llm-wiki#70](https://github.com/equationalapplications/expo-llm-wiki/issues/70)
+**PR:** [equationalapplications/expo-llm-wiki#71](https://github.com/equationalapplications/expo-llm-wiki/pull/71)
 
 ---
 
@@ -35,16 +36,25 @@ Export `chunkText`, `safeSlice`, and the ingest default constants from
 that already exist and are already used internally; this only changes what's visible from
 the package boundary.
 
+As implemented, the constants are declared at their point of use in `IngestionService.ts`
+(not in `index.ts` as originally sketched below) and re-exported from `index.ts`:
+
 ```ts
-// packages/core/src/index.ts
-export { chunkText, safeSlice } from './utils/pure';
+// packages/core/src/services/IngestionService.ts
 export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
 export const DEFAULT_CHUNK_OVERLAP = 400;
+
+// packages/core/src/index.ts
+export { chunkText, safeSlice } from './utils/pure';
+export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './services/IngestionService';
 ```
 
-`IngestionService.ts:49-50` is updated to reference `DEFAULT_MAX_CHUNK_LENGTH` /
-`DEFAULT_CHUNK_OVERLAP` instead of the inline literals `12000` / `400`, so the exported
-constants and the actual ingest-time defaults cannot drift apart.
+This keeps the constant and the ingest-time default as the same binding rather than two
+values kept in sync by convention.
+
+All three literal sites in `IngestionService.ingestDocument` — not just `:49-50` — now
+reference the constants: the `maxChunkLength`/`rawOverlap` defaults and the sanitizer
+fallback used when a caller-supplied `chunkOverlap` is non-finite or negative.
 
 `packages/expo/src/index.ts` requires no change — it already does
 `export * from '@equationalapplications/core-llm-wiki'`, so the new exports flow through
@@ -98,6 +108,12 @@ package entry point, not a deep internal path), asserting:
 Existing behavioral coverage of the chunking algorithm itself
 (`packages/core/__tests__/chunkText.test.ts`, via `WikiMemory.__testables`) is unaffected
 and continues to be the source of truth for chunking edge cases.
+
+As implemented, `packages/core/README.md` also gained a "Chunking Utilities" section
+documenting `chunkText`/`safeSlice`/the two constants for external consumers, including a
+note that `chunkText`'s per-chunk overlap is a maximum (a chunk repeats fewer than `overlap`
+characters when the previous chunk was shorter than that), and that `ingestDocument`'s
+overlap-clamp (Decision 2) still applies only to non-default configs.
 
 ## Minor Considerations
 

--- a/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
+++ b/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
@@ -1,0 +1,110 @@
+# Spec: Export `chunkText` / `safeSlice` from the Public API
+
+**Date:** 2026-08-06
+**Status:** Draft
+**Packages:** `core-llm-wiki` (primary), `expo-llm-wiki` (re-export, no code change needed)
+**Issue:** [equationalapplications/expo-llm-wiki#70](https://github.com/equationalapplications/expo-llm-wiki/issues/70)
+
+---
+
+## Problem
+
+`chunkText` and its helper `safeSlice` (`packages/core/src/utils/pure.ts:102` and `:64`)
+implement the document-chunking algorithm `IngestionService.ingestDocument` uses to split
+text before embedding. Neither is exported from `packages/core/src/index.ts`, so they are
+invisible from the package's public entry point (`dist/index.d.ts`) — `expo-llm-wiki`
+re-exports everything from `core-llm-wiki` via `export *`, so this is a single-package fix.
+
+A downstream consumer (aws-cloud-agent's cortex judge, spec
+`2026-08-05-cortex-judge-design.md`) needs to re-chunk a source document at read time and
+rank the resulting chunks against a fact's stored embedding, to recover roughly the passage
+a fact was extracted from. That only works if the re-chunking matches what the library did
+at ingest time. Lacking a public export, the consumer ported the algorithm verbatim into its
+own codebase (`src/judge/chunk.ts`, copied from `chunk-W53E3I44.mjs` lines 996–1064). That
+copy will silently drift from the library's actual behavior if `chunkText` ever changes,
+degrading passage recovery without any error.
+
+The consumer also needs to know the default `maxChunkLength`/`chunkOverlap` values ingest
+uses when a host app doesn't override them (`IngestionService.ts:49-50`, currently the
+literals `12000` and `400`), so it can reproduce default-config chunking without guessing.
+
+## Solution
+
+Export `chunkText`, `safeSlice`, and the ingest default constants from
+`packages/core/src/index.ts`. No new code, no behavior change — these are pure functions
+that already exist and are already used internally; this only changes what's visible from
+the package boundary.
+
+```ts
+// packages/core/src/index.ts
+export { chunkText, safeSlice } from './utils/pure';
+export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
+export const DEFAULT_CHUNK_OVERLAP = 400;
+```
+
+`IngestionService.ts:49-50` is updated to reference `DEFAULT_MAX_CHUNK_LENGTH` /
+`DEFAULT_CHUNK_OVERLAP` instead of the inline literals `12000` / `400`, so the exported
+constants and the actual ingest-time defaults cannot drift apart.
+
+`packages/expo/src/index.ts` requires no change — it already does
+`export * from '@equationalapplications/core-llm-wiki'`, so the new exports flow through
+automatically.
+
+## Design Decisions
+
+### 1. Export location: `core-llm-wiki`, not `expo-llm-wiki`
+
+`chunkText`/`safeSlice` are pure, platform-independent string functions with no dependency
+on `expo-sqlite` or any Expo API. They belong in `core-llm-wiki` alongside the other pure
+utilities already exported there (`parseEmbedding`, `formatContext`, etc.). `expo-llm-wiki`
+picks them up for free via its existing `export *`.
+
+### 2. Export default chunking constants, not the overlap-clamp logic
+
+`IngestionService.ingestDocument` also clamps a caller-supplied `chunkOverlap` via
+`Math.min(rawOverlap, maxChunkLength - 1)` (`IngestionService.ts:51-54`). That clamp only
+matters when a caller overrides `chunkOverlap` to a value close to (or exceeding)
+`maxChunkLength`. This issue's motivating use case is reproducing *default-config* ingest
+chunking, where the clamp is a no-op (`400 < 12000 - 1`). Exporting the clamp function is
+out of scope; a future issue can add it if a consumer needs to replicate custom-config
+ingest behavior exactly.
+
+### 3. Signatures are unchanged
+
+The existing signatures already match the issue's ask exactly:
+
+```ts
+function chunkText(
+  input: string,
+  maxChunkLength: number,
+  overlap: number
+): { chunks: string[]; truncated: boolean }
+
+function safeSlice(value: string, start: number, end?: number): string
+```
+
+No signature changes are needed — this is a visibility change only.
+
+## Testing
+
+Add `packages/core/__tests__/publicExports.test.ts`, importing from `../src/index` (the
+package entry point, not a deep internal path), asserting:
+
+- `chunkText` and `safeSlice` are exported and produce output identical to calling the
+  internal `utils/pure` implementations directly (i.e., the export is the same function,
+  not a copy).
+- `DEFAULT_MAX_CHUNK_LENGTH === 12000` and `DEFAULT_CHUNK_OVERLAP === 400`.
+
+Existing behavioral coverage of the chunking algorithm itself
+(`packages/core/__tests__/chunkText.test.ts`, via `WikiMemory.__testables`) is unaffected
+and continues to be the source of truth for chunking edge cases.
+
+## Non-Goals
+
+- Changing the chunking algorithm's behavior.
+- Exporting the overlap-clamping helper from `IngestionService` (see Decision 2).
+- Adding new configuration surface for chunking (existing `WikiOptions.config.maxChunkLength`
+  / `chunkOverlap` are untouched).
+- Persisting the actual `maxChunkLength`/`chunkOverlap` used per-fact at ingest time (would
+  let a consumer reproduce chunking under custom config, not just defaults) — out of scope
+  for this issue; the ask is limited to exporting the existing pure functions.

--- a/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
+++ b/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
@@ -10,7 +10,7 @@
 
 ## Problem
 
-`chunkText` and its helper `safeSlice` (`packages/core/src/utils/pure.ts:102` and `:64`)
+`chunkText` and its helper `safeSlice` (both in `packages/core/src/utils/pure.ts`)
 implement the document-chunking algorithm `IngestionService.ingestDocument` uses to split
 text before embedding. Neither is exported from `packages/core/src/index.ts`, so they are
 invisible from the package's public entry point (`dist/index.d.ts`) — `expo-llm-wiki`
@@ -26,8 +26,9 @@ copy will silently drift from the library's actual behavior if `chunkText` ever 
 degrading passage recovery without any error.
 
 The consumer also needs to know the default `maxChunkLength`/`chunkOverlap` values ingest
-uses when a host app doesn't override them (`IngestionService.ts:49-50`, currently the
-literals `12000` and `400`), so it can reproduce default-config chunking without guessing.
+uses when a host app doesn't override them (the defaulting at the top of
+`IngestionService.ingestDocument`, at the time of writing the bare literals `12000` and
+`400`), so it can reproduce default-config chunking without guessing.
 
 ## Solution
 
@@ -36,25 +37,34 @@ Export `chunkText`, `safeSlice`, and the ingest default constants from
 that already exist and are already used internally; this only changes what's visible from
 the package boundary.
 
-As implemented, the constants are declared at their point of use in `IngestionService.ts`
-(not in `index.ts` as originally sketched below) and re-exported from `index.ts`:
+As implemented, the constants live in a small dependency-free module (not in `index.ts` as
+originally sketched, and no longer in `IngestionService.ts` — see the review note below).
+`IngestionService` imports them from there, and `index.ts` re-exports them:
 
 ```ts
-// packages/core/src/services/IngestionService.ts
+// packages/core/src/utils/chunkingDefaults.ts
 export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
 export const DEFAULT_CHUNK_OVERLAP = 400;
 
+// packages/core/src/services/IngestionService.ts
+import { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from '../utils/chunkingDefaults';
+
 // packages/core/src/index.ts
 export { chunkText, safeSlice } from './utils/pure';
-export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './services/IngestionService';
+export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './utils/chunkingDefaults';
 ```
 
 This keeps the constant and the ingest-time default as the same binding rather than two
-values kept in sync by convention.
+values kept in sync by convention. The constants first landed directly in
+`IngestionService.ts`; PR review pointed out that this made the public constants depend on
+that service module's runtime import graph (importing them via the package entry point would
+execute `IngestionService` and its non-type imports like `PromptService`), so they moved to
+`utils/chunkingDefaults.ts` — same single binding, no service code on the constant path.
 
-All three literal sites in `IngestionService.ingestDocument` — not just `:49-50` — now
-reference the constants: the `maxChunkLength`/`rawOverlap` defaults and the sanitizer
-fallback used when a caller-supplied `chunkOverlap` is non-finite or negative.
+All three literal sites in `IngestionService.ingestDocument` — not just the two the spec
+originally named — now reference the constants: the `maxChunkLength`/`rawOverlap` defaults
+and the sanitizer fallback used when a caller-supplied `chunkOverlap` is non-finite or
+negative.
 
 `packages/expo/src/index.ts` requires no change — it already does
 `export * from '@equationalapplications/core-llm-wiki'`, so the new exports flow through
@@ -71,13 +81,17 @@ picks them up for free via its existing `export *`.
 
 ### 2. Export default chunking constants, not the overlap-clamp logic
 
-`IngestionService.ingestDocument` also clamps a caller-supplied `chunkOverlap` via
-`Math.min(rawOverlap, maxChunkLength - 1)` (`IngestionService.ts:51-54`). That clamp only
-matters when a caller overrides `chunkOverlap` to a value close to (or exceeding)
-`maxChunkLength`. This issue's motivating use case is reproducing *default-config* ingest
-chunking, where the clamp is a no-op (`400 < 12000 - 1`). Exporting the clamp function is
-out of scope; a future issue can add it if a consumer needs to replicate custom-config
-ingest behavior exactly.
+`IngestionService.ingestDocument` also clamps the *resolved* overlap via
+`Math.min(rawOverlap, maxChunkLength - 1)` (`IngestionService.ts:52-55`). The clamp is
+evaluated on every call and applies to the resolved value whatever its source — an explicit
+`chunkOverlap`, `WikiOptions.config.chunkOverlap`, or `DEFAULT_CHUNK_OVERLAP`. It is a no-op
+for the shipped defaults (`400 < 12000 - 1`), which is this issue's motivating use case, but
+it also bites when a custom `maxChunkLength` alone leaves the resolved overlap too large
+(e.g. `maxChunkLength: 100` with the default overlap `400` ingests at an effective overlap of
+`99`). Note the clamp is only observable at ingest: passing the unclamped pair to `chunkText`
+throws, since it requires `overlap < maxChunkLength`. Exporting the clamp function is out of
+scope; a future issue can add it if a consumer needs to replicate custom-config ingest
+behavior exactly.
 
 ### 3. Signatures are unchanged
 

--- a/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
+++ b/docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md
@@ -99,6 +99,30 @@ Existing behavioral coverage of the chunking algorithm itself
 (`packages/core/__tests__/chunkText.test.ts`, via `WikiMemory.__testables`) is unaffected
 and continues to be the source of truth for chunking edge cases.
 
+## Minor Considerations
+
+### Constant naming
+
+Checked existing exports in `packages/core/src/index.ts`: none of the current top-level
+exports use a package-wide prefix (`formatContext`, `parseEmbedding`, `validateManifest`,
+etc. are all bare names); the one prefixed constant, `ONTOLOGY_BACKFILL_SYSTEM_PROMPT`, is
+prefixed with its own domain term, not a package-wide tag. `DEFAULT_MAX_CHUNK_LENGTH` and
+`DEFAULT_CHUNK_OVERLAP` also already match the field names on `WikiOptions.config`
+(`maxChunkLength`, `chunkOverlap`), so keeping the unprefixed names stays consistent with
+both established conventions and makes the connection to the config surface obvious.
+Decision: keep `DEFAULT_MAX_CHUNK_LENGTH` / `DEFAULT_CHUNK_OVERLAP` as specified — no
+prefix change.
+
+### JSDoc
+
+`chunkText`, `safeSlice`, and the two new constants are moving from internal-only to public
+API surface consumed by at least one external package (aws-cloud-agent). Add JSDoc comments
+to all four at their definition sites (`packages/core/src/utils/pure.ts` for the functions,
+`packages/core/src/index.ts` for the constants) covering: what each does, parameter/return
+semantics for the functions, and — for the constants — that they are the values
+`IngestionService` uses when a caller doesn't override `maxChunkLength`/`chunkOverlap`. This
+is documentation only; no behavior or signature change.
+
 ## Non-Goals
 
 - Changing the chunking algorithm's behavior.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -817,7 +817,7 @@ const { chunks, truncated } = chunkText(
 );
 ```
 
-`chunkText(input, maxChunkLength, overlap)` returns `{ chunks, truncated }`. It prefers to split on a paragraph break, then a sentence terminator, then whitespace, falling back to a hard cut only when none is found within the window — `truncated` is `true` if any split needed that fallback. Consecutive chunks repeat `overlap` characters so context isn't lost at a boundary. Throws if `maxChunkLength` is not an integer >= 2, or if `overlap` is not a non-negative integer < `maxChunkLength`.
+`chunkText(input, maxChunkLength, overlap)` returns `{ chunks, truncated }`. It prefers to split on a paragraph break, then a sentence terminator, then whitespace, falling back to a hard cut only when none is found within the window — `truncated` is `true` if any split needed that fallback. Consecutive chunks repeat up to `overlap` characters so context isn't lost at a boundary (less than `overlap` when the previous chunk was shorter than that). Throws if `maxChunkLength` is not an integer >= 2, or if `overlap` is not a non-negative integer < `maxChunkLength`.
 
 `safeSlice(value, start, end?)` slices like `String.prototype.slice` but clamps out-of-range indices, swaps a start-after-end range, and never splits a UTF-16 surrogate pair.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -817,7 +817,7 @@ const { chunks, truncated } = chunkText(
 );
 ```
 
-`chunkText(input, maxChunkLength, overlap)` returns `{ chunks, truncated }`. It prefers to split on a paragraph break, then a sentence terminator, then whitespace, falling back to a hard cut only when none is found within the window — `truncated` is `true` if any split needed that fallback. Consecutive chunks repeat up to `overlap` characters so context isn't lost at a boundary (less than `overlap` when the previous chunk was shorter than that). Throws if `maxChunkLength` is not an integer >= 2, or if `overlap` is not a non-negative integer < `maxChunkLength`.
+`chunkText(input, maxChunkLength, overlap)` returns `{ chunks, truncated }`. It prefers to split on a paragraph break, then a sentence terminator, then whitespace, falling back to a hard cut only when none is found within the window — `truncated` is `true` if any split needed that fallback. Consecutive chunks repeat up to `overlap` characters so context isn't lost at a boundary (less than `overlap` when the previous chunk was shorter than that). Empty/whitespace-only input returns `{ chunks: [], truncated: false }` without validating `maxChunkLength`/`overlap`; otherwise throws if `maxChunkLength` is not an integer >= 2, or if `overlap` is not a non-negative integer < `maxChunkLength`.
 
 `safeSlice(value, start, end?)` slices like `String.prototype.slice` but clamps out-of-range indices, swaps a start-after-end range, and never splits a UTF-16 surrogate pair.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -92,8 +92,8 @@ const wikiMemory = new WikiMemory(db, {
     maxResults: 10,                    // default: 10
     autoLibrarianThreshold: 20,        // default: 20 — events before librarian auto-runs
     autoHealThreshold: 100,            // default: 100 — events before heal auto-runs
-    maxChunkLength: 12000,             // default: 12000 (char count per ingestDocument chunk)
-    chunkOverlap: 400,                 // default: 400 (overlap between chunks in characters)
+    maxChunkLength: 12000,             // default: 12000 (char count per ingestDocument chunk; exported as DEFAULT_MAX_CHUNK_LENGTH)
+    chunkOverlap: 400,                 // default: 400 (overlap between chunks in characters; exported as DEFAULT_CHUNK_OVERLAP)
     chunkConcurrency: 1,               // default: 1 (parallel LLM calls per ingestDocument)
     pruneRetainSoftDeletedFor: 7,      // default: 7 (days before hard-deleting soft-deleted facts)
     pruneEventsAfter: 30,              // default: 30 (days before hard-deleting old events)
@@ -797,6 +797,33 @@ configureRandomSource(getRandomValues);
 ```
 
 `@equationalapplications/expo-llm-wiki` does this automatically on import (main entry and `/factory` subpath). If you use `@equationalapplications/core-llm-wiki` directly on React Native without the expo package, you must call `configureRandomSource()` yourself or polyfill `globalThis.crypto.getRandomValues`.
+
+## Chunking Utilities
+
+`ingestDocument()` splits a document into chunks before extraction. That same chunking is exported as a pure function, so a consumer can reproduce ingest-time chunk boundaries exactly — useful for recovering the passage a fact was extracted from, by re-chunking the source and ranking chunks against the fact's stored embedding.
+
+```typescript
+import {
+  chunkText,
+  safeSlice,
+  DEFAULT_MAX_CHUNK_LENGTH,  // 12000
+  DEFAULT_CHUNK_OVERLAP,     // 400
+} from '@equationalapplications/core-llm-wiki';
+
+const { chunks, truncated } = chunkText(
+  sourceDocument,
+  DEFAULT_MAX_CHUNK_LENGTH,
+  DEFAULT_CHUNK_OVERLAP
+);
+```
+
+`chunkText(input, maxChunkLength, overlap)` returns `{ chunks, truncated }`. It prefers to split on a paragraph break, then a sentence terminator, then whitespace, falling back to a hard cut only when none is found within the window — `truncated` is `true` if any split needed that fallback. Consecutive chunks repeat `overlap` characters so context isn't lost at a boundary. Throws if `maxChunkLength` is not an integer >= 2, or if `overlap` is not a non-negative integer < `maxChunkLength`.
+
+`safeSlice(value, start, end?)` slices like `String.prototype.slice` but clamps out-of-range indices, swaps a start-after-end range, and never splits a UTF-16 surrogate pair.
+
+`DEFAULT_MAX_CHUNK_LENGTH` and `DEFAULT_CHUNK_OVERLAP` are the values `ingestDocument()` uses when neither the call nor `WikiConfig` overrides them. Pass the same values your host app configured (`config.maxChunkLength` / `config.chunkOverlap`) to match a non-default ingest.
+
+> **Note:** when a caller overrides `chunkOverlap`, `ingestDocument()` additionally clamps it to `maxChunkLength - 1`. That clamp is internal and a no-op at the defaults; reproduce it yourself if you re-chunk with an overlap close to `maxChunkLength`.
 
 ## Adapter Interface
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -823,7 +823,7 @@ const { chunks, truncated } = chunkText(
 
 `DEFAULT_MAX_CHUNK_LENGTH` and `DEFAULT_CHUNK_OVERLAP` are the values `ingestDocument()` uses when neither the call nor `WikiConfig` overrides them. Pass the same values your host app configured (`config.maxChunkLength` / `config.chunkOverlap`) to match a non-default ingest.
 
-> **Note:** when a caller overrides `chunkOverlap`, `ingestDocument()` additionally clamps it to `maxChunkLength - 1`. That clamp is internal and a no-op at the defaults; reproduce it yourself if you re-chunk with an overlap close to `maxChunkLength`.
+> **Note:** `ingestDocument()` clamps the resolved overlap — whether it came from `chunkOverlap`, `WikiConfig`, or `DEFAULT_CHUNK_OVERLAP` — to `maxChunkLength - 1`. The clamp is evaluated on every call and is a no-op at the shipped defaults (`400 < 12000 - 1`), but it also bites when a custom `maxChunkLength` alone leaves the resolved overlap too large (e.g. `maxChunkLength: 100` with the default overlap `400` ingests at an effective overlap of `99`). That clamp is internal: passing the unclamped pair straight to `chunkText` throws, since it requires `overlap < maxChunkLength`. Apply the same `Math.min(overlap, maxChunkLength - 1)` yourself when re-chunking under a custom config.
 
 ## Adapter Interface
 

--- a/packages/core/__tests__/publicExports.test.ts
+++ b/packages/core/__tests__/publicExports.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  chunkText,
+  safeSlice,
+  DEFAULT_MAX_CHUNK_LENGTH,
+  DEFAULT_CHUNK_OVERLAP,
+} from '../src/index';
+import { chunkText as chunkTextInternal, safeSlice as safeSliceInternal } from '../src/utils/pure';
+
+describe('public exports: chunking', () => {
+  it('exports chunkText as the same function reference as utils/pure', () => {
+    expect(chunkText).toBe(chunkTextInternal);
+  });
+
+  it('exports safeSlice as the same function reference as utils/pure', () => {
+    expect(safeSlice).toBe(safeSliceInternal);
+  });
+
+  it('chunkText via the public entry point produces identical output to the internal implementation', () => {
+    const text = 'a'.repeat(50) + '\n\n' + 'b'.repeat(50);
+    expect(chunkText(text, 60, 5)).toEqual(chunkTextInternal(text, 60, 5));
+  });
+
+  it('safeSlice via the public entry point produces identical output to the internal implementation', () => {
+    expect(safeSlice('hello world', 2, 8)).toBe(safeSliceInternal('hello world', 2, 8));
+  });
+
+  it('exports the ingest default chunking constants', () => {
+    expect(DEFAULT_MAX_CHUNK_LENGTH).toBe(12000);
+    expect(DEFAULT_CHUNK_OVERLAP).toBe(400);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,8 @@ export { parseOkfBundle, type OkfImportOptions } from './utils/parseOkfBundle';
 export { parseEmbedding } from './utils/embedding';
 export { validateManifest } from './utils/ontology';
 export { configureRandomSource } from './utils/ids';
+export { chunkText, safeSlice } from './utils/pure';
+export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './services/IngestionService';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export { parseEmbedding } from './utils/embedding';
 export { validateManifest } from './utils/ontology';
 export { configureRandomSource } from './utils/ids';
 export { chunkText, safeSlice } from './utils/pure';
-export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './services/IngestionService';
+export { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from './utils/chunkingDefaults';
 export * from './librarianPrompt';
 export { PromptService } from './services/PromptService';
 export {

--- a/packages/core/src/services/IngestionService.ts
+++ b/packages/core/src/services/IngestionService.ts
@@ -10,6 +10,20 @@ import type { EmbeddingService } from './EmbeddingService';
 import type { OntologyService, TitleIndexEntry } from './OntologyService';
 import { PromptService } from './PromptService';
 
+/**
+ * Default maximum characters per chunk that `ingestDocument` uses when a
+ * caller doesn't override `maxChunkLength` (directly or via
+ * `WikiOptions.config.maxChunkLength`).
+ */
+export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
+
+/**
+ * Default character overlap between consecutive chunks that
+ * `ingestDocument` uses when a caller doesn't override `chunkOverlap`
+ * (directly or via `WikiOptions.config.chunkOverlap`).
+ */
+export const DEFAULT_CHUNK_OVERLAP = 400;
+
 export class IngestionService {
   private promptService: PromptService;
 
@@ -46,10 +60,10 @@ export class IngestionService {
     const sourceHash = normalizeSourceHash(params.sourceHash);
     if (!sourceHash) throw new Error('Invalid sourceHash (must be 64-char hex string)');
 
-    const maxChunkLength = params.maxChunkLength ?? this.options.config?.maxChunkLength ?? 12000;
-    const rawOverlap = params.chunkOverlap ?? this.options.config?.chunkOverlap ?? 400;
+    const maxChunkLength = params.maxChunkLength ?? this.options.config?.maxChunkLength ?? DEFAULT_MAX_CHUNK_LENGTH;
+    const rawOverlap = params.chunkOverlap ?? this.options.config?.chunkOverlap ?? DEFAULT_CHUNK_OVERLAP;
     const chunkOverlap = Math.min(
-      Number.isFinite(rawOverlap) && rawOverlap >= 0 ? Math.floor(rawOverlap) : 400,
+      Number.isFinite(rawOverlap) && rawOverlap >= 0 ? Math.floor(rawOverlap) : DEFAULT_CHUNK_OVERLAP,
       maxChunkLength - 1
     );
 

--- a/packages/core/src/services/IngestionService.ts
+++ b/packages/core/src/services/IngestionService.ts
@@ -9,20 +9,7 @@ import type { JobManager } from './JobManager';
 import type { EmbeddingService } from './EmbeddingService';
 import type { OntologyService, TitleIndexEntry } from './OntologyService';
 import { PromptService } from './PromptService';
-
-/**
- * Default maximum characters per chunk that `ingestDocument` uses when a
- * caller doesn't override `maxChunkLength` (directly or via
- * `WikiOptions.config.maxChunkLength`).
- */
-export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
-
-/**
- * Default character overlap between consecutive chunks that
- * `ingestDocument` uses when a caller doesn't override `chunkOverlap`
- * (directly or via `WikiOptions.config.chunkOverlap`).
- */
-export const DEFAULT_CHUNK_OVERLAP = 400;
+import { DEFAULT_MAX_CHUNK_LENGTH, DEFAULT_CHUNK_OVERLAP } from '../utils/chunkingDefaults';
 
 export class IngestionService {
   private promptService: PromptService;

--- a/packages/core/src/utils/chunkingDefaults.ts
+++ b/packages/core/src/utils/chunkingDefaults.ts
@@ -1,0 +1,16 @@
+/**
+ * Default maximum characters per chunk that `ingestDocument` uses when a
+ * caller doesn't override `maxChunkLength` (directly or via
+ * `WikiOptions.config.maxChunkLength`).
+ */
+export const DEFAULT_MAX_CHUNK_LENGTH = 12000;
+
+/**
+ * Default/fallback character overlap between consecutive chunks.
+ * `ingestDocument` uses this when a caller doesn't override `chunkOverlap`
+ * (directly or via `WikiOptions.config.chunkOverlap`), and clamps the
+ * effective overlap (including this default) to `maxChunkLength - 1` when
+ * needed. The clamp is a no-op for the shipped defaults; it can also apply
+ * when a custom `maxChunkLength` makes the resolved overlap too large.
+ */
+export const DEFAULT_CHUNK_OVERLAP = 400;

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -61,6 +61,20 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
   return sanitized;
 }
 
+/**
+ * Slices a string like `String.prototype.slice`, but clamps out-of-range
+ * indices instead of relying on JS's implicit clamping, normalizes a
+ * start-after-end range by swapping the two bounds, and nudges either bound
+ * off a UTF-16 surrogate pair boundary so slicing never splits one code
+ * point in half.
+ *
+ * @param value - The source string to slice.
+ * @param start - Start index; negative counts from the end, out-of-range
+ *   values are clamped to `[0, value.length]`.
+ * @param end - End index (exclusive); defaults to `value.length` when
+ *   omitted. Same clamping/negative-index rules as `start`.
+ * @returns The sliced substring, never splitting a surrogate pair.
+ */
 export function safeSlice(value: string, start: number, end?: number): string {
   const length = value.length;
   let safeStart = start < 0 ? Math.max(length + start, 0) : Math.min(start, length);
@@ -99,6 +113,29 @@ export function safeSlice(value: string, start: number, end?: number): string {
   return value.slice(safeStart, safeEnd);
 }
 
+/**
+ * Splits `input` into chunks of at most `maxChunkLength` characters,
+ * preferring to split on a paragraph break, then a sentence terminator,
+ * then whitespace, falling back to a hard cut only when none of those are
+ * found within the window. Consecutive chunks overlap by `overlap`
+ * characters so context isn't lost at a chunk boundary. This is the exact
+ * chunking algorithm `IngestionService.ingestDocument` uses before
+ * embedding, so callers can reproduce ingest-time chunk boundaries exactly
+ * given the same `maxChunkLength`/`overlap` (see `DEFAULT_MAX_CHUNK_LENGTH`
+ * and `DEFAULT_CHUNK_OVERLAP` for the defaults ingest uses).
+ *
+ * @param input - The text to chunk; leading/trailing whitespace is trimmed
+ *   before chunking.
+ * @param maxChunkLength - Maximum characters per chunk; must be an integer
+ *   >= 2.
+ * @param overlap - Number of characters each chunk repeats from the end of
+ *   the previous chunk; must be a non-negative integer less than
+ *   `maxChunkLength`.
+ * @returns `chunks` — the resulting chunk strings (empty array for
+ *   empty/whitespace-only input); `truncated` — `true` if any split had to
+ *   fall back to a hard cut (no paragraph/sentence/whitespace boundary
+ *   found in the window).
+ */
 export function chunkText(
   input: string,
   maxChunkLength: number,

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -117,7 +117,7 @@ export function safeSlice(value: string, start: number, end?: number): string {
  * Splits `input` into chunks of at most `maxChunkLength` characters,
  * preferring to split on a paragraph break, then a sentence terminator,
  * then whitespace, falling back to a hard cut only when none of those are
- * found within the window. Consecutive chunks overlap by `overlap`
+ * found within the window. Consecutive chunks overlap by up to `overlap`
  * characters so context isn't lost at a chunk boundary. This is the exact
  * chunking algorithm `IngestionService.ingestDocument` uses before
  * embedding, so callers can reproduce ingest-time chunk boundaries exactly
@@ -128,9 +128,10 @@ export function safeSlice(value: string, start: number, end?: number): string {
  *   before chunking.
  * @param maxChunkLength - Maximum characters per chunk; must be an integer
  *   >= 2.
- * @param overlap - Number of characters each chunk repeats from the end of
- *   the previous chunk; must be a non-negative integer less than
- *   `maxChunkLength`.
+ * @param overlap - Maximum number of characters each chunk repeats from the
+ *   end of the previous chunk; must be a non-negative integer less than
+ *   `maxChunkLength`. A chunk repeats fewer characters when the previous
+ *   chunk was shorter than `overlap`.
  * @returns `chunks` — the resulting chunk strings (empty array for
  *   empty/whitespace-only input); `truncated` — `true` if any split had to
  *   fall back to a hard cut (no paragraph/sentence/whitespace boundary

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -125,13 +125,14 @@ export function safeSlice(value: string, start: number, end?: number): string {
  * and `DEFAULT_CHUNK_OVERLAP` for the defaults ingest uses).
  *
  * @param input - The text to chunk; leading/trailing whitespace is trimmed
- *   before chunking.
- * @param maxChunkLength - Maximum characters per chunk; must be an integer
- *   >= 2.
- * @param overlap - Maximum number of characters each chunk repeats from the
- *   end of the previous chunk; must be a non-negative integer less than
- *   `maxChunkLength`. A chunk repeats fewer characters when the previous
- *   chunk was shorter than `overlap`.
+ *   before chunking. Empty/whitespace-only input returns the empty result
+ *   below without validating `maxChunkLength`/`overlap`.
+ * @param maxChunkLength - For non-empty input, maximum characters per chunk;
+ *   must be an integer >= 2.
+ * @param overlap - For non-empty input, maximum number of characters each
+ *   chunk repeats from the end of the previous chunk; must be a
+ *   non-negative integer less than `maxChunkLength`. A chunk repeats fewer
+ *   characters when the previous chunk was shorter than `overlap`.
  * @returns `chunks` — the resulting chunk strings (empty array for
  *   empty/whitespace-only input); `truncated` — `true` if any split had to
  *   fall back to a hard cut (no paragraph/sentence/whitespace boundary


### PR DESCRIPTION
Closes #70. Implements `docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md`.

## What

Spec: docs/superpowers/specs/2026-08-06-export-chunk-text-public-api.md

Makes the document-chunking algorithm part of the public API of `@equationalapplications/core-llm-wiki`:

- `export { chunkText, safeSlice } from './utils/pure'`
- `DEFAULT_MAX_CHUNK_LENGTH` (12000) and `DEFAULT_CHUNK_OVERLAP` (400)
- JSDoc on all four symbols
- `packages/core/__tests__/publicExports.test.ts`
- README section documenting the utilities

No behavior change and no signature change — this is a visibility change plus documentation. `packages/expo` picks the exports up for free via its existing `export *`.

## Why

A downstream consumer needs to re-chunk a source document at read time and rank the resulting chunks against a fact's stored embedding, to recover the passage a fact was extracted from. That only works if the re-chunking matches what the library did at ingest. Without a public export, the consumer had ported the algorithm verbatim, where it would silently drift from the library's behavior and degrade passage recovery with no error.

## Notes on deviations from the spec

1. **Constants live in `packages/core/src/utils/chunkingDefaults.ts`, imported by `IngestionService` and re-exported from `index.ts`** — the spec's snippet declared them in `index.ts`. Defining them once and importing at the point of use makes the anti-drift goal structural rather than conventional: the exported constant and the ingest-time default are the same binding. They initially landed directly in `IngestionService.ts`; review noted that this put the service module's runtime import graph (`PromptService` et al.) on the path of anyone importing just the constants, so they moved to a dependency-free module.

2. **Three literals replaced, not two** — the spec named two sites in `ingestDocument`, but the sanitizer fallback for a non-finite/negative `chunkOverlap` override was a third `400`. It now uses `DEFAULT_CHUNK_OVERLAP` too.

The overlap-clamp helper stays internal (spec Decision 2); the README documents it as a caveat for anyone re-chunking under a custom config. Note the clamp is evaluated on every `ingestDocument` call against the resolved overlap — it is a no-op at the shipped defaults, but bites when a custom `maxChunkLength` alone leaves the resolved overlap too large.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 67 files, 816 tests passing
- `npm run build` succeeds; all four symbols present in `dist/index.d.ts` with JSDoc intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)