### PR TITLE
ci: run build, typecheck, and tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer push to the same PR/branch supersedes an in-flight run.
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # release.yml publishes on 24.10.0; deploy.yml builds on 20.19.0.
+        # Both are exercised so neither path can break unnoticed.
+        node-version: ["20.19.0", "24.10.0"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v4.0.0
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-node${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node${{ matrix.node-version }}-pnpm-store-
+
+      - run: pnpm install --frozen-lockfile
+
+      # Build MUST come before typecheck. Packages resolve each other through
+      # built output (e.g. packages/react imports types from
+      # @equationalapplications/core-llm-wiki), so on a clean checkout with no
+      # dist/ the typecheck fails with spurious TS2305 "has no exported member"
+      # errors. This is also the step release.yml runs before publishing, so a
+      # break here is a break in the publish path.
+      - name: Build
+        run: pnpm run build
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test


### PR DESCRIPTION
## What

Adds `.github/workflows/test.yml` — a `Test` workflow running the root **build**, **typecheck**, and **test** scripts on every pull request (plus pushes to `main` and manual dispatch).

## Why

This repo publishes to npm from `main` via `release.yml`, but nothing verified a branch before it got there. The only workflows were `release.yml` and `deploy.yml`, **both triggered on push to `main`** — i.e. after merge. `gh api .../check-runs` on a PR head came back empty.

That means a PR could merge, cut a version, and publish to npm without a single test having run. It surfaced during #71: the only verification behind that release was me running `vitest` by hand. It happened to be green — but that was luck, not process.

## Shape of the workflow

Two choices worth calling out, both commented in the file:

**Build runs before typecheck.** My first draft ordered it `typecheck → test → build` and would have failed on *every* run. Packages resolve each other through built output (`packages/react` imports types from `@equationalapplications/core-llm-wiki`), so on a clean checkout with no `dist/` the typecheck dies with spurious `TS2305: has no exported member` errors. Build is also the step `release.yml` runs before publishing, so a break there is a break in the publish path.

**Node is matrixed over `20.19.0` and `24.10.0`** — `deploy.yml` builds on the former, `release.yml` publishes on the latter. Both paths need to keep working, and the suite is fast enough that the second leg is nearly free.

Action SHA pins and the pnpm-store cache pattern are copied from `release.yml` so all three workflows stay consistent. `permissions: contents: read` only, and `concurrency` cancels superseded in-flight runs.

The root build includes `apps/wiki-demo`, so demo breakage is caught too.

## Verification

Run locally from a genuinely clean tree — no `dist/`, no `*.tsbuildinfo` (including `apps/wiki-demo/node_modules/.tmp/`), fresh `pnpm install --frozen-lockfile`:

- `pnpm run build` — pass
- `pnpm run typecheck` — pass
- `pnpm run test` — pass

This PR also exercises the workflow against itself.

## Follow-up worth considering

With this in place, `Test` can be made a required status check on `main` — that's the part that actually closes the gap, since the workflow alone doesn't block a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)