### PR TITLE
fix: close heal/librarian dedupe race by moving heal's dedupe read inside its transaction (#69)

### DIFF
--- a/docs/superpowers/specs/2026-08-06-heal-librarian-dedupe-race-design.md
+++ b/docs/superpowers/specs/2026-08-06-heal-librarian-dedupe-race-design.md
@@ -1,7 +1,7 @@
 # Spec: Heal/Librarian Dedupe Race
 
 **Date:** 2026-08-06
-**Status:** Approved, not implemented
+**Status:** Implemented
 **Issue:** [#69](https://github.com/equationalapplications/expo-llm-wiki/issues/69)
 **Packages:** `@eq/wiki-core`
 

--- a/docs/superpowers/specs/2026-08-06-heal-librarian-dedupe-race-design.md
+++ b/docs/superpowers/specs/2026-08-06-heal-librarian-dedupe-race-design.md
@@ -1,0 +1,218 @@
+# Spec: Heal/Librarian Dedupe Race
+
+**Date:** 2026-08-06
+**Status:** Approved, not implemented
+**Issue:** [#69](https://github.com/equationalapplications/expo-llm-wiki/issues/69)
+**Packages:** `@eq/wiki-core`
+
+---
+
+## Problem
+
+`librarian` and `heal` may run concurrently on the same entity. Both passes end by
+synthesizing new facts behind a "skip if a very similar fact already exists" Jaccard
+check. Heal reads that dedupe corpus **outside** its write transaction, so a librarian
+insert landing during heal's LLM round-trip is invisible to heal's check, and heal can
+insert a near-duplicate of it.
+
+The two passes are not symmetrical about when they snapshot the corpus:
+
+- Librarian opens its transaction at `MaintenanceService.ts:391` and reads the corpus
+  at `:407`, passing `tx`. Its exposure is a few statements.
+- Heal reads the corpus at `MaintenanceService.ts:630-632` **without** `tx`, and does
+  not open its transaction until `:634`. Its exposure spans the entire LLM call.
+
+Nothing errors. Both passes write in transactions; the corpus quietly accumulates
+redundant facts.
+
+This is reasoned from the code, not an observed failure. It is the same defect class as
+the bug fixed in #68 (`a2ba9ca`), where heal's dedupe snapshot went stale against heal's
+*own* same-pass deletions. That one was single-threaded and demonstrable; this one is a
+race.
+
+### The concurrency is intentional
+
+`JobManager.acquireLock` (`JobManager.ts:123-133`) handles `librarian`, `heal`, and
+`ontologyBackfill` in one branch that blocks each against its own key plus
+prune/reembed/import/forget — but never against each other. `jobs.test.ts:82` asserts
+it: *"runHeal does not block runLibrarian for same entity after mutex split"*. This is a
+deliberate mutex split, not a missing lock, and this spec preserves it.
+
+---
+
+## Key finding: transactions are globally serialized
+
+`withSerializedTransactions` (`packages/core/src/db/serializedAdapter.ts:57`) wraps
+`withTransactionAsync` in a promise-chain mutex so transactions on the single shared
+connection run strictly one at a time. This was added by the
+[2026-07-09 transaction serialization spec](./2026-07-09-transaction-serialization-spec.md).
+
+This changes the conclusion issue #69 reached. The issue assumed moving heal's dedupe
+read inside its transaction would only *shrink* the stale window from "one LLM
+round-trip" to "a few statements," leaving a residual race that might justify full
+mutual exclusion.
+
+It does not. It **closes** the race. With transactions serialized end to end, a
+librarian transaction either commits entirely before heal's transaction begins or
+entirely after it ends. There is no interleaving point at which librarian can insert a
+fact that heal's in-transaction snapshot missed but heal's insert would duplicate.
+
+Two facts make the change cheap:
+
+- `findInferredTitlesByEntityId(entityId, tx?)` (`EntryRepository.ts:1064`) already
+  accepts a `tx` parameter. No signature change.
+- Its `WHERE` clause already filters `deleted_at IS NULL`, so reading it *after*
+  `softDeleteByIds` reproduces the `safeDeletedSet` filter from #68 naturally.
+
+---
+
+## Solution
+
+Three changes, in one commit.
+
+### 1. Move heal's dedupe read inside its transaction
+
+`MaintenanceService.ts:630-632` moves into the transaction, after the soft delete:
+
+```ts
+await this.db.withTransactionAsync(async (tx) => {
+  await this.entryRepo.downgradeByIds(safeDowngraded, entityId, tx);
+  await this.entryRepo.softDeleteByIds(safeDeleted, entityId, tx);
+
+  const healFactsForDedupe = await this.entryRepo.findInferredTitlesByEntityId(entityId, tx);
+```
+
+The `.filter(f => !safeDeletedSet.has(f.id))` is dropped. Ordering is load-bearing: the
+read must follow `softDeleteByIds`, or rows this pass retires are still in the corpus
+and a delete-plus-restate — heal's normal output shape — would match the row it replaces,
+drop the replacement, and leave the fact gone entirely. That is the #68 regression,
+guarded by `healBounding.test.ts:195` — *"does not dedupe a replacement against the fact
+deleted in the same pass"* — which must still pass unchanged.
+
+That test's explanatory comment (`:197-199`) describes the corpus as "read before the
+pass's" deletions and needs updating alongside the code. The assertions do not change;
+only the rationale text, which would otherwise describe a mechanism that no longer
+exists.
+
+The comment block at `:621-629` is rewritten. The "read before the transaction
+soft-deletes" rationale is now obsolete and would contradict the code. The full-breadth
+rationale at `:621-624` stays — it is still true and still load-bearing.
+
+`healFactsForDedupe` keeps its declared type `Array<{ id: string; title: string }>`,
+which the query already returns.
+
+### 2. Correct the false guarantee in WriteService
+
+`WriteService.ts:119-121` currently claims:
+
+> Guarded by `isBlocked('librarian')` so heal still never overlaps a librarian pass
+
+That guarantee does not hold. `maybeRunHeal` (`:145`) awaits `getCheckpoint` before
+reaching `tryAcquireAutoHealLock` (`JobManager.ts:257`), which only checks the heal key,
+so a librarian pass can start in the gap.
+
+**The check stays; only the comment changes.** The check is redundancy avoidance, not a
+safety rule — a librarian pass already calls `maybeRunHeal` when it finishes
+(`runLibrarianThenMaybeHeal`, `:126`), so losing the race costs a duplicate pass, not
+correctness.
+
+The corrected comment states what is actually true: heal and librarian can overlap, the
+check only reduces redundant passes, and correctness rests on heal's dedupe read being
+transactional (change 1).
+
+This correction ships with change 1 rather than separately. The dedupe fix does **not**
+make the old comment true — heal and librarian still run concurrently afterward; only
+the data race is closed. Shipping the fix and leaving the comment would leave a false
+statement that actively misleads the next reader into believing the overlap is
+impossible.
+
+### 3. Regression test
+
+Per the issue's "before acting" note, confirm the failure is real rather than designing
+against a hypothesis.
+
+**The test must be demonstrated failing on current `main` before the fix lands.** A test
+that passes both before and after proves nothing.
+
+Shape:
+
+1. Mock LLM provider with a controllable delay on heal's `generateText`.
+2. While heal is inside that call, commit a librarian pass inserting a
+   `librarian_inferred` fact.
+3. Heal's mocked output synthesizes a fact whose title is within `FUZZY_THRESHOLD`
+   Jaccard of the librarian fact, with both titles at or above `MIN_TOKENS_TO_QUALIFY`
+   tokens.
+4. Assert exactly one matching fact exists.
+
+Before the fix: two facts. After: one.
+
+---
+
+## Behavior changes
+
+Dropping the `safeDeletedSet` filter is **not a pure no-op**, and is not being shipped
+as "removed redundant code."
+
+In the normal case the two are equivalent: `softDeleteByIds` runs first and the query
+filters `deleted_at IS NULL`, so those rows leave the corpus either way.
+
+They diverge when `softDeleteByIds` does not actually delete a row it was asked to —
+the id belongs to another entity, or the row was already deleted. Old behavior: filtered
+out of the corpus regardless. New behavior: stays in the corpus.
+
+The new behavior is more correct. If a row is still live, a synthesized replacement
+*should* dedupe against it, because the fact is not gone. This is the exact failure #68
+protected against, and the new ordering protects against it more precisely — it keys off
+what the database actually contains rather than what the model asked for.
+
+No public API changes. `runHeal` and `runLibrarian` keep their current signatures and
+blocking behavior. Ships as a `fix:` patch release.
+
+---
+
+## Costs
+
+Moving a full-breadth read into the transaction puts it inside the globally serialized
+critical section, where it blocks every other transaction for its duration.
+
+Acceptable: two columns, single entity, and librarian already does exactly this at
+`MaintenanceService.ts:407`. `EntryRepository.ts:1062` documents the query as "full
+breadth, two columns, cheap." Named here as a considered tradeoff rather than a free
+change.
+
+---
+
+## Out of scope
+
+**Mutual exclusion between librarian and heal.** Considered and rejected. It was only
+justified if option A left a residual race — it does not, given transaction
+serialization. It would reverse the deliberate mutex split, make `wiki.runHeal()` throw
+`WikiBusyError` while a librarian pass runs (breaking for hosts), and risk starving
+heal: librarian fires every `autoLibrarianThreshold` (default 20) events, while heal is
+bounded to `HEAL_BATCH_SIZE` (25) facts per pass and needs many passes to sweep a
+corpus. On a write-heavy entity heal could fall permanently behind. Strictly worse for
+zero remaining benefit.
+
+**Changing the `isBlocked('librarian')` check itself.** Per the issue: it "should not be
+'fixed' in isolation." It stays as redundancy avoidance; only its documentation is
+corrected.
+
+**The `healCandidates` read, also outside the transaction.** It selects candidates
+rather than gating inserts, so a stale entry costs a wasted candidate, not a duplicate
+fact. Different exposure, not addressed here.
+
+---
+
+## Verification
+
+- New regression test: red on `main`, green after the fix.
+- `healBounding.test.ts:195` (delete-plus-restate) still passes — guards the ordering
+  requirement in change 1.
+- `healBounding.test.ts:159` (dedupe outside the candidate window) still passes —
+  guards the full-breadth property, which the move must not narrow.
+- `jobs.test.ts:82` still passes — confirms the mutex split is preserved.
+- Full `packages/core` suite passes.
+
+Constants cited above, verified against `MaintenanceService.ts`: `FUZZY_THRESHOLD` 0.5
+(`:20`), `MIN_TOKENS_TO_QUALIFY` 3 (`:21`), `HEAL_BATCH_SIZE` 25 (`:48`);
+`autoLibrarianThreshold` defaults to 20 (`WriteService.ts:77`).

--- a/packages/core/__tests__/healBounding.test.ts
+++ b/packages/core/__tests__/healBounding.test.ts
@@ -194,9 +194,9 @@ describe('doRunHeal — per-pass call bounding (#67)', () => {
 
   it('does not dedupe a replacement against the fact deleted in the same pass', async () => {
     // Delete-plus-replace is the shape heal is built for: the model retires a
-    // stale fact and restates it. The dedupe corpus is read before the pass's
-    // own soft-deletes land, so the retired row must be excluded explicitly or
-    // its replacement is dropped as a duplicate of a row that no longer exists.
+    // stale fact and restates it. The dedupe corpus is read after the pass's
+    // own soft-deletes land, so the retired row leaves the corpus via the
+    // deleted_at IS NULL filter and its replacement is not falsely matched.
     const generateText = vi.fn(async () => JSON.stringify({
       downgraded: [],
       deleted: ['stale'],

--- a/packages/core/__tests__/healBounding.test.ts
+++ b/packages/core/__tests__/healBounding.test.ts
@@ -241,4 +241,70 @@ describe('doRunHeal — per-pass call bounding (#67)', () => {
     expect(result.skipped).toBe(2);
     expect(result.scanned).toBe(2);
   });
+
+  it('does not insert a duplicate when a librarian pass commits right before heal opens its transaction', async () => {
+    // Heal reads the dedupe corpus at line 630 (outside tx), then opens its
+    // transaction at line 634. A librarian insert landing in that gap is
+    // invisible to heal's dedupe check. We inject the librarian by spying on
+    // findInferredTitlesByEntityId: when called without a tx (the pre-tx read),
+    // we insert a matching fact and return a stale snapshot that omits it.
+    //
+    // Before the fix: the pre-tx read returns a stale snapshot → duplicate.
+    // After the fix: the read moves inside the tx callback (called with tx),
+    // so the spy's tx-less branch never fires and the real query sees the
+    // injected fact → deduped.
+    const generateText = vi.fn(async () => JSON.stringify({
+      downgraded: [],
+      deleted: [],
+      newFacts: [{
+        title: 'concurrent race test title',
+        body: 'heal body',
+        tags: [],
+        confidence: 'inferred',
+      }],
+    }));
+
+    const { db, wiki } = await makeHealWiki(generateText);
+    await seedFact(db, { id: 'c0', updatedAt: 1000 });
+
+    const entryRepo = wiki.__testAccess.entryRepo;
+    const originalFind = entryRepo.findInferredTitlesByEntityId.bind(entryRepo);
+
+    vi.spyOn(entryRepo, 'findInferredTitlesByEntityId').mockImplementation(
+      async (entityId: string, tx?: any) => {
+        if (!tx) {
+          // Pre-transaction read (line 630): inject a matching librarian fact
+          // and return a stale snapshot that doesn't include it.
+          await db.withTransactionAsync(async (innerTx: any) => {
+            await entryRepo.upsert({
+              id: 'fact_lib_1',
+              entity_id: 'e1',
+              title: 'concurrent race test title',
+              body: 'librarian body',
+              tags: [],
+              confidence: 'inferred',
+              source_type: 'librarian_inferred',
+              source_hash: null,
+              source_ref: null,
+              created_at: 2000,
+              updated_at: 2000,
+              last_accessed_at: null,
+              access_count: 0,
+              deleted_at: null,
+            }, innerTx);
+          });
+          return [];
+        }
+        // Inside-transaction read (after fix): do the real query.
+        return originalFind(entityId, tx);
+      },
+    );
+
+    await wiki.runHeal('e1', { batchSize: 1 });
+
+    const rows = await db.getAllAsync<{ c: number }>(
+      `SELECT COUNT(*) AS c FROM ${PREFIX}entries
+       WHERE title = 'concurrent race test title' AND deleted_at IS NULL`);
+    expect(rows[0].c).toBe(1);
+  });
 });

--- a/packages/core/__tests__/healBounding.test.ts
+++ b/packages/core/__tests__/healBounding.test.ts
@@ -243,16 +243,19 @@ describe('doRunHeal — per-pass call bounding (#67)', () => {
   });
 
   it('does not insert a duplicate when a librarian pass commits right before heal opens its transaction', async () => {
-    // Heal reads the dedupe corpus at line 630 (outside tx), then opens its
-    // transaction at line 634. A librarian insert landing in that gap is
-    // invisible to heal's dedupe check. We inject the librarian by spying on
-    // findInferredTitlesByEntityId: when called without a tx (the pre-tx read),
-    // we insert a matching fact and return a stale snapshot that omits it.
+    // Heal reads its dedupe corpus inside its serialized write transaction
+    // (after same-pass soft-deletes). Because transactions are globally
+    // serialized, a librarian insert that commits before heal's transaction
+    // begins is guaranteed to be visible to heal's dedupe check — there is no
+    // interleaving point at which a librarian insert could land unseen.
     //
-    // Before the fix: the pre-tx read returns a stale snapshot → duplicate.
-    // After the fix: the read moves inside the tx callback (called with tx),
-    // so the spy's tx-less branch never fires and the real query sees the
-    // injected fact → deduped.
+    // We simulate that librarian pass by inserting a matching fact directly
+    // before heal runs. To reproduce the pre-fix race, we spy on
+    // findInferredTitlesByEntityId so the pre-transaction read (the unfixed
+    // path, called without a tx) returns a stale snapshot that omits the
+    // librarian fact — as if the librarian committed after that read. The
+    // fixed path reads inside the transaction (called with tx), so the real
+    // query sees the librarian fact and heal must skip creating its own.
     const generateText = vi.fn(async () => JSON.stringify({
       downgraded: [],
       deleted: [],
@@ -266,6 +269,13 @@ describe('doRunHeal — per-pass call bounding (#67)', () => {
 
     const { db, wiki } = await makeHealWiki(generateText);
     await seedFact(db, { id: 'c0', updatedAt: 1000 });
+    // Independent librarian insert that commits before heal's transaction.
+    await seedFact(db, {
+      id: 'fact_lib_1',
+      title: 'concurrent race test title',
+      body: 'librarian body',
+      updatedAt: 2000,
+    });
 
     const entryRepo = wiki.__testAccess.entryRepo;
     const originalFind = entryRepo.findInferredTitlesByEntityId.bind(entryRepo);
@@ -273,35 +283,25 @@ describe('doRunHeal — per-pass call bounding (#67)', () => {
     vi.spyOn(entryRepo, 'findInferredTitlesByEntityId').mockImplementation(
       async (entityId: string, tx?: any) => {
         if (!tx) {
-          // Pre-transaction read (line 630): inject a matching librarian fact
-          // and return a stale snapshot that doesn't include it.
-          await db.withTransactionAsync(async (innerTx: any) => {
-            await entryRepo.upsert({
-              id: 'fact_lib_1',
-              entity_id: 'e1',
-              title: 'concurrent race test title',
-              body: 'librarian body',
-              tags: [],
-              confidence: 'inferred',
-              source_type: 'librarian_inferred',
-              source_hash: null,
-              source_ref: null,
-              created_at: 2000,
-              updated_at: 2000,
-              last_accessed_at: null,
-              access_count: 0,
-              deleted_at: null,
-            }, innerTx);
-          });
+          // Pre-transaction read (unfixed path): return a stale snapshot that
+          // omits the already-committed librarian fact.
           return [];
         }
-        // Inside-transaction read (after fix): do the real query.
+        // Inside-transaction read (fixed path): do the real query, which sees
+        // fact_lib_1 because it committed before this transaction began.
         return originalFind(entityId, tx);
       },
     );
 
     await wiki.runHeal('e1', { batchSize: 1 });
 
+    // fact_lib_1 remains live (heal did not delete it)...
+    const libRows = await db.getAllAsync<{ c: number }>(
+      `SELECT COUNT(*) AS c FROM ${PREFIX}entries
+       WHERE id = 'fact_lib_1' AND deleted_at IS NULL`);
+    expect(libRows[0].c).toBe(1);
+
+    // ...and heal created zero matching facts of its own.
     const rows = await db.getAllAsync<{ c: number }>(
       `SELECT COUNT(*) AS c FROM ${PREFIX}entries
        WHERE title = 'concurrent race test title' AND deleted_at IS NULL`);

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -623,17 +623,23 @@ export class MaintenanceService {
     // duplicates a librarian_inferred fact outside the window pass the Jaccard
     // check — and a convergence loop would then multiply those duplicates.
     //
-    // Read before the transaction soft-deletes safeDeleted, so rows this pass
-    // retires are still in it. Filtered out here: delete-plus-restate is heal's
-    // normal output shape, and matching a replacement against the row it
-    // replaces would drop the replacement and leave the fact gone entirely.
-    const healFactsForDedupe: Array<{ id: string; title: string }> =
-      (await this.entryRepo.findInferredTitlesByEntityId(entityId))
-        .filter(f => !safeDeletedSet.has(f.id));
-
+    // Read inside the transaction, after softDeleteByIds. The query filters
+    // deleted_at IS NULL, so rows this pass retires leave the corpus naturally
+    // — no explicit safeDeletedSet filter needed. Ordering is load-bearing:
+    // the read must follow softDeleteByIds, or a delete-plus-restate (heal's
+    // normal output shape) would match the replacement against the row it
+    // replaces, drop the replacement, and leave the fact gone entirely (#68).
+    // Reading inside the transaction also closes the race with concurrent
+    // librarian passes (#69): withSerializedTransactions ensures a librarian
+    // transaction either commits entirely before this transaction begins or
+    // entirely after it ends, so there is no interleaving point at which a
+    // librarian insert could land unseen.
     await this.db.withTransactionAsync(async (tx) => {
       await this.entryRepo.downgradeByIds(safeDowngraded, entityId, tx);
       await this.entryRepo.softDeleteByIds(safeDeleted, entityId, tx);
+
+      const healFactsForDedupe: Array<{ id: string; title: string }> =
+        await this.entryRepo.findInferredTitlesByEntityId(entityId, tx);
 
       for (const fact of validNewFacts) {
         const newTokens = titleTokens(fact.title);

--- a/packages/core/src/services/WriteService.ts
+++ b/packages/core/src/services/WriteService.ts
@@ -116,9 +116,13 @@ export class WriteService {
       // librarian threshold crossing (another autoLibrarianThreshold events),
       // or forever if no further librarian pass runs.
       //
-      // Guarded by isBlocked('librarian') so heal still never overlaps a
-      // librarian pass, and by tryAcquireAutoHealLock inside maybeRunHeal so a
-      // burst of writes cannot stack passes.
+      // heal and librarian can overlap (deliberate mutex split in
+      // JobManager.acquireLock). This check only reduces redundant passes — a
+      // librarian pass already calls maybeRunHeal when it finishes, so losing
+      // the race costs a duplicate pass, not correctness. Correctness rests on
+      // heal's dedupe read being inside its transaction (#69).
+      // tryAcquireAutoHealLock inside maybeRunHeal prevents a burst of writes
+      // from stacking passes.
       this.maybeRunHeal(entityId, eventCount).catch(console.error);
     }
   }


### PR DESCRIPTION
## Summary

Spec: docs/superpowers/specs/2026-08-06-heal-librarian-dedupe-race-design.md

Closes the race where concurrent heal and librarian passes could produce near-duplicate facts. Heal read its dedupe corpus **outside** its write transaction, so a librarian insert landing during heal's LLM round-trip was invisible to heal's Jaccard check.

The fix moves heal's `findInferredTitlesByEntityId` call **inside** the transaction, after `softDeleteByIds`. With `withSerializedTransactions` serializing all transactions end-to-end, a librarian transaction either commits entirely before heal's transaction begins or entirely after it ends — there is no interleaving point for a duplicate insert.

## Changes

1. **`MaintenanceService.ts`** — Move `healFactsForDedupe` read inside the transaction after `softDeleteByIds`; drop the now-redundant `safeDeletedSet` filter (the query's `WHERE deleted_at IS NULL` handles it); pass `tx` to `findInferredTitlesByEntityId`; rewrite rationale comments.
2. **`healBounding.test.ts`** — Add a regression test that injects a librarian fact in the gap between heal's corpus read and its transaction open (red → green); update the stale comment on the delete-plus-restate test.
3. **`WriteService.ts`** — Correct the false guarantee comment: heal and librarian *can* overlap (deliberate mutex split); the check only reduces redundant passes, and correctness rests on heal's in-transaction dedupe read.

## Verification

- Regression test fails on `main` (count = 2), passes after fix (count = 1)
- All 11 heal bounding tests pass
- Full `packages/core` suite: **817 tests pass**
- `tsc --noEmit`: no errors

Closes #69