### PR TITLE
chore(release): 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [5.2.1](https://github.com/equationalapplications/expo-llm-wiki/compare/v5.2.0...v5.2.1) (2026-08-08)
+
+
+### Bug Fixes
+
+* **ci:** address CodeRabbit review feedback on PR [#80](https://github.com/equationalapplications/expo-llm-wiki/issues/80) ([587e58b](https://github.com/equationalapplications/expo-llm-wiki/commit/587e58b89f72629e4ec7a25a5e69aef95919df1e))
+* **ci:** escape awk regex and rewrite audit step to avoid command substitution ([e55be5a](https://github.com/equationalapplications/expo-llm-wiki/commit/e55be5a521e014fb4b6ed348a5e983277978e959))
+* **ci:** pin js-yaml 3.x to 3.15.1 and gate audit on fixable advisories only ([57846f4](https://github.com/equationalapplications/expo-llm-wiki/commit/57846f47bbe4fe819bc7cd97233bcad5fc5bebf0))
+* **ci:** pipe gh pr list output to jq instead of gh --jq --arg ([37b29d1](https://github.com/equationalapplications/expo-llm-wiki/commit/37b29d118801b2d88a74504b3607fb055e84702a))
+* **core:** disambiguate hash-lock key with NUL separator ([#80](https://github.com/equationalapplications/expo-llm-wiki/issues/80) review) ([f8dc235](https://github.com/equationalapplications/expo-llm-wiki/commit/f8dc235ce47e8c6b4ffd0938c6191adc8ac7d8c0))
+* **core:** enforce unique live source hashes ([e303bdd](https://github.com/equationalapplications/expo-llm-wiki/commit/e303bdd223c0dba8050c4c6f54e693fe3b19e511)), closes [#79](https://github.com/equationalapplications/expo-llm-wiki/issues/79)
+* **core:** move TOCTOU safety net to source_ref_index table ([4e9aa8d](https://github.com/equationalapplications/expo-llm-wiki/commit/4e9aa8d1c9c51136ec94771d9e8e4c08e8c0760b)), closes [#1](https://github.com/equationalapplications/expo-llm-wiki/issues/1)
+* **core:** preserve sqlite unique constraint codes ([d30ac0c](https://github.com/equationalapplications/expo-llm-wiki/commit/d30ac0c77a5271f1199c47ec921077304f835fbe))
+* **core:** serialize ingest locks by source hash ([b585328](https://github.com/equationalapplications/expo-llm-wiki/commit/b585328caca079ecf3898260b09e1d2324ea8c5f))
+* **core:** translate racing duplicate hash writes ([3df4824](https://github.com/equationalapplications/expo-llm-wiki/commit/3df482433601c2a40811021db4f8fc0aaf2f372d))
+
 # [5.2.0](https://github.com/equationalapplications/expo-llm-wiki/compare/v5.1.1...v5.2.0) (2026-08-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-llm-wiki",
   "private": true,
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Private workspace root. Published packages are under packages/. src/ contains backward-compat build aliases only.",
   "license": "MIT",
   "packageManager": "pnpm@10.33.2",

--- a/packages/core-llm-tools/package.json
+++ b/packages/core-llm-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/core-llm-tools",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Zero-dependency Gemini function-calling schemas and capability-scoped tool injection for edge AI agents. Works in Node.js, browser, and React Native (Hermes).",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/core-llm-wiki",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fact extraction, semantic vector search, and multi-agent architectures over SQLite. Bring your own adapter.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/expo-llm-wiki",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Local-first LLM memory for Expo and React Native. Combines the core semantic search and extraction engine with expo-sqlite and ready-to-use React hooks.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/core-okf",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Zero-dependency Open Knowledge Format (OKF) v0.1 primitives: frontmatter serialization, concept documents, index.md and log.md builders.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/prisma-outbox/package.json
+++ b/packages/prisma-outbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/prisma-outbox",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Sync core-llm-wiki SQLite outbox events to your Prisma-backed database using the transactional outbox pattern — at-least-once delivery with ordering guarantees.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/react-llm-wiki",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., sql.js WebAssembly) for a complete, zero-server RAG experience.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/schema-org/package.json
+++ b/packages/schema-org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equationalapplications/schema-org-llm-wiki",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Curated schema.org warm-agent ontology manifest for LLM Wiki Memory: 9 node types, 28 edges, fully schema.org-standard. Data-only.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Automated release PR. Merging this via squash will trigger Phase 2 (publish + GitHub Release).

This PR was prepared manually after the automated Phase 1 run failed with `fatal: tag 'v5.2.1' already exists` — an orphan tag from a prior partial run was blocking the workflow. The orphan tag and notes ref have been deleted, and the release branch was rebuilt from `main` via the same semantic-release → chore-commit → tag → push pipeline that Phase 1 uses.