### PR TITLE
fix(ci): make release.yml Phase 1 tag push idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,9 @@ jobs:
           # (branch up, tag rejected) would silently leave Phase 1 looking green
           # while Phase 2 has nothing to relocate.
           # --force: the orphan-tag scenario we hit on 2026-08-08 (a prior
-          # verifyRelease created a remote tag at a different commit) means the
-          # push can otherwise reject. The release branch is ephemeral, so
+          # failed Phase 1 push left a remote tag at a different commit —
+          # verifyRelease's own tag is local only, per the comment above) means
+          # the push can otherwise reject. The release branch is ephemeral, so
           # force-pushing it is safe. See PR #80 spec §C1 step 6 for context.
           git push --atomic origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}" --force
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,15 @@ jobs:
           # force-push is safe — no review history lives on it.
           git tag -d "v${RELEASE_VERSION}" 2>/dev/null || true
           git tag -a "v${RELEASE_VERSION}" -m "v${RELEASE_VERSION}"
-          git push origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}" --force
+          # --atomic: branch and tag succeed or fail together. Phase 2 depends on
+          # the tag being present after Phase 1; without atomicity a partial push
+          # (branch up, tag rejected) would silently leave Phase 1 looking green
+          # while Phase 2 has nothing to relocate.
+          # --force: the orphan-tag scenario we hit on 2026-08-08 (a prior
+          # verifyRelease created a remote tag at a different commit) means the
+          # push can otherwise reject. The release branch is ephemeral, so
+          # force-pushing it is safe. See PR #80 spec §C1 step 6 for context.
+          git push --atomic origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}" --force
 
           PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "chore(release): ${RELEASE_VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,23 @@ jobs:
           # lightweight tag is a ref without an object, and `git push --follow-tags`
           # only follows annotated tags — pushing it would silently leave the
           # tag local and Phase 2's `git fetch --tags` would not find it.
+          #
+          # semantic-release's verifyRelease step creates a local lightweight tag
+          # at HEAD before its plugins run; @semantic-release/git is removed from
+          # .releaserc.json so the tag stays local. Without the `tag -d` below,
+          # `git tag -a` fails with `fatal: tag 'vX.Y.Z' already exists` because
+          # the lightweight tag exists at HEAD (which is the chore commit after
+          # `git commit` above, but on a re-run of a stuck workflow HEAD was on
+          # main and the tag pointed at the spec merge — that's what broke the
+          # 2026-08-08 Phase 1 run for v5.2.1, see PR #80 spec §C1 step 6).
+          #
+          # --force on the push so an orphan tag (or a stale release branch) from
+          # a prior failed run cannot block this push either. The release branch
+          # is ephemeral and only ever carries one chore commit at a time, so a
+          # force-push is safe — no review history lives on it.
+          git tag -d "v${RELEASE_VERSION}" 2>/dev/null || true
           git tag -a "v${RELEASE_VERSION}" -m "v${RELEASE_VERSION}"
-          git push origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}"
+          git push origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}" --force
 
           PR_URL=$(gh pr create --base main --head "$BRANCH" \
             --title "chore(release): ${RELEASE_VERSION}" \


### PR DESCRIPTION
## What

Makes `release.yml` Phase 1 robust against the failure that broke the
2026-08-08 v5.2.1 release attempt.

## Why

Phase 1's bash script ended with:

```bash
git tag -a "v${RELEASE_VERSION}" -m "v${RELEASE_VERSION}"
git push origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}"
```

This failed with `fatal: tag 'v5.2.1' already exists`. The cause is
that `semantic-release`'s `verifyRelease` step creates a local
lightweight tag at HEAD as part of its core flow. `@semantic-release/git`
was removed from `.releaserc.json` (per the spec in PR #80, §C2), so the
tag stays local instead of being pushed. The next `git tag -a` then
trips on the existing local tag.

Two other failure modes that `--force` also closes:
- A stale local tag from a prior workflow run that left the runner in
  inconsistent state.
- An orphan remote tag from a prior failed run (the very state the
  v5.2.1 release is in right now — a tag at `9a5dcd2` pointing at the
  spec merge, with no associated release branch).

## Fix

```bash
git tag -d "v${RELEASE_VERSION}" 2>/dev/null || true
git tag -a "v${RELEASE_VERSION}" -m "v${RELEASE_VERSION}"
git push origin "$BRANCH" "refs/tags/v${RELEASE_VERSION}" --force
```

- `git tag -d` clears any pre-existing local tag so `git tag -a` can
  replace it.
- `--force` lets the push overwrite a stale release branch or orphan
  remote tag. The release branch is ephemeral — it only ever carries
  one chore commit, so force-pushing it destroys no review history.

The detailed comment block above the change in `release.yml` records
*why* so a future reader doesn't simplify the script back into the
buggy form.

## Verification

YAML loads cleanly (`js-yaml.load`). Behavior change is bounded to
the Phase 1 tag-and-push step; nothing else in the workflow is
touched.

## Related

- v5.2.1 release PR: #81
- Spec: `docs/superpowers/specs/2026-08-07-dependabot-concurrency-release-hygiene-design.md` §C1 step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>