### PR TITLE
fix(ci): prune orphaned local tags before semantic-release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,26 @@ jobs:
 
       - run: pnpm run build
 
+      - name: Prune orphaned local tags
+        run: |
+          # actions/checkout fetches tags by default. A tag left over from a
+          # prior failed Phase 1 run (tagged before the branch+tag push, then
+          # never reached because the run died) points at a "chore(release)"
+          # commit that was never merged into main - it is not an ancestor of
+          # HEAD. semantic-release's verifyRelease step creates a local tag
+          # named after the computed version and fails with `fatal: tag
+          # 'vX.Y.Z' already exists` if a same-named tag is already present,
+          # so any such orphan must be deleted before semantic-release runs
+          # (this bit us with v5.2.1 on 2026-08-08, see PR #82 / #84).
+          # Real historical release tags remain untouched: they were reached
+          # via a squash-merge onto main, so they ARE ancestors of HEAD.
+          for tag in $(git tag); do
+            if ! git merge-base --is-ancestor "$tag" HEAD 2>/dev/null; then
+              echo "Deleting orphaned local tag: $tag"
+              git tag -d "$tag"
+            fi
+          done
+
       - name: Run semantic-release (--no-ci, dry local mutation only)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a step to `release.yml` Phase 1 that deletes any local tag not
reachable from HEAD before `semantic-release` runs.

## Why

Release run #84 (triggered by merging #82) still failed:

```
fatal: tag 'v5.2.1' already exists
```

This happened *inside semantic-release's own verifyRelease step* —
before Phase 1's idempotency fix from #82 ever got a chance to run.
`actions/checkout` fetches tags by default, and an orphan `v5.2.1` tag
from an earlier failed run (pointing at a `chore(release)` commit that
was never merged to main, i.e. not an ancestor of HEAD) was already
present locally when semantic-release tried to create its own
same-named tag.

## Fix

Before the `Run semantic-release` step, walk local tags and delete any
that are not an ancestor of `HEAD`. Real historical release tags are
always ancestors (they land via squash-merge onto main), so this only
ever removes leftover cruft from interrupted runs.

Also manually deleted the existing orphan `v5.2.1` tag from origin to
unblock the next run.

## Verification

YAML loads cleanly. Scope is limited to a new step in Phase 1 of
`release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>