### PR TITLE
fix(ci): detect and recover from orphan tag pointing at HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          RELEASE_BOT_PAT: ${{ secrets.RELEASE_BOT_PAT }}
         run: |
           # A second orphan-tag class is not reachable by the local prune
           # above: a tag that points AT HEAD (or at a commit reachable from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,41 @@ jobs:
             fi
           done
 
+      - name: Detect and recover from orphan tag at HEAD
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # A second orphan-tag class is not reachable by the local prune
+          # above: a tag that points AT HEAD (or at a commit reachable from
+          # HEAD) but at a non-chore(release) commit. semantic-release's
+          # findLastRelease sees the tag, computes "0 commits since last
+          # release", and Phase 1 silently exits with has_changes=false —
+          # the exact failure mode that produced the v5.3.0 ghost tag at
+          # the PR #84 merge commit (fa9e9bb) on 2026-08-14. The tag was
+          # reachable from HEAD so the local prune above did nothing.
+          #
+          # Detection: the latest tag must agree with main's package.json
+          # version. If they disagree, the tag is from a feature merge (or
+          # any non-chore commit) and must be removed so semantic-release
+          # can compute the next release cleanly.
+          #
+          # Use RELEASE_BOT_PAT to delete the remote tag — pushing via
+          # GITHUB_TOKEN is suppressed by GitHub's anti-recursion guard
+          # for GITHUB_TOKEN-triggered synchronize events, and a ref delete
+          # still counts as a synchronize event for that guard.
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$LATEST_TAG" ] && git merge-base --is-ancestor "$LATEST_TAG" HEAD 2>/dev/null; then
+            TAG_VERSION=${LATEST_TAG#v}
+            HEAD_VERSION=$(node -p "require('./package.json').version")
+            if [ "$TAG_VERSION" != "$HEAD_VERSION" ]; then
+              echo "::warning::Latest tag $LATEST_TAG points at a commit whose package.json does not match main ($HEAD_VERSION). Treating as orphan and deleting (local + remote) so semantic-release can recompute."
+              git tag -d "$LATEST_TAG" || true
+              git push "https://x-access-token:${RELEASE_BOT_PAT}@github.com/${REPO}.git" ":refs/tags/${LATEST_TAG}" 2>&1 \
+                || echo "::warning::Could not delete remote tag $LATEST_TAG — clean it up manually before re-running."
+            fi
+          fi
+
       - name: Run semantic-release (--no-ci, dry local mutation only)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Root cause this fixes

On 2026-08-14, after merging the WikiMemory PR (#84), the Release workflow's Phase 1 ran and "succeeded" while doing nothing. semantic-release saw a tag at HEAD and computed "0 commits since last release", so Phase 1 exited with `has_changes=false` and never bumped any version or opened a release PR.

The tag was the v5.3.0 ghost tag at the PR #84 merge commit (`fa9e9bb`) — **reachable** from HEAD, so the existing "Prune orphaned local tags" step (`git merge-base --is-ancestor`) left it alone. Yet it was still semantically orphan: it pointed at a feature-merge commit, not at a `chore(release)` commit, so semantic-release's `findLastRelease` was tricked into thinking HEAD was already a release.

## What this PR adds

A new Phase 1 step, **after** the existing local-tag prune and **before** semantic-release runs:

1. Reads the latest tag (`git describe --tags --abbrev=0`)
2. Confirms it's reachable from HEAD (cheap, almost always true)
3. Compares the tag's version to main's `package.json` version
4. On disagreement (the orphan case), deletes the tag locally and remote (via `RELEASE_BOT_PAT` to bypass GitHub's anti-recursion guard on `GITHUB_TOKEN` ref-deletes) and emits a `::warning::` so the run log explains the recovery

This complements, doesn't replace, the existing local prune: the local prune still catches the more common case of a tag at an unreleased chore commit on a release branch that never got merged. This new step catches the rarer but more insidious case where the tag IS at a commit reachable from main.

## Why the remote delete needs `RELEASE_BOT_PAT`

A ref delete still counts as a synchronize event for GitHub's anti-recursion guard. Pushing via `GITHUB_TOKEN` would be silently dropped (or, in some configs, fail outright). The existing recovery push in Phase 1 already authenticates with `RELEASE_BOT_PAT` for the same reason — we reuse that pattern.

## Verification

Recreates the 2026-08-14 scenario: with a tag like `v9.9.9` placed at HEAD while main's `package.json` says something else, Phase 1 would now:
- Detect the version mismatch
- Delete the orphan tag (local + remote)
- Let semantic-release recompute the correct next version

Backward-compatible: when the latest tag is consistent with `package.json` (the normal case), the step is a no-op.

## Related

- v5.3.0 recovery (this branch's parent event): see memory entry `project_release-pipeline-traps.md` for the full failure timeline.
- Existing local prune: same file, ~25 lines above this new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)