### PR TITLE
docs(readmes): document new public APIs from implemented specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,8 @@ const result = await wiki.ingestDocument('entity-123', {
   promptOverride: `Extract strict technical requirements: {{documentChunk}}
 
 Return JSON: {"facts": [{"title": "...", "body": "...", "tags": ["..."], "confidence": "certain|tentative|inferred"}]}`,
+  // Optional: control behavior when a different live sourceRef already holds this hash
+  onDuplicateHash: 'ingest',          // 'ingest' (default) | 'skip' | 'throw'
 });
 // result: {
 //   truncated: boolean;          // true if at least one hard-split was required (no sentence boundary)
@@ -490,6 +492,33 @@ Return JSON: {"facts": [{"title": "...", "body": "...", "tags": ["..."], "confid
 ```
 
 **Hosts must update**: a host that today treats `ingestDocument` throwing as the only failure signal will, after release 5.4.1, see a successful return with `parseFailures[]` set when a subset of chunks failed. Inspect `result.failedChunks` and surface `result.parseFailures[]` for observability — do not rely on the throw for partial failures. Only `WikiIngestEmptyError` (every chunk failed) still throws.
+
+**Duplicate hash handling:** When the same `sourceHash` is already held live under a *different* `sourceRef` (e.g., the same document ingested at another path), `onDuplicateHash` controls behavior:
+- `'ingest'` (default): Proceed with extraction as normal — the pre-guard behavior. Use when duplicate content under different refs is acceptable.
+- `'skip'`: Return early without writing and without an LLM call (zero-chunk result). Use when the stored document holding this hash is authoritative.
+- `'throw'`: Throw `WikiDuplicateHashError` (carries the canonical `sourceRef`). Use for strict auditing.
+
+### Direct Graph Write
+
+Write structured graph data directly without LLM extraction — useful for programmatic fact ingestion, parsers, and deterministic pipelines:
+
+```typescript
+import { WikiMemory } from '@equationalapplications/core-llm-wiki';
+
+const { nodesWritten, edgesWritten, superseded } = await wiki.upsertGraph('entity-123', {
+  sourceRef: 'codebase_main.ts',
+  sourceHash: sha256(sourceCode),
+  nodes: [
+    { id: 'fn_processData', type: 'function', title: 'processData', body: 'Processes user data' },
+    { id: 'class_UserService', type: 'class', title: 'UserService', body: 'User management service' },
+  ],
+  edges: [
+    { type: 'calls', sourceId: 'fn_processData', targetId: 'class_UserService' },
+  ],
+}, adapter); // SQLiteAdapter from your platform driver — writes join the caller's transaction
+```
+
+`upsertGraph` is "the tail of `ingestDocument` with the middle (LLM extraction) step removed" — it accepts caller-supplied nodes (`{ id, type, title, body? }`) and edges (`{ type, sourceId, targetId, id? }`) and writes them under the same `(sourceRef, sourceHash)` semantics. If a *different* live `sourceRef` already holds the same `sourceHash`, it throws `WikiSourceRefHashCollision`; re-writing the identical `(sourceRef, sourceHash)` is a no-op returning zero counts. The adapter parameter is required so writes participate in the caller's transaction.
 
 ### Background Maintenance
 
@@ -574,6 +603,29 @@ Advanced Prompting: For full details on `{{mustache}}` prompt templating, hydrat
 
 Facts are ranked by a weighted score combining confidence tier, access frequency, and recency. Returns an empty string for an empty bundle.
 
+### Entity Enumeration
+
+List all entities that have stored data in the wiki:
+
+```typescript
+const entityIds = await wiki.listEntityIds();
+// Returns all entity_ids with at least one row (including soft-deleted-only entities)
+// Optional prefix filter: await wiki.listEntityIds({ prefix: 'tier_' });
+```
+
+Use this for maintenance scheduling, multi-entity operations, or discovering which namespaces exist. Includes entities with only soft-deleted rows so prune operations can reclaim orphaned storage.
+
+### Source Reference Enumeration
+
+List all documents currently stored for an entity:
+
+```typescript
+const sourceRefs = await wiki.listSourceRefs('entity-123');
+// Returns: Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+```
+
+Use this to audit stored documents, validate external sync state, or preview the blast radius before `forget()` operations.
+
 ### Forget
 
 ```typescript
@@ -584,6 +636,14 @@ await wiki.forget('entity-123', { taskId: 'task_xyz' });     // single task
 // sourceRef is normalized the same way as in ingestDocument (slashes stripped)
 await wiki.forget('entity-123', { sourceRef: 'x.md' }); // all facts from a document
 await wiki.forget('entity-123', { clearAll: true });          // wipe entity
+```
+
+**Dry-run mode** — preview deletion impact without writing:
+
+```typescript
+const preview = await wiki.forget('entity-123', { sourceRef: 'doc.md' }, { dryRun: true });
+// preview: { deleted: { entries: number; tasks: number } }
+// No database writes performed; safe for blast-radius validation
 ```
 
 Throws `Error` if `sourceRef` or `sourceHash` is provided but invalid. Soft-deletes are idempotent — calling again with the same parameters returns `{ deleted: { entries: 0; tasks: 0 } }`.
@@ -600,6 +660,21 @@ if (changed) {
 ```
 
 Returns `true` if the document has never been ingested, all prior ingest results were forgotten, or the stored hash differs from the supplied one. Returns `false` if the stored hash matches exactly.
+
+**Batch overload** — check multiple documents in one query:
+
+```typescript
+const batch = [
+  { sourceRef: 'doc1.md', sourceHash: sha256(content1) },
+  { sourceRef: 'doc2.md', sourceHash: sha256(content2) },
+  { sourceRef: 'doc3.md', sourceHash: sha256(content3) },
+];
+const changes = await wiki.hasChanged('entity-123', batch);
+// changes: Array<{ sourceRef: string; changed: boolean; duplicateOf?: string }>
+// duplicateOf — when present, the canonical stored different sourceRef holding
+// the same hash (DB-normalized spelling; sourceRef echoes the raw caller value).
+// Efficient single query with per-document change detection
+```
 
 Throws `Error` if `sourceRef` or `sourceHash` is invalid (same rules as `ingestDocument`).
 

--- a/README.md
+++ b/README.md
@@ -473,7 +473,9 @@ const result = await wiki.ingestDocument('entity-123', {
   promptOverride: `Extract strict technical requirements: {{documentChunk}}
 
 Return JSON: {"facts": [{"title": "...", "body": "...", "tags": ["..."], "confidence": "certain|tentative|inferred"}]}`,
-  // Optional: control behavior when a different live sourceRef already holds this hash
+}, {
+  // Optional third-argument opts — control behavior when a different live
+  // sourceRef already holds this hash.
   onDuplicateHash: 'ingest',          // 'ingest' (default) | 'skip' | 'throw'
 });
 // result: {
@@ -493,10 +495,11 @@ Return JSON: {"facts": [{"title": "...", "body": "...", "tags": ["..."], "confid
 
 **Hosts must update**: a host that today treats `ingestDocument` throwing as the only failure signal will, after release 5.4.1, see a successful return with `parseFailures[]` set when a subset of chunks failed. Inspect `result.failedChunks` and surface `result.parseFailures[]` for observability — do not rely on the throw for partial failures. Only `WikiIngestEmptyError` (every chunk failed) still throws.
 
-**Duplicate hash handling:** When the same `sourceHash` is already held live under a *different* `sourceRef` (e.g., the same document ingested at another path), `onDuplicateHash` controls behavior:
-- `'ingest'` (default): Proceed with extraction as normal — the pre-guard behavior. Use when duplicate content under different refs is acceptable.
-- `'skip'`: Return early without writing and without an LLM call (zero-chunk result). Use when the stored document holding this hash is authoritative.
-- `'throw'`: Throw `WikiDuplicateHashError` (carries the canonical `sourceRef`). Use for strict auditing.
+**Duplicate hash handling:** When the same `sourceHash` is already held live under a *different* `sourceRef` (e.g., the same document ingested at another path), `onDuplicateHash` (a third-argument option, not a params field) controls behavior:
+- `'ingest'` (default): No duplicate pre-check; extraction proceeds as before this option existed. A collision detected at commit time (concurrent-writer race caught by the source-ref unique index) still throws `WikiDuplicateHashError`.
+- `'skip'`: Pre-check before any LLM call; if a different live `sourceRef` already holds the hash, return a zero-chunk result without writing.
+- `'throw'`: Pre-check before any LLM call; throw `WikiDuplicateHashError` (carries the canonical `sourceRef`).
+- The guard only considers **live** references — soft-deleted refs do not trigger it in any mode.
 
 ### Direct Graph Write
 
@@ -621,7 +624,10 @@ List all documents currently stored for an entity:
 
 ```typescript
 const sourceRefs = await wiki.listSourceRefs('entity-123');
-// Returns: Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+// One row per live sourceRef (soft-deleted rows are excluded):
+// Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+// factCount — number of live facts under that sourceRef
+// lastIngestedAt — Unix timestamp in ms from the most recently updated live entry
 ```
 
 Use this to audit stored documents, validate external sync state, or preview the blast radius before `forget()` operations.
@@ -673,7 +679,7 @@ const changes = await wiki.hasChanged('entity-123', batch);
 // changes: Array<{ sourceRef: string; changed: boolean; duplicateOf?: string }>
 // duplicateOf — when present, the canonical stored different sourceRef holding
 // the same hash (DB-normalized spelling; sourceRef echoes the raw caller value).
-// Efficient single query with per-document change detection
+// Per-document change detection; internally batched across queries
 ```
 
 Throws `Error` if `sourceRef` or `sourceHash` is invalid (same rules as `ingestDocument`).

--- a/docs/superpowers/specs/2026-08-16-documentation-update-summary.md
+++ b/docs/superpowers/specs/2026-08-16-documentation-update-summary.md
@@ -1,0 +1,124 @@
+# Documentation Update Summary
+
+**Date:** 2026-08-16
+**Status:** Completed
+**Branch:** docs/spec-revise-ingest-parse-resilience
+
+## Overview
+
+Updated README files across the mono repo to document features implemented in the following specs:
+- export-chunk-text-public-api (2026-08-06)
+- heal-librarian-dedupe-race-design (2026-08-06)
+- dependabot-concurrency-release-hygiene-design (2026-08-07)
+- source-ref-lifecycle-design (2026-08-07)
+- okf-v02-upgrade-design (2026-08-14)
+- wikimemory-public-api-extensions-design (2026-08-14)
+- ingest-parse-resilience-design (2026-08-15)
+
+## Files Updated
+
+### Main Repository README
+**File:** `/README.md`
+
+**New Sections Added:**
+1. **Entity Enumeration** - `listEntityIds()` API
+2. **Source Reference Enumeration** - `listSourceRefs()` API
+3. **Direct Graph Write** - `upsertGraph()` API
+4. **Batch Change Detection** - `hasChanged()` batch overload
+
+**Existing Sections Enhanced:**
+1. **Ingest Document** - Added `onDuplicateHash` option
+2. **Forget** - Added dry-run mode capability
+3. **Check for Changes** - Added batch overload documentation
+
+### Core Package README
+**File:** `/packages/core/README.md`
+
+**New Sections Added:**
+1. **Entity Enumeration** - `listEntityIds()` API with prefix filtering
+2. **Source Reference Enumeration** - `listSourceRefs()` API for document auditing
+3. **Direct Graph Write** - `upsertGraph()` API for deterministic graph ingestion
+4. **Duplicate Hash Detection** - `onDuplicateHash` option documentation
+5. **Batch Change Detection** - `hasChanged()` batch overload
+6. **Dry-Run Deletion** - `forget()` dry-run mode
+
+## New Public APIs Documented
+
+### `listEntityIds(options?: { prefix?: string }): Promise<string[]>`
+Returns all entity IDs with stored data. Includes entities with only soft-deleted rows so prune operations can reclaim storage. Supports optional prefix filtering for namespace filtering.
+
+### `listSourceRefs(entityId): Promise<StoredSourceRef[]>`
+Lists all documents stored for an entity with metadata (sourceRef, sourceHash, factCount, lastIngestedAt). Useful for auditing stored documents and validating sync state.
+
+### `upsertGraph(entityId, params, adapter): Promise<{ nodesWritten, edgesWritten, superseded }>`
+Writes structured graph data directly without LLM extraction. The tail of `ingestDocument` with the middle (LLM extraction) step removed. Accepts caller-supplied nodes (`{ id, type, title, body? }`) and edges (`{ type, sourceId, targetId, id? }`) under same `(sourceRef, sourceHash)` semantics. Throws `WikiSourceRefHashCollision` when a different live `sourceRef` already holds the same hash.
+
+### `ingestDocument(..., { onDuplicateHash: 'ingest' | 'skip' | 'throw' })`
+Controls behavior when a different live `sourceRef` already holds the same `sourceHash`:
+- `'ingest'` (default): Proceed with extraction (pre-guard behavior)
+- `'skip'`: Return early, zero-chunk result, no LLM call
+- `'throw'`: Throw `WikiDuplicateHashError`
+
+### `hasChanged(entityId, batch[]): Promise<Array<{ sourceRef, changed, duplicateOf? }>>`
+Batch overload for checking multiple documents in one efficient query. `duplicateOf`, when present, is the canonical stored different `sourceRef` holding the same hash.
+
+### `forget(entityId, params, { dryRun: true })`
+Preview deletion impact without writing to database. Returns `{ deleted: { entries, tasks } }` for blast-radius validation.
+
+## Packages Requiring No Updates
+
+The following packages were reviewed and require no documentation updates:
+
+### `@equationalapplications/expo-llm-wiki`
+Expo package documentation focuses on React hooks and platform-specific setup. Core WikiMemory methods are documented in the main and core READMEs.
+
+### `@equationalapplications/react-llm-wiki`
+React package documentation focuses on React hooks and component lifecycle. Core WikiMemory methods are documented in the main and core READMEs.
+
+### `@equationalapplications/core-llm-tools`
+Focused on Gemini tool schemas and capability injection. Does not export the new WikiMemory APIs.
+
+### `@equationalapplications/core-okf`
+OKF v0.2 support already documented in core package README under "OKF v0.2 conformance (llm-wiki/2)" section.
+
+### `@equationalapplications/prisma-outbox`
+Focused on transactional outbox pattern. Does not export the new WikiMemory APIs.
+
+## Already Documented Features
+
+The following features were already documented in existing sections:
+
+### Chunking Utilities (export-chunk-text-public-api)
+Already documented in core package README with `chunkText`, `safeSlice`, `DEFAULT_MAX_CHUNK_LENGTH`, and `DEFAULT_CHUNK_OVERLAP` exports.
+
+### Ingest Parse Resilience (ingest-parse-resilience-design)
+Already documented in "Recent changes - 5.4.1" section of main and core READMEs with `WikiParseError`, partial-commit semantics, and retry behavior.
+
+### OKF v0.2 Conformance (okf-v02-upgrade-design)
+Already documented in core package README under "OKF v0.2 conformance (llm-wiki/2)" section with profile auto-detection and new public methods for trust/provenance writes.
+
+### Heal/Librarian Dedupe Race (heal-librarian-dedupe-race-design)
+Internal implementation fix with no user-facing API changes.
+
+### Dependabot Concurrency Release Hygiene (dependabot-concurrency-release-hygiene-design)
+CI/CD infrastructure improvements with no user-facing API changes.
+
+## Documentation Approach
+
+All new APIs were integrated into existing documentation sections rather than creating separate "What's New" sections. This maintains the handbook-style reference approach where developers can find APIs alongside related functionality.
+
+## Testing Recommendations
+
+Documentation should be tested by:
+1. Verifying all code examples compile with TypeScript
+2. Testing each new API in a development environment
+3. Cross-referencing spec documents with README documentation
+4. Ensuring all parameter types and return types are accurately described
+
+## Future Considerations
+
+As additional specs are implemented, documentation updates should:
+1. Follow the same integration approach (add to existing sections)
+2. Update both main README and core package README
+3. Include working code examples with proper TypeScript types
+4. Reference the original spec documents for detailed design rationale

--- a/docs/superpowers/specs/2026-08-16-documentation-update-summary.md
+++ b/docs/superpowers/specs/2026-08-16-documentation-update-summary.md
@@ -53,14 +53,15 @@ Lists all documents stored for an entity with metadata (sourceRef, sourceHash, f
 ### `upsertGraph(entityId, params, adapter): Promise<{ nodesWritten, edgesWritten, superseded }>`
 Writes structured graph data directly without LLM extraction. The tail of `ingestDocument` with the middle (LLM extraction) step removed. Accepts caller-supplied nodes (`{ id, type, title, body? }`) and edges (`{ type, sourceId, targetId, id? }`) under same `(sourceRef, sourceHash)` semantics. Throws `WikiSourceRefHashCollision` when a different live `sourceRef` already holds the same hash.
 
-### `ingestDocument(..., { onDuplicateHash: 'ingest' | 'skip' | 'throw' })`
-Controls behavior when a different live `sourceRef` already holds the same `sourceHash`:
-- `'ingest'` (default): Proceed with extraction (pre-guard behavior)
-- `'skip'`: Return early, zero-chunk result, no LLM call
-- `'throw'`: Throw `WikiDuplicateHashError`
+### `ingestDocument(entityId, params, { onDuplicateHash: 'ingest' | 'skip' | 'throw' })`
+The duplicate-hash option is a third-argument `opts` field, not part of `params`. Controls behavior when a different live `sourceRef` already holds the same `sourceHash`:
+- `'ingest'` (default): No pre-check; proceeds. A live collision detected at commit time (concurrent-writer race) throws `WikiDuplicateHashError`.
+- `'skip'`: Pre-check; return early with a zero-chunk result, no LLM call.
+- `'throw'`: Pre-check; throw `WikiDuplicateHashError`.
+- Soft-deleted refs never trigger the guard (live rows only).
 
 ### `hasChanged(entityId, batch[]): Promise<Array<{ sourceRef, changed, duplicateOf? }>>`
-Batch overload for checking multiple documents in one efficient query. `duplicateOf`, when present, is the canonical stored different `sourceRef` holding the same hash.
+Batch overload for per-document change detection. `duplicateOf`, when present, is the canonical stored different `sourceRef` holding the same hash.
 
 ### `forget(entityId, params, { dryRun: true })`
 Preview deletion impact without writing to database. Returns `{ deleted: { entries, tasks } }` for blast-radius validation.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -845,7 +845,10 @@ List all documents currently stored for an entity:
 
 ```typescript
 const sourceRefs = await wikiMemory.listSourceRefs('user-123');
-// Returns: Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+// One row per live sourceRef (soft-deleted rows are excluded):
+// Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+// factCount — number of live facts under that sourceRef
+// lastIngestedAt — Unix timestamp in ms from the most recently updated live entry
 ```
 
 Use this to audit stored documents, validate external sync state, or preview the blast radius before `forget()` operations.
@@ -872,24 +875,28 @@ const { nodesWritten, edgesWritten, superseded } = await wikiMemory.upsertGraph(
 
 ## Duplicate Hash Detection
 
-Control behavior when multiple `sourceRef` values share the same `sourceHash`:
+Control behavior when a different live `sourceRef` already holds the same `sourceHash`. The option is passed as a third argument to `ingestDocument`, not inside the params object:
 
 ```typescript
-await wikiMemory.ingestDocument('entity-123', {
-  sourceRef: 'doc.md',
-  sourceHash: sha256(content),
-  documentChunk: content,
-  onDuplicateHash: 'ingest',  // 'ingest' (default) | 'skip' | 'throw'
-});
+await wikiMemory.ingestDocument(
+  'entity-123',
+  {
+    sourceRef: 'doc.md',
+    sourceHash: sha256(content),
+    documentChunk: content,
+  },
+  { onDuplicateHash: 'ingest' }  // 'ingest' (default) | 'skip' | 'throw'
+);
 ```
 
-- `'ingest'` (default): Proceed with extraction as normal — the pre-guard behavior. Use when duplicate content under different refs is acceptable.
-- `'skip'`: Return early without writing and without an LLM call (zero-chunk result). Use when the stored document holding this hash is authoritative.
-- `'throw'`: Throw `WikiDuplicateHashError` (carries the canonical `sourceRef`). Use for strict auditing.
+- `'ingest'` (default): No duplicate pre-check; extraction proceeds as before this option existed. If a different live `sourceRef` is found holding the same hash at commit time (a concurrent-writer race caught by the source-ref unique index), the call still throws `WikiDuplicateHashError`.
+- `'skip'`: Pre-check before any LLM call; if a different live `sourceRef` already holds the hash, return a zero-chunk result without writing.
+- `'throw'`: Pre-check before any LLM call; throw `WikiDuplicateHashError` (carries the canonical `sourceRef`).
+- The guard only considers **live** references — soft-deleted refs do not trigger it in any mode.
 
 ## Batch Change Detection
 
-Check multiple documents for changes in one query:
+Check multiple documents for changes in one call:
 
 ```typescript
 const batch = [
@@ -901,7 +908,7 @@ const changes = await wikiMemory.hasChanged('entity-123', batch);
 // changes: Array<{ sourceRef: string; changed: boolean; duplicateOf?: string }>
 // duplicateOf — when present, the canonical stored different sourceRef holding
 // the same hash (DB-normalized spelling; sourceRef echoes the raw caller value).
-// Efficient single query with per-document change detection
+// Per-document change detection; internally batched across queries
 ```
 
 ## Dry-Run Deletion

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -827,6 +827,93 @@ configureRandomSource(getRandomValues);
 
 `@equationalapplications/expo-llm-wiki` does this automatically on import (main entry and `/factory` subpath). If you use `@equationalapplications/core-llm-wiki` directly on React Native without the expo package, you must call `configureRandomSource()` yourself or polyfill `globalThis.crypto.getRandomValues`.
 
+## Entity Enumeration
+
+List all entities that have stored data in the wiki:
+
+```typescript
+const entityIds = await wikiMemory.listEntityIds();
+// Returns all entity_ids with at least one row (including soft-deleted-only entities)
+// Optional prefix filter: await wikiMemory.listEntityIds({ prefix: 'tier_' });
+```
+
+Use this for maintenance scheduling, multi-entity operations, or discovering which namespaces exist. Includes entities with only soft-deleted rows so `runPrune()` can reclaim orphaned storage.
+
+## Source Reference Enumeration
+
+List all documents currently stored for an entity:
+
+```typescript
+const sourceRefs = await wikiMemory.listSourceRefs('user-123');
+// Returns: Array<{ sourceRef: string; sourceHash: string | null; factCount: number; lastIngestedAt: number }>
+```
+
+Use this to audit stored documents, validate external sync state, or preview the blast radius before `forget()` operations.
+
+## Direct Graph Write
+
+Write structured graph data directly without LLM extraction — useful for programmatic fact ingestion, parsers, and deterministic pipelines:
+
+```typescript
+const { nodesWritten, edgesWritten, superseded } = await wikiMemory.upsertGraph('entity-123', {
+  sourceRef: 'codebase_main.ts',
+  sourceHash: sha256(sourceCode),
+  nodes: [
+    { id: 'fn_processData', type: 'function', title: 'processData', body: 'Processes user data' },
+    { id: 'class_UserService', type: 'class', title: 'UserService', body: 'User management service' },
+  ],
+  edges: [
+    { type: 'calls', sourceId: 'fn_processData', targetId: 'class_UserService' },
+  ],
+}, adapter); // SQLiteAdapter from your platform driver — writes join the caller's transaction
+```
+
+`upsertGraph` is "the tail of `ingestDocument` with the middle (LLM extraction) step removed" — it accepts caller-supplied nodes (`{ id, type, title, body? }`) and edges (`{ type, sourceId, targetId, id? }`) and writes them under the same `(sourceRef, sourceHash)` semantics. If a *different* live `sourceRef` already holds the same `sourceHash`, it throws `WikiSourceRefHashCollision`; re-writing the identical `(sourceRef, sourceHash)` is a no-op returning zero counts. The adapter parameter is required so writes participate in the caller's transaction.
+
+## Duplicate Hash Detection
+
+Control behavior when multiple `sourceRef` values share the same `sourceHash`:
+
+```typescript
+await wikiMemory.ingestDocument('entity-123', {
+  sourceRef: 'doc.md',
+  sourceHash: sha256(content),
+  documentChunk: content,
+  onDuplicateHash: 'ingest',  // 'ingest' (default) | 'skip' | 'throw'
+});
+```
+
+- `'ingest'` (default): Proceed with extraction as normal — the pre-guard behavior. Use when duplicate content under different refs is acceptable.
+- `'skip'`: Return early without writing and without an LLM call (zero-chunk result). Use when the stored document holding this hash is authoritative.
+- `'throw'`: Throw `WikiDuplicateHashError` (carries the canonical `sourceRef`). Use for strict auditing.
+
+## Batch Change Detection
+
+Check multiple documents for changes in one query:
+
+```typescript
+const batch = [
+  { sourceRef: 'doc1.md', sourceHash: sha256(content1) },
+  { sourceRef: 'doc2.md', sourceHash: sha256(content2) },
+  { sourceRef: 'doc3.md', sourceHash: sha256(content3) },
+];
+const changes = await wikiMemory.hasChanged('entity-123', batch);
+// changes: Array<{ sourceRef: string; changed: boolean; duplicateOf?: string }>
+// duplicateOf — when present, the canonical stored different sourceRef holding
+// the same hash (DB-normalized spelling; sourceRef echoes the raw caller value).
+// Efficient single query with per-document change detection
+```
+
+## Dry-Run Deletion
+
+Preview deletion impact without writing:
+
+```typescript
+const preview = await wikiMemory.forget('entity-123', { sourceRef: 'doc.md' }, { dryRun: true });
+// preview: { deleted: { entries: number; tasks: number } }
+// No database writes performed; safe for blast-radius validation
+```
+
 ## Chunking Utilities
 
 `ingestDocument()` splits a document into chunks before extraction. That same chunking is exported as a pure function, so a consumer can reproduce ingest-time chunk boundaries exactly — useful for recovering the passage a fact was extracted from, by re-chunking the source and ranking chunks against the fact's stored embedding.


### PR DESCRIPTION
Add comprehensive documentation for features implemented in 7 recent specs.

## What's documented

### New public APIs
- **listEntityIds({ prefix? })** - Enumerate all entities with stored data
- **listSourceRefs(entityId)** - List all documents for an entity with metadata
- **upsertGraph(entityId, params, adapter)** - Deterministic graph writes without LLM extraction
- **ingestDocument onDuplicateHash** - Control behavior when multiple sourceRefs share the same hash
- **hasChanged(batch[])** - Efficient multi-document change detection
- **forget() dry-run mode** - Preview deletion impact without writing

### Files updated
- `README.md` - Main repository documentation
- `packages/core/README.md` - Core package API documentation
- `docs/superpowers/specs/2026-08-16-documentation-update-summary.md` - Summary of changes

### Implementation specs covered
- export-chunk-text-public-api (already documented in Chunking Utilities)
- source-ref-lifecycle-design (new APIs documented)
- wikimemory-public-api-extensions-design (new APIs documented)
- okf-v02-upgrade-design (already documented in OKF v0.2 conformance section)
- ingest-parse-resilience-design (already documented in Recent changes 5.4.1)

### Packages verified
- expo, react, core-llm-tools, okf, prisma-outbox packages reviewed and confirmed no updates needed

## Testing recommendations
- Verify all code examples compile with TypeScript
- Test each new API in development environment
- Cross-reference spec documents with README documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)