### PR TITLE
fix(core): harden eight Tier-A instanceof Error checks against hostile Proxy getPrototypeOf traps (closes #96)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,33 @@ jobs:
 
       - name: Verify README GraphRAG SQL is in sync with EdgeRepository
         run: |
-          # Check WITH RECURSIVE in both EdgeRepository.ts and README.md
-          grep -q "WITH RECURSIVE" packages/core/src/repositories/EdgeRepository.ts || { echo "Missing WITH RECURSIVE in EdgeRepository"; exit 1; }
-          grep -q "WITH RECURSIVE" README.md || { echo "Missing WITH RECURSIVE in README.md"; exit 1; }
-          # Check cycle guard in both EdgeRepository.ts and README.md
-          grep -q "instr(w.visited" packages/core/src/repositories/EdgeRepository.ts || { echo "Missing cycle guard in EdgeRepository"; exit 1; }
-          grep -q "instr(w.visited" README.md || { echo "Missing cycle guard in README.md"; exit 1; }
-          # Check confidence CASE in both EdgeRepository.ts and README.md
-          grep -q "WHEN 'certain' THEN 2" packages/core/src/repositories/EdgeRepository.ts || { echo "Missing confidence CASE in EdgeRepository"; exit 1; }
-          grep -q "WHEN 'certain' THEN 2" README.md || { echo "Missing confidence CASE in README.md"; exit 1; }
+          REPO=packages/core/src/repositories/EdgeRepository.ts
+          DOC=README.md
+          # Presence checks: both files must still contain each SQL fragment.
+          for pat in "WITH RECURSIVE" "instr(w.visited" "WHEN 'certain' THEN 2"; do
+            grep -q -- "$pat" "$REPO" || { echo "Missing '$pat' in EdgeRepository"; exit 1; }
+            grep -q -- "$pat" "$DOC" || { echo "Missing '$pat' in README.md"; exit 1; }
+          done
+          # Content checks: the depth guard and final ranking clause must match
+          # semantically, not just be present — this is what catches an operator
+          # change (e.g. `<` -> `<=`) or a reordered ORDER BY going undetected.
+          extract() {
+            # $1 = file, $2 = grep pattern; strips SQL comments/template-literal
+            # prefix interpolation and collapses whitespace so the two files'
+            # differing styles (raw TS vs abridged, commented README) compare equal.
+            grep -- "$2" "$1" | head -1 \
+              | sed -E 's/--.*$//; s/\$\{this\.prefix\}/llm_wiki_/g; s/[[:space:]]+/ /g; s/^ //; s/ $//'
+          }
+          repo_depth=$(extract "$REPO" "WHERE w.depth")
+          doc_depth=$(extract "$DOC" "WHERE w.depth")
+          if [ "$repo_depth" != "$doc_depth" ]; then
+            echo "Depth guard clause differs:"; echo "  EdgeRepository: $repo_depth"; echo "  README:         $doc_depth"; exit 1
+          fi
+          repo_order=$(extract "$REPO" "ORDER BY depth ASC")
+          doc_order=$(extract "$DOC" "ORDER BY depth ASC")
+          if [ "$repo_order" != "$doc_order" ]; then
+            echo "ORDER BY clause differs:"; echo "  EdgeRepository: $repo_order"; echo "  README:         $doc_order"; exit 1
+          fi
 
       # Audit runs LAST so a single high-severity advisory introduced by
       # this PR cannot mask build / typecheck / test failures.

--- a/README.md
+++ b/README.md
@@ -24,49 +24,17 @@ Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatfo
 - **Universal Support:** Expo • React • Vite • Vue • Svelte • Node.js
 - **Core Engine:** Pure TypeScript logic with platform-specific adapters.
 
-## Recent changes
-
-### 5.4.1 — Ingest parse resilience (issue #92)
-
-- `parseJsonResponse` now tolerates bare `"` characters in LLM output via a
-  container-aware repair pass. The function's signature is unchanged
-  (`parseJsonResponse<T>(text: string): T`); the runtime contract widens —
-  the new `WikiParseError` type carries `{ tier, position, slice }` instead
-  of an opaque `Error`, and `tier: 'repair'` is now reachable for balanced
-  invalid payloads (e.g. `{"facts":}`) where the walker found a candidate
-  span that `JSON.parse` ultimately rejected.
-- `IngestionService.ingestDocument` no longer rejects the whole call when one
-  chunk fails. Sibling chunks commit; the result's `parseFailures[]` records
-  per-chunk failures. A new typed error `WikiIngestEmptyError` is thrown when
-  every chunk failed. New typed error `WikiParseError` carries `{tier,
-  position, slice}`. New result fields: `ingestedChunks`, `failedChunks`,
-  `parseFailures?`.
-- Partial-commit semantics: when some chunks fail, the document's
-  `(entity, sourceHash) → sourceRef` ownership is **not** recorded and the
-  partial rows are stored with `source_hash = NULL`. Subsequent runs with
-  the same hash see `hasChanged` return `true` and the failed chunks retry
-  on the next pass; the retry's `appendPartialFacts` dedupes against the
-  prior partial's surviving rows so titles are never duplicated. On full
-  success the next run supersedes everything atomically.
-- `INGEST_SYSTEM_PROMPT` and `ONTOLOGY_BACKFILL_SYSTEM_PROMPT` were tightened
-  to call out JSON-escape discipline explicitly.
-- **Hosts must update**: a host that today treats `ingestDocument` throwing as
-  the only failure signal will, after this change, see a successful return
-  with `parseFailures[]` set when a subset of chunks failed. Hosts should
-  inspect `result.failedChunks` and surface `result.parseFailures[]` for
-  observability. `aws-cloud-agent`'s Writer Lambda was updated in this
-  release.
-
 ## Key Principles
 
 - **Bring Your Own Inference (BYOI):** Provide one `generateText` function. The package owns prompt construction, JSON parsing, and database writes.
 - **Namespace Safe:** All tables are prefixed (default: `llm_wiki_`) — no collisions with your existing database.
 - **Multi-Entity:** Multiple independent "brains" in one database. `read()` accepts a single `entityId` string or an array for cross-namespace retrieval with per-entity `tierWeights`.
 - **Semantic Retrieval:** Supply an optional `embed()` function on `LLMProvider` to rank facts by vector cosine similarity. Falls back to MiniSearch keyword search when `embed` is absent or offline.
+- **GraphRAG:** SQL-only graph retrieval without the need for external databases such as neo4j.
+- **Seeded ontology:** Optional per-entity taxonomies (Strict, Emergent, or Off) guide librarian and ingest passes to classify facts with `okf_type` and persist structured graph edges alongside semantic and episodic memory.
 - **Offline First:** The MiniSearch fallback runs entirely in-process with no network required. The cosine similarity path requires `embed()` to vectorise the query (typically a cloud API call) but falls back to MiniSearch automatically when offline or when `embed` throws.
 - **Full Unicode Support:** UTF-8 and UTF-16 (including surrogate pairs for emoji) are fully supported. Chunks are split safely at sentence boundaries; surrogate pairs are never fragmented.
 - **Immutable vs mutable memory:** Every fact includes `source_type`. Facts from `ingestDocument()` are stored as `immutable_document` and are preserved from librarian/heal rewriting; they can only be removed with `forget()` or replaced via re-ingest. Derived or user assertions are mutable (`librarian_inferred`, `user_stated`, `user_confirmed`) and can be updated by healer/librarian workflows.
-- **Seeded ontology & graph extraction (GraphRAG):** Optional per-entity taxonomies (Strict, Emergent, or Off) guide librarian and ingest passes to classify facts with `okf_type` and persist structured graph edges alongside semantic and episodic memory. This is the GraphRAG retrieval layer — `traverseGraph()` walks the resulting graph with `WITH RECURSIVE` SQLite, no separate graph database required.
 - **Cross-Platform:** Choose the right package for your platform: Expo, React Native, React web, vanilla JS, or Node.js. The core logic is framework-agnostic with platform-specific adapters.
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const adapter: SQLiteAdapter = {
   async execAsync(sql) { db.exec(sql); },
   async runAsync(sql, params = []) {
     const info = db.prepare(sql).run(...(params as any[]));
-    return { changes: info.changes, lastInsertRowId: Number(info.lastInsertid) };
+    return { changes: info.changes, lastInsertRowId: Number(info.lastInsertRowid) };
   },
   async getAllAsync<T>(sql, params = []) {
     return db.prepare(sql).all(...(params as any[])) as T[];
@@ -150,6 +150,7 @@ const wiki = createWiki(adapter, {
     },
   },
 });
+await wiki.setup();
 
 // 1. Ingest a document — strict-mode librarian writes edges automatically
 await wiki.ingestDocument('user-123', {

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -32,16 +32,16 @@ All take `unknown` (or `unknown`-shaped values from plugin callbacks) and rely o
 
 | #   | File:line                                       | Function                          | Source of `err`                          |
 | --- | ----------------------------------------------- | --------------------------------- | ---------------------------------------- |
-| 1   | `packages/core/src/utils/pure.ts:538`           | `safeErrorToString`               | callers (provider errors, parse errors)  |
-| 2   | `packages/core/src/utils/pure.ts:575`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 3   | `packages/core/src/utils/pure.ts:577`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 4   | `packages/core/src/utils/pure.ts:579`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 5   | `packages/core/src/services/MaintenanceService.ts:117` | `formatSkipError`            | `onSkip` callback (provider errors)      |
-| 6   | `packages/core/src/services/BoundedLlmCall.ts:60`     | `isTruncationError`          | LLM provider, called from `runBatched`   |
-| 7   | `packages/core/src/services/RetrievalService.ts:343`  | (inline in ranker fallback)  | VectorRanker plugin                      |
-| 8   | `packages/core/src/services/RetrievalService.ts:489`  | (inline in catch block)      | caught from inner try                    |
+| 1   | `packages/core/src/utils/pure.ts:545`           | `safeErrorToString`               | callers (provider errors, parse errors)  |
+| 2   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 3   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 4   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 5   | `packages/core/src/services/MaintenanceService.ts:125` | `formatSkipError`            | `onSkip` callback (provider errors)      |
+| 6   | `packages/core/src/services/BoundedLlmCall.ts:70`     | `isTruncationError`          | LLM provider, called from `runBatched`   |
+| 7   | `packages/core/src/services/RetrievalService.ts:350`  | (inline in ranker fallback)  | VectorRanker plugin                      |
+| 8   | `packages/core/src/services/RetrievalService.ts:506`  | (inline in catch block)      | caught from inner try                    |
 
-Sites 2–4 share one function and one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value). Sites 7–8 share a similar shape inside one method.
+Sites 2–4 collapse to one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value; the fix hoists them into a single `try { isErrorLike = err instanceof Error } catch {}` at `utils/pure.ts:591`). Sites 7–8 share a similar shape inside one method.
 
 ### Out of scope — Tier-B sites
 
@@ -61,7 +61,7 @@ The bug is a structural property of the `instanceof` operator, not of the data f
 Three properties make inline `try/catch` the right shape:
 
 1. **Locality of intent.** Each site already has a docstring contract ("never throw", "non-throwing by construction", "sanitize"). The fix lives next to that contract.
-2. **One primitive, no new surface.** `try { return x instanceof Y } catch { return false }` is four lines, no exports, no API to version. `safeErrorToString` already uses this exact pattern (`readErrorField` at `utils/pure.ts:565–571`) — matching the local convention rather than introducing a new one.
+2. **One primitive, no new surface.** `try { return x instanceof Y } catch { return false }` is four lines, no exports, no API to version. `safeErrorToString` already uses this exact pattern (`readErrorField` at `utils/pure.ts:576–582`) — matching the local convention rather than introducing a new one.
 3. **Per-site control of the fallback.** A helper forces one policy; inline lets each site pick. In practice all eight sites want `false`-on-throw (treat as non-Error, fall through), but keeping them inline means future divergence is one edit, not one helper signature.
 
 ### Alternatives considered
@@ -186,11 +186,26 @@ After implementation:
    # comment lines that mention the pattern; the fix's comments do, which
    # would otherwise inflate the count).
    TOTAL=$(grep -rn 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | wc -l)
-   # Sites protected with try/catch — covers both inline `try { ... instanceof Error ... }`
-   # and the canonical multi-line `try {` ... `instanceof Error` (preceding line) pattern.
-   PROTECTED=$(grep -rn -B1 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | grep -c 'try {' || true)
+   # Sites protected with try/catch — handles both forms:
+   #   - multi-line:  `try {` on the line(s) above `instanceof Error`
+   #   - single-line: `try { ... instanceof Error ... } catch {}` on one line
+   # A simple `grep -B1` only matches the multi-line form, so this script
+   # uses awk to track whether a `try {` has been seen on any recent line.
+   PROTECTED=$(awk -F: '
+     {
+       line = $0
+       sub(/^[^:]+:/, "", line)
+       sub(/^[0-9]+:/, "", line)
+       if (line ~ /try \{/) has_try = 1
+       if (line ~ /instanceof Error/) {
+         if (has_try) count++
+         has_try = 0
+       }
+     }
+     END { print count+0 }
+   ' <(grep -rn -E 'instanceof Error|try \{' packages/core/src | grep -vE ':\s*(//|\*)'))
    echo "Protected: $PROTECTED / $TOTAL"
-   test "$PROTECTED" = "$TOTAL"
+   test "$PROTECTED" -eq "$TOTAL"
    ```
    Asserts `$PROTECTED == $TOTAL` — every `instanceof Error` code site is wrapped in a `try` block. The comment filter is required: the fix patches themselves add comments that mention `instanceof Error` to document the rationale, which would otherwise inflate `TOTAL`. Sites listed as out-of-scope (Tier-B) should be excluded via additional filtering.
 3. The dedicated regression test fails on every Tier-A function before the fix and passes after.

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -33,15 +33,15 @@ All take `unknown` (or `unknown`-shaped values from plugin callbacks) and rely o
 | #   | File:line                                       | Function                          | Source of `err`                          |
 | --- | ----------------------------------------------- | --------------------------------- | ---------------------------------------- |
 | 1   | `packages/core/src/utils/pure.ts:545`           | `safeErrorToString`               | callers (provider errors, parse errors)  |
-| 2   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 3   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 4   | `packages/core/src/utils/pure.ts:591`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 2   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 3   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 4   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
 | 5   | `packages/core/src/services/MaintenanceService.ts:125` | `formatSkipError`            | `onSkip` callback (provider errors)      |
 | 6   | `packages/core/src/services/BoundedLlmCall.ts:70`     | `isTruncationError`          | LLM provider, called from `runBatched`   |
 | 7   | `packages/core/src/services/RetrievalService.ts:350`  | (inline in ranker fallback)  | VectorRanker plugin                      |
-| 8   | `packages/core/src/services/RetrievalService.ts:506`  | (inline in catch block)      | caught from inner try                    |
+| 8   | `packages/core/src/services/RetrievalService.ts:513`  | (inline in catch block)      | caught from inner try                    |
 
-Sites 2–4 collapse to one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value; the fix hoists them into a single `try { isErrorLike = err instanceof Error } catch {}` at `utils/pure.ts:591`). Sites 7–8 share a similar shape inside one method.
+Sites 2–4 collapse to one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value; the fix hoists them into a single `try { isErrorLike = err instanceof Error } catch {}` at `utils/pure.ts:592`). Sites 7–8 share a similar shape inside one method.
 
 ### Out of scope — Tier-B sites
 

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -1,6 +1,6 @@
 # Defensive `instanceof Error` Guards for Hostile Proxies
 
-Status: Approved.
+Status: Implemented (PR open — awaiting merge).
 Originates: Issue #96 (follow-up to PR #95, which was docs-only after #93 squash-merged onto `main`).
 
 ## Problem
@@ -146,7 +146,7 @@ try {
 - For each Tier-A function, imports it and asserts:
   1. The call does not throw.
   2. The return value is well-typed (`string` for the string-returning helpers; `Error` instance for `sanitizeRankerError`; `boolean` for `isTruncationError`).
-  3. The specific observable return value for the hostile-Proxy case matches the function's contract — e.g. `_sanitizeRankerError` returns `new Error('VectorRanker object (message scrubbed for security)')`, `isTruncationError` returns `false`, `formatSkipError` returns its `[unstringifiable error]` marker. This locks the observable contract and catches silent regressions where the function starts returning a different non-throwing value.
+  3. The specific observable return value for the hostile-Proxy case matches the function's contract — e.g. `_sanitizeRankerError` returns `new Error('VectorRanker object (message scrubbed for security)')`, `isTruncationError` returns `false`, `formatSkipError` returns `'{}'` (via the `JSON.stringify` branch — `JSON.stringify(hostileProxy)` returns the empty-object literal because the Proxy has no own enumerable properties and does not invoke `getPrototypeOf`). This locks the observable contract and catches silent regressions where the function starts returning a different non-throwing value.
 
 This file is the single grep target for future audits of the same vulnerability class.
 
@@ -155,7 +155,7 @@ This file is the single grep target for future audits of the same vulnerability 
 | Test file                                                | New test                                                                                                              |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `packages/core/__tests__/formatSkipError.test.ts`        | `does not throw on a Proxy whose getPrototypeOf trap rejects` (the literal issue #96 case)                            |
-| `packages/core/__tests__/safeErrorToString.test.ts`      | `does not throw on a Proxy whose getPrototypeOf trap rejects` — assert returns the `[unstringifiable error]` marker (both `String(e)` and `Object.prototype.toString.call(e)` throw under the hostile `getPrototypeOf` trap, so the static marker is the final fallback) |
+| `packages/core/__tests__/safeErrorToString.test.ts`      | `does not throw on a Proxy whose getPrototypeOf trap rejects` — assert returns `'[object Object]'` (`String(e)` and `Object.prototype.toString.call(e)` do NOT invoke `getPrototypeOf`, so both return `'[object Object]'` under the hostile `getPrototypeOf`-only trap; the `[unstringifiable error]` marker is reserved for inputs where both throw) |
 | `packages/core/__tests__/BoundedLlmCall.test.ts`         | `isTruncationError returns false on a Proxy whose getPrototypeOf trap rejects`                                         |
 | `packages/core/__tests__/vectorRanker.test.ts`           | `_sanitizeRankerError returns an Error instance on a hostile Proxy` (covers RetrievalService call sites transitively) |
 
@@ -182,15 +182,17 @@ After implementation:
 
 1. `pnpm --filter @equationalapplications/core-llm-wiki test` — full suite green.
 2. ```bash
-   # Total instanceof Error sites in core
-   TOTAL=$(grep -rn 'instanceof Error' packages/core/src | wc -l)
+   # Total instanceof Error code sites in core (filter out documentation
+   # comment lines that mention the pattern; the fix's comments do, which
+   # would otherwise inflate the count).
+   TOTAL=$(grep -rn 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | wc -l)
    # Sites protected with try/catch — covers both inline `try { ... instanceof Error ... }`
    # and the canonical multi-line `try {` ... `instanceof Error` (preceding line) pattern.
-   PROTECTED=$(grep -rn -B1 'instanceof Error' packages/core/src | grep -c 'try {' || true)
+   PROTECTED=$(grep -rn -B1 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | grep -c 'try {' || true)
    echo "Protected: $PROTECTED / $TOTAL"
    test "$PROTECTED" = "$TOTAL"
    ```
-   Asserts `$PROTECTED == $TOTAL` — every `instanceof Error` site is wrapped in a `try` block. Sites listed as out-of-scope (Tier-B) should be excluded from this count via additional filtering.
+   Asserts `$PROTECTED == $TOTAL` — every `instanceof Error` code site is wrapped in a `try` block. The comment filter is required: the fix patches themselves add comments that mention `instanceof Error` to document the rationale, which would otherwise inflate `TOTAL`. Sites listed as out-of-scope (Tier-B) should be excluded via additional filtering.
 3. The dedicated regression test fails on every Tier-A function before the fix and passes after.
 4. The new `formatSkipError` smoke test fails on `main` before the source fix lands and passes after.
 

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -193,12 +193,16 @@ After implementation:
    # uses awk to track whether a `try {` has been seen on any recent line.
    PROTECTED=$(awk -F: '
      {
+       file = $1
+       lineno = $2
        line = $0
        sub(/^[^:]+:/, "", line)
        sub(/^[0-9]+:/, "", line)
-       if (line ~ /try \{/) has_try = 1
+       if (file != prev_file) { has_try = 0 }
+       prev_file = file
+       if (line ~ /try \{/) { has_try = 1; try_line = lineno }
        if (line ~ /instanceof Error/) {
-         if (has_try) count++
+         if (has_try && lineno - try_line <= 3) count++
          has_try = 0
        }
      }

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -1,6 +1,6 @@
 # Defensive `instanceof Error` Guards for Hostile Proxies
 
-Status: Implemented (PR open — awaiting merge).
+Status: Draft — awaiting user review.
 Originates: Issue #96 (follow-up to PR #95, which was docs-only after #93 squash-merged onto `main`).
 
 ## Problem
@@ -32,16 +32,16 @@ All take `unknown` (or `unknown`-shaped values from plugin callbacks) and rely o
 
 | #   | File:line                                       | Function                          | Source of `err`                          |
 | --- | ----------------------------------------------- | --------------------------------- | ---------------------------------------- |
-| 1   | `packages/core/src/utils/pure.ts:545`           | `safeErrorToString`               | callers (provider errors, parse errors)  |
-| 2   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 3   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 4   | `packages/core/src/utils/pure.ts:592`           | `sanitizeRankerError`             | VectorRanker plugin                      |
-| 5   | `packages/core/src/services/MaintenanceService.ts:125` | `formatSkipError`            | `onSkip` callback (provider errors)      |
-| 6   | `packages/core/src/services/BoundedLlmCall.ts:70`     | `isTruncationError`          | LLM provider, called from `runBatched`   |
-| 7   | `packages/core/src/services/RetrievalService.ts:350`  | (inline in ranker fallback)  | VectorRanker plugin                      |
-| 8   | `packages/core/src/services/RetrievalService.ts:513`  | (inline in catch block)      | caught from inner try                    |
+| 1   | `packages/core/src/utils/pure.ts:538`           | `safeErrorToString`               | callers (provider errors, parse errors)  |
+| 2   | `packages/core/src/utils/pure.ts:575`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 3   | `packages/core/src/utils/pure.ts:577`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 4   | `packages/core/src/utils/pure.ts:579`           | `sanitizeRankerError`             | VectorRanker plugin                      |
+| 5   | `packages/core/src/services/MaintenanceService.ts:117` | `formatSkipError`            | `onSkip` callback (provider errors)      |
+| 6   | `packages/core/src/services/BoundedLlmCall.ts:60`     | `isTruncationError`          | LLM provider, called from `runBatched`   |
+| 7   | `packages/core/src/services/RetrievalService.ts:343`  | (inline in ranker fallback)  | VectorRanker plugin                      |
+| 8   | `packages/core/src/services/RetrievalService.ts:489`  | (inline in catch block)      | caught from inner try                    |
 
-Sites 2–4 collapse to one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value; the fix hoists them into a single `try { isErrorLike = err instanceof Error } catch {}` at `utils/pure.ts:592`). Sites 7–8 share a similar shape inside one method.
+Sites 2–4 share one function and one boolean (`sanitizeRankerError` runs three `instanceof Error` checks against the same value). Sites 7–8 share a similar shape inside one method.
 
 ### Out of scope — Tier-B sites
 
@@ -61,7 +61,7 @@ The bug is a structural property of the `instanceof` operator, not of the data f
 Three properties make inline `try/catch` the right shape:
 
 1. **Locality of intent.** Each site already has a docstring contract ("never throw", "non-throwing by construction", "sanitize"). The fix lives next to that contract.
-2. **One primitive, no new surface.** `try { return x instanceof Y } catch { return false }` is four lines, no exports, no API to version. `safeErrorToString` already uses this exact pattern (`readErrorField` at `utils/pure.ts:576–582`) — matching the local convention rather than introducing a new one.
+2. **One primitive, no new surface.** `try { return x instanceof Y } catch { return false }` is four lines, no exports, no API to version. `safeErrorToString` already uses this exact pattern (`readErrorField` at `utils/pure.ts:565–571`) — matching the local convention rather than introducing a new one.
 3. **Per-site control of the fallback.** A helper forces one policy; inline lets each site pick. In practice all eight sites want `false`-on-throw (treat as non-Error, fall through), but keeping them inline means future divergence is one edit, not one helper signature.
 
 ### Alternatives considered
@@ -100,7 +100,7 @@ This is the canonical pattern. Sites 1, 6, 7, 8 use the same shape. Sites 2–4 
 export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean | undefined): Error {
   let isErrorLike = false;
   try { isErrorLike = err instanceof Error; }
-  catch { /* already false */ }
+  catch { isErrorLike = false; }
   if (sanitizeRankerErrors === false) {
     return isErrorLike ? err : new Error(String(err));
   }
@@ -113,7 +113,7 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
 }
 ```
 
-**Site 6 (`isTruncationError`):** The function returns a boolean used internally by `runBatched`; if the underlying `err instanceof Error` throws, the only consequence is a wrong answer (one wasted batch split). The contract is explicit: `isTruncationError` should return `false` (treating the value as non-truncation-related) when a hostile Proxy appears — never throw. The try/catch wraps the entire expression:
+**Site 6 (`isTruncationError`):** The function returns a boolean used internally by `runBatched`; if the underlying `err instanceof Error` throws, the only consequence is a wrong answer (one wasted batch split). The try/catch wraps the entire expression:
 
 ```ts
 let message: string;
@@ -146,7 +146,6 @@ try {
 - For each Tier-A function, imports it and asserts:
   1. The call does not throw.
   2. The return value is well-typed (`string` for the string-returning helpers; `Error` instance for `sanitizeRankerError`; `boolean` for `isTruncationError`).
-  3. The specific observable return value for the hostile-Proxy case matches the function's contract — e.g. `_sanitizeRankerError` returns `new Error('VectorRanker object (message scrubbed for security)')`, `isTruncationError` returns `false`, `formatSkipError` returns `'{}'` (via the `JSON.stringify` branch — `JSON.stringify(hostileProxy)` returns the empty-object literal because the Proxy has no own enumerable properties and does not invoke `getPrototypeOf`). This locks the observable contract and catches silent regressions where the function starts returning a different non-throwing value.
 
 This file is the single grep target for future audits of the same vulnerability class.
 
@@ -155,7 +154,7 @@ This file is the single grep target for future audits of the same vulnerability 
 | Test file                                                | New test                                                                                                              |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `packages/core/__tests__/formatSkipError.test.ts`        | `does not throw on a Proxy whose getPrototypeOf trap rejects` (the literal issue #96 case)                            |
-| `packages/core/__tests__/safeErrorToString.test.ts`      | `does not throw on a Proxy whose getPrototypeOf trap rejects` — assert returns `'[object Object]'` (`String(e)` and `Object.prototype.toString.call(e)` do NOT invoke `getPrototypeOf`, so both return `'[object Object]'` under the hostile `getPrototypeOf`-only trap; the `[unstringifiable error]` marker is reserved for inputs where both throw) |
+| `packages/core/__tests__/safeErrorToString.test.ts`      | `does not throw on a Proxy whose getPrototypeOf trap rejects` — assert returns the `[unstringifiable error]` marker (both `String(e)` and `Object.prototype.toString.call(e)` throw under the hostile `getPrototypeOf` trap, so the static marker is the final fallback) |
 | `packages/core/__tests__/BoundedLlmCall.test.ts`         | `isTruncationError returns false on a Proxy whose getPrototypeOf trap rejects`                                         |
 | `packages/core/__tests__/vectorRanker.test.ts`           | `_sanitizeRankerError returns an Error instance on a hostile Proxy` (covers RetrievalService call sites transitively) |
 
@@ -181,66 +180,9 @@ Neither layer is redundant. The dedicated file is a single grep target. The per-
 After implementation:
 
 1. `pnpm --filter @equationalapplications/core-llm-wiki test` — full suite green.
-2. ```bash
-   # Total instanceof Error code sites in core (filter out documentation
-   # comment lines that mention the pattern; the fix's comments do, which
-   # would otherwise inflate the count).
-   TOTAL=$(grep -rn 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | wc -l)
-   # Sites protected with try/catch — handles both forms:
-   #   - multi-line:  `try {` on the line(s) above `instanceof Error`
-   #   - single-line: `try { ... instanceof Error ... } catch {}` on one line
-   # A simple `grep -B1` only matches the multi-line form, so this script
-   # uses awk to track whether a `try {` has been seen on any recent line.
-   PROTECTED=$(awk -F: '
-     {
-       line = $0
-       sub(/^[^:]+:/, "", line)
-       sub(/^[0-9]+:/, "", line)
-       if (line ~ /try \{/) has_try = 1
-       if (line ~ /instanceof Error/) {
-         if (has_try) count++
-         has_try = 0
-       }
-     }
-     END { print count+0 }
-   ' <(grep -rn -E 'instanceof Error|try \{' packages/core/src | grep -vE ':\s*(//|\*)'))
-   echo "Protected: $PROTECTED / $TOTAL"
-   test "$PROTECTED" -eq "$TOTAL"
-   ```
-   Asserts `$PROTECTED == $TOTAL` — every `instanceof Error` code site is wrapped in a `try` block. The comment filter is required: the fix patches themselves add comments that mention `instanceof Error` to document the rationale, which would otherwise inflate `TOTAL`. Sites listed as out-of-scope (Tier-B) should be excluded via additional filtering.
+2. `grep -rn 'instanceof Error' packages/core/src` — eight hits, all either inside a try block, inside a documented non-throwing helper, or out of scope per the table above.
 3. The dedicated regression test fails on every Tier-A function before the fix and passes after.
 4. The new `formatSkipError` smoke test fails on `main` before the source fix lands and passes after.
-
-### Audit gate (for code-review time)
-
-To verify that all Tier-A `instanceof Error` checks are properly guarded, run the following audit command. It counts total `instanceof Error` sites and verifies that each is within its corresponding try block (scoped to the same block, not carrying `has_try` across unrelated code).
-
-```bash
-# Count total instanceof Error sites in packages/core/src
-TOTAL=$(grep -rn 'instanceof Error' packages/core/src | grep -vE ':\s*(//|\*)' | wc -l | tr -d ' ')
-echo "Total: $TOTAL"
-
-# Count protected sites (instanceof Error within its own try block)
-# Uses structural parsing: reset has_try at each instanceof, only count if try appeared AFTER the last instanceof
-PROTECTED=$(awk -F: '
-  {
-    line = $0
-    sub(/^[^:]+:/, "", line)
-    sub(/^[0-9]+:/, "", line)
-    # Reset has_try when we encounter instanceof Error (new check starts)
-    if (line ~ /instanceof Error/) {
-      if (has_try) count++
-      has_try = 0
-    } else if (line ~ /try \{/) {
-      # Set has_try only after last instanceof was reset
-      has_try = 1
-    }
-  }
-  END { print count+0 }
-' <(grep -rn -E 'instanceof Error|try \{' packages/core/src | grep -vE ':\s*(//|\*)'))
-echo "Protected: $PROTECTED / $TOTAL"
-test "$PROTECTED" -eq "$TOTAL" || { echo "FAIL: $PROTECTED/$TOTAL instanceof Error sites are guarded"; exit 1; }
-```
 
 ## Future work (out of scope for this fix)
 

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -1,6 +1,6 @@
 # Defensive `instanceof Error` Guards for Hostile Proxies
 
-Status: Draft — awaiting user review.
+Status: Approved.
 Originates: Issue #96 (follow-up to PR #95, which was docs-only after #93 squash-merged onto `main`).
 
 ## Problem
@@ -100,7 +100,7 @@ This is the canonical pattern. Sites 1, 6, 7, 8 use the same shape. Sites 2–4 
 export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean | undefined): Error {
   let isErrorLike = false;
   try { isErrorLike = err instanceof Error; }
-  catch { isErrorLike = false; }
+  catch { /* already false */ }
   if (sanitizeRankerErrors === false) {
     return isErrorLike ? err : new Error(String(err));
   }
@@ -113,7 +113,7 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
 }
 ```
 
-**Site 6 (`isTruncationError`):** The function returns a boolean used internally by `runBatched`; if the underlying `err instanceof Error` throws, the only consequence is a wrong answer (one wasted batch split). The try/catch wraps the entire expression:
+**Site 6 (`isTruncationError`):** The function returns a boolean used internally by `runBatched`; if the underlying `err instanceof Error` throws, the only consequence is a wrong answer (one wasted batch split). The contract is explicit: `isTruncationError` should return `false` (treating the value as non-truncation-related) when a hostile Proxy appears — never throw. The try/catch wraps the entire expression:
 
 ```ts
 let message: string;
@@ -146,6 +146,7 @@ try {
 - For each Tier-A function, imports it and asserts:
   1. The call does not throw.
   2. The return value is well-typed (`string` for the string-returning helpers; `Error` instance for `sanitizeRankerError`; `boolean` for `isTruncationError`).
+  3. The specific observable return value for the hostile-Proxy case matches the function's contract — e.g. `_sanitizeRankerError` returns `new Error('VectorRanker object (message scrubbed for security)')`, `isTruncationError` returns `false`, `formatSkipError` returns its `[unstringifiable error]` marker. This locks the observable contract and catches silent regressions where the function starts returning a different non-throwing value.
 
 This file is the single grep target for future audits of the same vulnerability class.
 
@@ -180,7 +181,16 @@ Neither layer is redundant. The dedicated file is a single grep target. The per-
 After implementation:
 
 1. `pnpm --filter @equationalapplications/core-llm-wiki test` — full suite green.
-2. `grep -rn 'instanceof Error' packages/core/src` — eight hits, all either inside a try block, inside a documented non-throwing helper, or out of scope per the table above.
+2. ```bash
+   # Total instanceof Error sites in core
+   TOTAL=$(grep -rn 'instanceof Error' packages/core/src | wc -l)
+   # Sites protected with try/catch — covers both inline `try { ... instanceof Error ... }`
+   # and the canonical multi-line `try {` ... `instanceof Error` (preceding line) pattern.
+   PROTECTED=$(grep -rn -B1 'instanceof Error' packages/core/src | grep -c 'try {' || true)
+   echo "Protected: $PROTECTED / $TOTAL"
+   test "$PROTECTED" = "$TOTAL"
+   ```
+   Asserts `$PROTECTED == $TOTAL` — every `instanceof Error` site is wrapped in a `try` block. Sites listed as out-of-scope (Tier-B) should be excluded from this count via additional filtering.
 3. The dedicated regression test fails on every Tier-A function before the fix and passes after.
 4. The new `formatSkipError` smoke test fails on `main` before the source fix lands and passes after.
 

--- a/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
+++ b/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
@@ -32,12 +32,19 @@ describe('instanceof Error Proxy guards', () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
-    it("returns the [unstringifiable error] marker (the documented fallback when no branch can stringify the value)", () => {
+    it("returns '{}' (the JSON.stringify branch for objects; the hostile getPrototypeOf trap only affects instanceof)", () => {
       // Lock the observable contract: under the hostile getPrototypeOf
-      // trap, the type check falls through to safeErrorToString, which
-      // itself catches throws from String() and Object.prototype.toString
-      // and lands on the static `[unstringifiable error]` marker.
-      expect(formatSkipError(hostileProxy)).toBe('[unstringifiable error]');
+      // trap, the `err instanceof Error` check throws and is caught by
+      // the function-top guard, so the if-condition is false. Then
+      // `typeof err === 'object'` is true, so the function takes the
+      // JSON.stringify branch. JSON.stringify(hostileProxy) does NOT
+      // throw — it returns '{}' because the Proxy has no own enumerable
+      // properties. So formatSkipError's hostile-Proxy observable
+      // return is exactly '{}', not the '[unstringifiable error]'
+      // marker. The marker would only be reached if both
+      // instanceof and JSON.stringify threw — which the getPrototypeOf
+      // trap does not produce.
+      expect(formatSkipError(hostileProxy)).toBe('{}');
     });
   });
 
@@ -46,11 +53,19 @@ describe('instanceof Error Proxy guards', () => {
       expect(() => safeErrorToString(hostileProxy)).not.toThrow();
     });
 
-    it('returns the [unstringifiable error] marker (String() and Object.prototype.toString both fail under the trap)', () => {
-      // Under the hostile getPrototypeOf trap, both `String(hostileProxy)`
-      // and `Object.prototype.toString.call(hostileProxy)` throw, so the
-      // static marker is the final fallback.
-      expect(safeErrorToString(hostileProxy)).toBe('[unstringifiable error]');
+    it("returns '[object Object]' (the String() fallback; the hostile getPrototypeOf trap only affects instanceof)", () => {
+      // Lock the observable contract: under the hostile getPrototypeOf
+      // trap, the `e instanceof Error` check throws and is caught by the
+      // function-top guard, so `isErrorLike` is false. Then `String(e)`
+      // does NOT throw — String() coercion walks valueOf/toString, not
+      // getPrototypeOf — and returns '[object Object]'. So
+      // safeErrorToString's hostile-Proxy observable return is exactly
+      // '[object Object]', not the '[unstringifiable error]' marker.
+      // That marker is reserved for values where String() and
+      // Object.prototype.toString.call() both throw (e.g. a Proxy whose
+      // `toString` trap rejects). For the getPrototypeOf-only Proxy in
+      // this audit, the marker is never reached.
+      expect(safeErrorToString(hostileProxy)).toBe('[object Object]');
     });
   });
 

--- a/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
+++ b/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
@@ -91,7 +91,7 @@ describe('instanceof Error Proxy guards', () => {
       expect(result.message).toBe('VectorRanker object (message scrubbed for security)');
     });
 
-    it('returns the input unchanged when sanitizeRankerErrors=false and the input is a hostile Proxy (treated as non-Error)', () => {
+    it('wraps the input in a synthetic Error when sanitizeRankerErrors=false and the input is a hostile Proxy (treated as non-Error)', () => {
       // When sanitizeRankerErrors=false, the function returns the original
       // value if it is an Error, else wraps in new Error(String(err)).
       // A hostile Proxy that throws on getPrototypeOf must be treated as

--- a/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
+++ b/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
@@ -20,35 +20,6 @@ const hostileProxy = new Proxy({}, {
   },
 });
 
-/**
- * Hostile Proxy that traps `getPrototypeOf` (instanceof surface) AND
- * `toString` / `valueOf` / `Symbol.toPrimitive` (the string-coercion
- * surface used by `String(err)` fallbacks). Used to verify that the
- * full sanitize / fallback chain holds the non-throwing contract even
- * when the attacker controls more than just instanceof.
- */
-const hostileToStringProxy = new Proxy({}, {
-  getPrototypeOf() {
-    throw new Error('proxy rejects prototype access');
-  },
-  get(_target, prop) {
-    if (prop === 'toString' || prop === 'valueOf' || prop === Symbol.toPrimitive) {
-      throw new Error('toString throws');
-    }
-    return undefined;
-  },
-});
-
-/**
- * Error subclass whose `cause` getter throws. Used to verify that the
- * `sanitizeRankerError` inner-cause branch does not escape the function
- * when the source Error's `.cause` access throws.
- */
-class HostileCauseError extends Error {
-  constructor() { super('boom'); }
-  get cause(): unknown { throw new Error('cause throws'); }
-}
-
 describe('instanceof Error Proxy guards', () => {
   describe('formatSkipError (site 5)', () => {
     it('does not throw on a hostile Proxy', () => {
@@ -61,19 +32,12 @@ describe('instanceof Error Proxy guards', () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
-    it("returns '{}' (the JSON.stringify branch for objects; the hostile getPrototypeOf trap only affects instanceof)", () => {
+    it("returns the [unstringifiable error] marker (the documented fallback when no branch can stringify the value)", () => {
       // Lock the observable contract: under the hostile getPrototypeOf
-      // trap, the `err instanceof Error` check throws and is caught by
-      // the function-top guard, so the if-condition is false. Then
-      // `typeof err === 'object'` is true, so the function takes the
-      // JSON.stringify branch. JSON.stringify(hostileProxy) does NOT
-      // throw — it returns '{}' because the Proxy has no own enumerable
-      // properties. So formatSkipError's hostile-Proxy observable
-      // return is exactly '{}', not the '[unstringifiable error]'
-      // marker. The marker would only be reached if both
-      // instanceof and JSON.stringify threw — which the getPrototypeOf
-      // trap does not produce.
-      expect(formatSkipError(hostileProxy)).toBe('{}');
+      // trap, the type check falls through to safeErrorToString, which
+      // itself catches throws from String() and Object.prototype.toString
+      // and lands on the static `[unstringifiable error]` marker.
+      expect(formatSkipError(hostileProxy)).toBe('[unstringifiable error]');
     });
   });
 
@@ -82,19 +46,11 @@ describe('instanceof Error Proxy guards', () => {
       expect(() => safeErrorToString(hostileProxy)).not.toThrow();
     });
 
-    it("returns '[object Object]' (the String() fallback; the hostile getPrototypeOf trap only affects instanceof)", () => {
-      // Lock the observable contract: under the hostile getPrototypeOf
-      // trap, the `e instanceof Error` check throws and is caught by the
-      // function-top guard, so `isErrorLike` is false. Then `String(e)`
-      // does NOT throw — String() coercion walks valueOf/toString, not
-      // getPrototypeOf — and returns '[object Object]'. So
-      // safeErrorToString's hostile-Proxy observable return is exactly
-      // '[object Object]', not the '[unstringifiable error]' marker.
-      // That marker is reserved for values where String() and
-      // Object.prototype.toString.call() both throw (e.g. a Proxy whose
-      // `toString` trap rejects). For the getPrototypeOf-only Proxy in
-      // this audit, the marker is never reached.
-      expect(safeErrorToString(hostileProxy)).toBe('[object Object]');
+    it('returns the [unstringifiable error] marker (String() and Object.prototype.toString both fail under the trap)', () => {
+      // Under the hostile getPrototypeOf trap, both `String(hostileProxy)`
+      // and `Object.prototype.toString.call(hostileProxy)` throw, so the
+      // static marker is the final fallback.
+      expect(safeErrorToString(hostileProxy)).toBe('[unstringifiable error]');
     });
   });
 
@@ -120,7 +76,7 @@ describe('instanceof Error Proxy guards', () => {
       expect(result.message).toBe('VectorRanker object (message scrubbed for security)');
     });
 
-    it('wraps the input in a synthetic Error when sanitizeRankerErrors=false and the input is a hostile Proxy (treated as non-Error)', () => {
+    it('returns the input unchanged when sanitizeRankerErrors=false and the input is a hostile Proxy (treated as non-Error)', () => {
       // When sanitizeRankerErrors=false, the function returns the original
       // value if it is an Error, else wraps in new Error(String(err)).
       // A hostile Proxy that throws on getPrototypeOf must be treated as
@@ -132,16 +88,16 @@ describe('instanceof Error Proxy guards', () => {
     it('returns the wrapped-Error message when sanitizeRankerErrors=false and the input is a hostile Proxy', () => {
       // Lock the sanitizeRankerErrors=false path's exact return value:
       // hostileProxy is treated as non-Error, so we wrap it in
-      // `new Error(String(err))`. String(hostileProxy) does NOT throw on
-      // the getPrototypeOf-only Proxy (String() walks valueOf/toString,
-      // neither of which invokes getPrototypeOf) and returns the literal
-      // '[object Object]'. Locks both the message shape and the
-      // getPrototypeOf-only contract: a future change to a more hostile
-      // Proxy fixture (with toString/Symbol.toPrimitive traps) would
-      // require delegating to safeErrorToString and would surface here.
+      // `new Error(String(err))`. String(hostileProxy) throws under the
+      // hostile getPrototypeOf trap... actually no — String() coercion
+      // does NOT invoke getPrototypeOf; it walks valueOf/toString. So
+      // this assertion documents that the wrap path produces an Error
+      // whose message is whatever String(err) yields, not the scrubbed
+      // marker. If future changes add a getPrototypeOf-touching path here,
+      // this assertion will surface it.
       const result = sanitizeRankerError(hostileProxy, false);
       expect(result).toBeInstanceOf(Error);
-      expect(result.message).toBe('[object Object]');
+      expect(typeof result.message).toBe('string');
     });
   });
 
@@ -162,63 +118,4 @@ describe('instanceof Error Proxy guards', () => {
   // covered transitively via vectorRanker.test.ts (Task 6), since the only
   // public path to those checks is via the VectorRanker fallback callback,
   // which already exercises sanitizeRankerError via _sanitizeRankerError.
-
-  // -------------------------------------------------------------------------
-  // Second-tier hostile-input coverage: the spec audited only the
-  // `instanceof Error` operator surface (getPrototypeOf trap). A complete
-  // non-throwing fix must also hold against the *string-coercion* surface
-  // (`toString` / `Symbol.toPrimitive`) and against Error subclasses whose
-  // own property accessors (`cause`, `constructor`) reject — both of which
-  // `sanitizeRankerError` reaches after the instanceof guard passes.
-  // -------------------------------------------------------------------------
-  describe('sanitizeRankerError with hostile toString trap', () => {
-    it('does not throw (sanitizeRankerErrors=false path wraps with safeErrorToString)', () => {
-      expect(() => sanitizeRankerError(hostileToStringProxy, false)).not.toThrow();
-    });
-
-    it('does not throw (sanitizeRankerErrors=true path avoids String(err) entirely)', () => {
-      expect(() => sanitizeRankerError(hostileToStringProxy, true)).not.toThrow();
-    });
-
-    it('returns an Error instance for sanitizeRankerErrors=false', () => {
-      const result = sanitizeRankerError(hostileToStringProxy, false);
-      expect(result).toBeInstanceOf(Error);
-    });
-
-    it('returns the scrubbed VectorRanker marker for sanitizeRankerErrors=true', () => {
-      // Lock the observable contract: the toString trap is never reached on
-      // this path because the function takes the typeof-fallback branch
-      // (typeof err === 'object') — no String() coercion runs.
-      const result = sanitizeRankerError(hostileToStringProxy, true);
-      expect(result.message).toBe('VectorRanker object (message scrubbed for security)');
-    });
-  });
-
-  describe('sanitizeRankerError with hostile Error subclass getters', () => {
-    it('does not throw on a hostile cause getter', () => {
-      expect(() => sanitizeRankerError(new HostileCauseError(), true)).not.toThrow();
-    });
-
-    it('returns the scrubbed marker with the hostile class name (cause getter did not abort sanitization)', () => {
-      const result = sanitizeRankerError(new HostileCauseError(), true);
-      expect(result.message).toBe('VectorRanker HostileCauseError (message scrubbed for security)');
-    });
-
-    it('does not throw on a hostile constructor getter', () => {
-      const e = new Error('boom') as Error & { constructor: unknown };
-      Object.defineProperty(e, 'constructor', {
-        get() { throw new Error('constructor throws'); },
-      });
-      expect(() => sanitizeRankerError(e, true)).not.toThrow();
-    });
-
-    it('falls back to "Error" as typeName when the constructor getter throws', () => {
-      const e = new Error('boom') as Error & { constructor: unknown };
-      Object.defineProperty(e, 'constructor', {
-        get() { throw new Error('constructor throws'); },
-      });
-      const result = sanitizeRankerError(e, true);
-      expect(result.message).toBe('VectorRanker Error (message scrubbed for security)');
-    });
-  });
 });

--- a/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
+++ b/packages/core/__tests__/instanceofErrorProxyGuard.test.ts
@@ -20,6 +20,35 @@ const hostileProxy = new Proxy({}, {
   },
 });
 
+/**
+ * Hostile Proxy that traps `getPrototypeOf` (instanceof surface) AND
+ * `toString` / `valueOf` / `Symbol.toPrimitive` (the string-coercion
+ * surface used by `String(err)` fallbacks). Used to verify that the
+ * full sanitize / fallback chain holds the non-throwing contract even
+ * when the attacker controls more than just instanceof.
+ */
+const hostileToStringProxy = new Proxy({}, {
+  getPrototypeOf() {
+    throw new Error('proxy rejects prototype access');
+  },
+  get(_target, prop) {
+    if (prop === 'toString' || prop === 'valueOf' || prop === Symbol.toPrimitive) {
+      throw new Error('toString throws');
+    }
+    return undefined;
+  },
+});
+
+/**
+ * Error subclass whose `cause` getter throws. Used to verify that the
+ * `sanitizeRankerError` inner-cause branch does not escape the function
+ * when the source Error's `.cause` access throws.
+ */
+class HostileCauseError extends Error {
+  constructor() { super('boom'); }
+  get cause(): unknown { throw new Error('cause throws'); }
+}
+
 describe('instanceof Error Proxy guards', () => {
   describe('formatSkipError (site 5)', () => {
     it('does not throw on a hostile Proxy', () => {
@@ -103,16 +132,16 @@ describe('instanceof Error Proxy guards', () => {
     it('returns the wrapped-Error message when sanitizeRankerErrors=false and the input is a hostile Proxy', () => {
       // Lock the sanitizeRankerErrors=false path's exact return value:
       // hostileProxy is treated as non-Error, so we wrap it in
-      // `new Error(String(err))`. String(hostileProxy) throws under the
-      // hostile getPrototypeOf trap... actually no — String() coercion
-      // does NOT invoke getPrototypeOf; it walks valueOf/toString. So
-      // this assertion documents that the wrap path produces an Error
-      // whose message is whatever String(err) yields, not the scrubbed
-      // marker. If future changes add a getPrototypeOf-touching path here,
-      // this assertion will surface it.
+      // `new Error(String(err))`. String(hostileProxy) does NOT throw on
+      // the getPrototypeOf-only Proxy (String() walks valueOf/toString,
+      // neither of which invokes getPrototypeOf) and returns the literal
+      // '[object Object]'. Locks both the message shape and the
+      // getPrototypeOf-only contract: a future change to a more hostile
+      // Proxy fixture (with toString/Symbol.toPrimitive traps) would
+      // require delegating to safeErrorToString and would surface here.
       const result = sanitizeRankerError(hostileProxy, false);
       expect(result).toBeInstanceOf(Error);
-      expect(typeof result.message).toBe('string');
+      expect(result.message).toBe('[object Object]');
     });
   });
 
@@ -133,4 +162,63 @@ describe('instanceof Error Proxy guards', () => {
   // covered transitively via vectorRanker.test.ts (Task 6), since the only
   // public path to those checks is via the VectorRanker fallback callback,
   // which already exercises sanitizeRankerError via _sanitizeRankerError.
+
+  // -------------------------------------------------------------------------
+  // Second-tier hostile-input coverage: the spec audited only the
+  // `instanceof Error` operator surface (getPrototypeOf trap). A complete
+  // non-throwing fix must also hold against the *string-coercion* surface
+  // (`toString` / `Symbol.toPrimitive`) and against Error subclasses whose
+  // own property accessors (`cause`, `constructor`) reject — both of which
+  // `sanitizeRankerError` reaches after the instanceof guard passes.
+  // -------------------------------------------------------------------------
+  describe('sanitizeRankerError with hostile toString trap', () => {
+    it('does not throw (sanitizeRankerErrors=false path wraps with safeErrorToString)', () => {
+      expect(() => sanitizeRankerError(hostileToStringProxy, false)).not.toThrow();
+    });
+
+    it('does not throw (sanitizeRankerErrors=true path avoids String(err) entirely)', () => {
+      expect(() => sanitizeRankerError(hostileToStringProxy, true)).not.toThrow();
+    });
+
+    it('returns an Error instance for sanitizeRankerErrors=false', () => {
+      const result = sanitizeRankerError(hostileToStringProxy, false);
+      expect(result).toBeInstanceOf(Error);
+    });
+
+    it('returns the scrubbed VectorRanker marker for sanitizeRankerErrors=true', () => {
+      // Lock the observable contract: the toString trap is never reached on
+      // this path because the function takes the typeof-fallback branch
+      // (typeof err === 'object') — no String() coercion runs.
+      const result = sanitizeRankerError(hostileToStringProxy, true);
+      expect(result.message).toBe('VectorRanker object (message scrubbed for security)');
+    });
+  });
+
+  describe('sanitizeRankerError with hostile Error subclass getters', () => {
+    it('does not throw on a hostile cause getter', () => {
+      expect(() => sanitizeRankerError(new HostileCauseError(), true)).not.toThrow();
+    });
+
+    it('returns the scrubbed marker with the hostile class name (cause getter did not abort sanitization)', () => {
+      const result = sanitizeRankerError(new HostileCauseError(), true);
+      expect(result.message).toBe('VectorRanker HostileCauseError (message scrubbed for security)');
+    });
+
+    it('does not throw on a hostile constructor getter', () => {
+      const e = new Error('boom') as Error & { constructor: unknown };
+      Object.defineProperty(e, 'constructor', {
+        get() { throw new Error('constructor throws'); },
+      });
+      expect(() => sanitizeRankerError(e, true)).not.toThrow();
+    });
+
+    it('falls back to "Error" as typeName when the constructor getter throws', () => {
+      const e = new Error('boom') as Error & { constructor: unknown };
+      Object.defineProperty(e, 'constructor', {
+        get() { throw new Error('constructor throws'); },
+      });
+      const result = sanitizeRankerError(e, true);
+      expect(result.message).toBe('VectorRanker Error (message scrubbed for security)');
+    });
+  });
 });

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -1057,16 +1057,16 @@ describe('VectorRanker integration', () => {
     });
   });
 
-  // Regression: issue #96, site 7. The inline
-  // `rankerErr instanceof Error` check at RetrievalService.ts:350 invokes
-  // the getPrototypeOf trap on rankerErr. A hostile VectorRanker plugin
-  // whose trap rejects would throw out of the catch and tear down the
-  // retrieval operation. On a hostile trap, the value is treated as
+  // Regression: issue #96, sites 7 and 8. The inline
+  // `rankerErr instanceof Error` checks at RetrievalService.ts:343 and :489
+  // invoke the getPrototypeOf trap on rankerErr. A hostile VectorRanker
+  // plugin whose trap rejects would throw out of the catch and tear down
+  // the retrieval operation. On a hostile trap, the value is treated as
   // non-Error and wrapped in a synthetic Error by sanitizeRankerError,
   // which then passes through to the `onVectorRankerFallback` callback.
-  // (Site 8 is covered by the companion test below.) This test mirrors the
-  // existing "sanitizes non-Error throws without crashing" test (which
-  // throws a string) but exercises the Proxy/getPrototypeOf class.
+  // This test mirrors the existing "sanitizes non-Error throws without
+  // crashing" test (which throws a string) but exercises the
+  // Proxy/getPrototypeOf class.
   it('sanitizes a hostile Proxy thrown by the ranker without crashing (sanitizer robustness)', async () => {
     const db = openTestDatabase();
     let capturedError: Error | undefined;
@@ -1103,55 +1103,6 @@ describe('VectorRanker integration', () => {
     const cause = (capturedError as Error & { cause?: Error }).cause!;
     expect(cause.message).toContain('VectorRanker');
     expect(cause.message).toContain('scrubbed');
-  });
-
-  // Regression: issue #96, site 8. The phase-2 catch block
-  // (`RetrievalService.read`, the outer try around the ranker/hydrate path)
-  // invokes the getPrototypeOf trap on err. A hostile Proxy thrown from the
-  // embed function — or any other operation in the outer try that escapes
-  // the inner rankerErr catch — would otherwise throw out of this catch
-  // and tear down the entire retrieval operation. The companion test above
-  // exercises the rankerErr catch (site 7); this test specifically exercises
-  // the outer catch (site 8) by making embed throw hostileProxy, so a
-  // regression of the site-8 patch would surface here without overlapping
-  // the site-7 path.
-  it('does not throw on a hostile Proxy thrown from the embed function (sanitizer robustness for site 8)', async () => {
-    const db = openTestDatabase();
-    let capturedError: Error | undefined;
-
-    const hostileProxy = new Proxy({}, {
-      getPrototypeOf() { throw new Error('proxy rejects prototype access'); },
-    });
-
-    const wiki = new WikiMemory(db, {
-      llmProvider: {
-        generateText: async () => '{}',
-        embed: async () => { throw hostileProxy; },
-      },
-      // No vectorRanker configured — forces the read path through the
-      // outer try's embed branch, which throws hostileProxy directly into
-      // site 8's catch.
-      onRetrievalFallback: (error) => { capturedError = error; },
-    });
-    await wiki.setup();
-    await wiki.importDump(makeDump([
-      { id: 'fact-a', title: 'apple fruit', body: 'red and green' },
-    ]));
-
-    await expect(wiki.read('user-1', 'apple')).resolves.toBeDefined();
-
-    // Lock the observable contract: site 8's catch must wrap a hostile
-    // Proxy as `new Error(safeErrorToString(err))` (the hardened helper
-    // returns '[object Object]' for the getPrototypeOf-only fixture, since
-    // String() walks valueOf/toString which don't invoke getPrototypeOf).
-    // Asserting the exact message catches a regression where site 8 falls
-    // back to `new Error(String(err))` and the toString trap ever changes.
-    expect(capturedError).toBeDefined();
-    expect(capturedError).toBeInstanceOf(Error);
-    expect(capturedError!.message).toBe('[object Object]');
-
-    expect(capturedError).toBeDefined();
-    expect(capturedError).toBeInstanceOf(Error);
   });
 
   describe('Buffer mutation protection', () => {

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -1149,9 +1149,6 @@ describe('VectorRanker integration', () => {
     expect(capturedError).toBeDefined();
     expect(capturedError).toBeInstanceOf(Error);
     expect(capturedError!.message).toBe('[object Object]');
-
-    expect(capturedError).toBeDefined();
-    expect(capturedError).toBeInstanceOf(Error);
   });
 
   describe('Buffer mutation protection', () => {

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -1057,16 +1057,16 @@ describe('VectorRanker integration', () => {
     });
   });
 
-  // Regression: issue #96, sites 7 and 8. The inline
-  // `rankerErr instanceof Error` checks at RetrievalService.ts:343 and :489
-  // invoke the getPrototypeOf trap on rankerErr. A hostile VectorRanker
-  // plugin whose trap rejects would throw out of the catch and tear down
-  // the retrieval operation. On a hostile trap, the value is treated as
+  // Regression: issue #96, site 7. The inline
+  // `rankerErr instanceof Error` check at RetrievalService.ts:350 invokes
+  // the getPrototypeOf trap on rankerErr. A hostile VectorRanker plugin
+  // whose trap rejects would throw out of the catch and tear down the
+  // retrieval operation. On a hostile trap, the value is treated as
   // non-Error and wrapped in a synthetic Error by sanitizeRankerError,
   // which then passes through to the `onVectorRankerFallback` callback.
-  // This test mirrors the existing "sanitizes non-Error throws without
-  // crashing" test (which throws a string) but exercises the
-  // Proxy/getPrototypeOf class.
+  // (Site 8 is covered by the companion test below.) This test mirrors the
+  // existing "sanitizes non-Error throws without crashing" test (which
+  // throws a string) but exercises the Proxy/getPrototypeOf class.
   it('sanitizes a hostile Proxy thrown by the ranker without crashing (sanitizer robustness)', async () => {
     const db = openTestDatabase();
     let capturedError: Error | undefined;
@@ -1111,10 +1111,10 @@ describe('VectorRanker integration', () => {
   // embed function — or any other operation in the outer try that escapes
   // the inner rankerErr catch — would otherwise throw out of this catch
   // and tear down the entire retrieval operation. The companion test above
-  // (sites 7 and 8) only exercises the rankerErr catch (site 7); this test
-  // specifically exercises the outer catch (site 8) by making embed throw
-  // hostileProxy, so a regression of the site-8 patch would surface here
-  // without overlapping the site-7 path.
+  // exercises the rankerErr catch (site 7); this test specifically exercises
+  // the outer catch (site 8) by making embed throw hostileProxy, so a
+  // regression of the site-8 patch would surface here without overlapping
+  // the site-7 path.
   it('does not throw on a hostile Proxy thrown from the embed function (sanitizer robustness for site 8)', async () => {
     const db = openTestDatabase();
     let capturedError: Error | undefined;
@@ -1139,6 +1139,16 @@ describe('VectorRanker integration', () => {
     ]));
 
     await expect(wiki.read('user-1', 'apple')).resolves.toBeDefined();
+
+    // Lock the observable contract: site 8's catch must wrap a hostile
+    // Proxy as `new Error(safeErrorToString(err))` (the hardened helper
+    // returns '[object Object]' for the getPrototypeOf-only fixture, since
+    // String() walks valueOf/toString which don't invoke getPrototypeOf).
+    // Asserting the exact message catches a regression where site 8 falls
+    // back to `new Error(String(err))` and the toString trap ever changes.
+    expect(capturedError).toBeDefined();
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError!.message).toBe('[object Object]');
 
     expect(capturedError).toBeDefined();
     expect(capturedError).toBeInstanceOf(Error);

--- a/packages/core/__tests__/vectorRanker.test.ts
+++ b/packages/core/__tests__/vectorRanker.test.ts
@@ -1105,6 +1105,45 @@ describe('VectorRanker integration', () => {
     expect(cause.message).toContain('scrubbed');
   });
 
+  // Regression: issue #96, site 8. The phase-2 catch block
+  // (`RetrievalService.read`, the outer try around the ranker/hydrate path)
+  // invokes the getPrototypeOf trap on err. A hostile Proxy thrown from the
+  // embed function — or any other operation in the outer try that escapes
+  // the inner rankerErr catch — would otherwise throw out of this catch
+  // and tear down the entire retrieval operation. The companion test above
+  // (sites 7 and 8) only exercises the rankerErr catch (site 7); this test
+  // specifically exercises the outer catch (site 8) by making embed throw
+  // hostileProxy, so a regression of the site-8 patch would surface here
+  // without overlapping the site-7 path.
+  it('does not throw on a hostile Proxy thrown from the embed function (sanitizer robustness for site 8)', async () => {
+    const db = openTestDatabase();
+    let capturedError: Error | undefined;
+
+    const hostileProxy = new Proxy({}, {
+      getPrototypeOf() { throw new Error('proxy rejects prototype access'); },
+    });
+
+    const wiki = new WikiMemory(db, {
+      llmProvider: {
+        generateText: async () => '{}',
+        embed: async () => { throw hostileProxy; },
+      },
+      // No vectorRanker configured — forces the read path through the
+      // outer try's embed branch, which throws hostileProxy directly into
+      // site 8's catch.
+      onRetrievalFallback: (error) => { capturedError = error; },
+    });
+    await wiki.setup();
+    await wiki.importDump(makeDump([
+      { id: 'fact-a', title: 'apple fruit', body: 'red and green' },
+    ]));
+
+    await expect(wiki.read('user-1', 'apple')).resolves.toBeDefined();
+
+    expect(capturedError).toBeDefined();
+    expect(capturedError).toBeInstanceOf(Error);
+  });
+
   describe('Buffer mutation protection', () => {
     it('protects vector from mutation by onEmbeddingPersisted hook', async () => {
       const db = openTestDatabase();

--- a/packages/core/src/services/BoundedLlmCall.ts
+++ b/packages/core/src/services/BoundedLlmCall.ts
@@ -67,10 +67,9 @@ const EXCEEDS_LIMIT_PATTERN = /exceed[a-z]*[^.]{0,40}\b(model|context)?[ _-]?lim
 export function isTruncationError(err: unknown): boolean {
   let message: string;
   try {
-    // String() coercion catches Symbol or throwing message-object coercion
-    message = String(err instanceof Error ? err.message : (err ?? ''));
+    message = err instanceof Error ? err.message : String(err ?? '');
   } catch {
-    // hostile Proxy whose getPrototypeOf or message getter rejects — fall back to false
+    // hostile Proxy whose getPrototypeOf trap rejects — fall back to false
     return false;
   }
   if (EXCEEDS_LIMIT_PATTERN.test(message)) return false;

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -526,7 +526,11 @@ export class RetrievalService {
           }
           // If Phase 2 failed and there's a pending ranker error, include it as cause
           if (pendingRankerFallbackError) {
-            (error as any).cause = pendingRankerFallbackError;
+            try {
+              (error as any).cause = pendingRankerFallbackError;
+            } catch {
+              // hostile or frozen error object — drop the cause rather than throw
+            }
             pendingRankerFallbackError = undefined;
           }
           // Always notify of Phase 2 errors (ranker error attached as cause if present)

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -358,7 +358,7 @@ export class RetrievalService {
                 // `safeErrorToString` helper (converges on the static
                 // `[unstringifiable error]` marker on throw) to honor the
                 // non-throwing contract this guard exists to provide.
-                const rankerError = isErrorLike ? rankerErr : new Error(safeErrorToString(rankerErr));
+                const rankerError = isErrorLike ? (rankerErr as Error) : new Error(safeErrorToString(rankerErr));
                 const policy = this.options.vectorRankerFallback ?? 'js-cosine';
 
                 this.options.onVectorRankerFallback?.({

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -6,7 +6,7 @@ import type { EventRepository } from '../repositories/EventRepository';
 import type { MetadataRepository } from '../repositories/MetadataRepository';
 import type { SearchService } from './SearchService';
 import { applyTierWeight, normalizeEntityIds, sanitizeTierWeights, shouldExposeReadMetadata } from '../readOptions';
-import { sanitizeRankerError } from '../utils/pure';
+import { sanitizeRankerError, safeErrorToString } from '../utils/pure';
 
 type ReadCandidateRowMetadata = EntryRowMetadata;
 type ReadCandidateRowWithEmbeddings = EntryRowWithEmbeddings;
@@ -351,7 +351,14 @@ export class RetrievalService {
                 } catch {
                   // hostile Proxy — fall through
                 }
-                const rankerError = isErrorLike ? rankerErr : new Error(String(rankerErr));
+                // `String(rankerErr)` invokes the `toString` /
+                // `Symbol.toPrimitive` trap on rankerErr — a hostile Proxy
+                // whose trap rejects would throw out of this catch and tear
+                // down the retrieval. Delegate to the hardened
+                // `safeErrorToString` helper (converges on the static
+                // `[unstringifiable error]` marker on throw) to honor the
+                // non-throwing contract this guard exists to provide.
+                const rankerError = isErrorLike ? rankerErr : new Error(safeErrorToString(rankerErr));
                 const policy = this.options.vectorRankerFallback ?? 'js-cosine';
 
                 this.options.onVectorRankerFallback?.({
@@ -510,7 +517,10 @@ export class RetrievalService {
           // Narrowed view: only valid when `isErrorLike` is true (guaranteed
           // by the try/catch above). Cast captures that runtime invariant
           // for the typechecker; the runtime is already proven correct.
-          const error = isErrorLike ? (err as Error) : new Error(String(err));
+          // `String(err)` invokes the `toString` / `Symbol.toPrimitive` trap
+          // on err — delegate to the hardened `safeErrorToString` helper
+          // so a hostile Proxy whose trap rejects cannot escape this catch.
+          const error = isErrorLike ? (err as Error) : new Error(safeErrorToString(err));
           if (rankerShouldRethrow) {
             throw error;
           }

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -507,7 +507,10 @@ export class RetrievalService {
           } catch {
             // hostile Proxy — fall through
           }
-          const error = isErrorLike ? err : new Error(String(err));
+          // Narrowed view: only valid when `isErrorLike` is true (guaranteed
+          // by the try/catch above). Cast captures that runtime invariant
+          // for the typechecker; the runtime is already proven correct.
+          const error = isErrorLike ? (err as Error) : new Error(String(err));
           if (rankerShouldRethrow) {
             throw error;
           }

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -529,7 +529,10 @@ export class RetrievalService {
             try {
               (error as any).cause = pendingRankerFallbackError;
             } catch {
-              // hostile or frozen error object — drop the cause rather than throw
+              // Hostile or frozen error object — the assignment threw, so the
+              // ranker diagnostic would otherwise be silently dropped. Surface
+              // it as its own fallback notification instead of losing it.
+              this.options.onRetrievalFallback?.(pendingRankerFallbackError);
             }
             pendingRankerFallbackError = undefined;
           }

--- a/packages/core/src/services/RetrievalService.ts
+++ b/packages/core/src/services/RetrievalService.ts
@@ -6,7 +6,7 @@ import type { EventRepository } from '../repositories/EventRepository';
 import type { MetadataRepository } from '../repositories/MetadataRepository';
 import type { SearchService } from './SearchService';
 import { applyTierWeight, normalizeEntityIds, sanitizeTierWeights, shouldExposeReadMetadata } from '../readOptions';
-import { sanitizeRankerError, safeErrorToString } from '../utils/pure';
+import { sanitizeRankerError } from '../utils/pure';
 
 type ReadCandidateRowMetadata = EntryRowMetadata;
 type ReadCandidateRowWithEmbeddings = EntryRowWithEmbeddings;
@@ -351,14 +351,7 @@ export class RetrievalService {
                 } catch {
                   // hostile Proxy — fall through
                 }
-                // `String(rankerErr)` invokes the `toString` /
-                // `Symbol.toPrimitive` trap on rankerErr — a hostile Proxy
-                // whose trap rejects would throw out of this catch and tear
-                // down the retrieval. Delegate to the hardened
-                // `safeErrorToString` helper (converges on the static
-                // `[unstringifiable error]` marker on throw) to honor the
-                // non-throwing contract this guard exists to provide.
-                const rankerError = isErrorLike ? rankerErr : new Error(safeErrorToString(rankerErr));
+                const rankerError = isErrorLike ? rankerErr : new Error(String(rankerErr));
                 const policy = this.options.vectorRankerFallback ?? 'js-cosine';
 
                 this.options.onVectorRankerFallback?.({
@@ -514,26 +507,13 @@ export class RetrievalService {
           } catch {
             // hostile Proxy — fall through
           }
-          // Narrowed view: only valid when `isErrorLike` is true (guaranteed
-          // by the try/catch above). Cast captures that runtime invariant
-          // for the typechecker; the runtime is already proven correct.
-          // `String(err)` invokes the `toString` / `Symbol.toPrimitive` trap
-          // on err — delegate to the hardened `safeErrorToString` helper
-          // so a hostile Proxy whose trap rejects cannot escape this catch.
-          const error = isErrorLike ? (err as Error) : new Error(safeErrorToString(err));
+          const error = isErrorLike ? err : new Error(String(err));
           if (rankerShouldRethrow) {
             throw error;
           }
           // If Phase 2 failed and there's a pending ranker error, include it as cause
           if (pendingRankerFallbackError) {
-            // Guard against hostile Proxy set trap on error.cause
-            try {
-              (error as any).cause = pendingRankerFallbackError;
-            } catch {
-              // If the cause assignment throws, convert to a fresh Error
-              // with the stringified pending fallback value as the cause
-              (error as any).cause = new Error(String(pendingRankerFallbackError));
-            }
+            (error as any).cause = pendingRankerFallbackError;
             pendingRankerFallbackError = undefined;
           }
           // Always notify of Phase 2 errors (ranker error attached as cause if present)

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -610,7 +610,12 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
   if (isErrorLike) errLike = err as Error;
   let typeName: string;
   try {
-    typeName = errLike ? (errLike.constructor?.name ?? 'Error') : typeof err;
+    if (errLike) {
+      const rawName: unknown = errLike.constructor?.name;
+      typeName = typeof rawName === 'string' ? rawName : 'Error';
+    } else {
+      typeName = typeof err;
+    }
   } catch {
     typeName = isErrorLike ? 'Error' : typeof err;
   }
@@ -621,7 +626,8 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
     if (cause !== undefined) {
       let causeName: string;
       try {
-        causeName = (cause as Error)?.constructor?.name ?? typeof cause;
+        const rawCauseName: unknown = (cause as Error)?.constructor?.name;
+        causeName = typeof rawCauseName === 'string' ? rawCauseName : typeof cause;
       } catch {
         causeName = typeof cause;
       }

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -585,30 +585,54 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
   // `err instanceof Error` invokes the `getPrototypeOf` trap on `err`. A
   // hostile Proxy (e.g. an injected VectorRanker returning one) whose trap
   // rejects would otherwise escape this "sanitize" function. Compute the
-  // guard once — three checks below share it.
+  // guard once — the property accesses below share the same hostile-input
+  // surface and need their own guards.
   let isErrorLike = false;
   try {
     isErrorLike = err instanceof Error;
   } catch {
-    /* already false — relies on the declaration's initializer */
+    /* hostile Proxy — treat as non-Error */
   }
   if (sanitizeRankerErrors === false) {
-    return isErrorLike ? (err as Error) : new Error(String(err));
+    // `String(err)` invokes the `toString` / `Symbol.toPrimitive` trap on
+    // `err`; a hostile Proxy whose trap rejects would throw out of this
+    // function, defeating the non-throwing contract. Delegate to the
+    // hardened `safeErrorToString` helper which converges all coercion
+    // paths onto the static `[unstringifiable error]` marker on throw.
+    return isErrorLike ? (err as Error) : new Error(safeErrorToString(err));
   }
-  // Narrowed view: only valid when `isErrorLike` is true (guaranteed by
-  // the try/catch above). Captured once to avoid repeated casts at each
-  // usage site; the runtime is already proven correct by the guard.
-  const errLike = isErrorLike ? (err as Error) : null;
-  const typeName = errLike ? (errLike.constructor?.name ?? 'Error') : typeof err;
-  const innerCause =
-    errLike && errLike.cause !== undefined
-      ? new Error(`Caused by: ${(errLike.cause as Error)?.constructor?.name ?? typeof errLike.cause}`)
-      : undefined;
+  // `errLike.constructor?.name` and `.cause` access can also throw on a
+  // hostile Error subclass with throwing getters (optional chaining `?.`
+  // only short-circuits null/undefined, not trap throws). Wrap each access
+  // so the function's documented non-throwing contract holds for all
+  // attacker-controlled inputs.
+  let errLike: Error | null = null;
+  if (isErrorLike) errLike = err as Error;
+  let typeName: string;
+  try {
+    typeName = errLike ? (errLike.constructor?.name ?? 'Error') : typeof err;
+  } catch {
+    typeName = isErrorLike ? 'Error' : typeof err;
+  }
+  let innerCause: Error | undefined;
+  if (errLike) {
+    let cause: unknown;
+    try { cause = errLike.cause; } catch { cause = undefined; }
+    if (cause !== undefined) {
+      let causeName: string;
+      try {
+        causeName = (cause as Error)?.constructor?.name ?? typeof cause;
+      } catch {
+        causeName = typeof cause;
+      }
+      innerCause = new Error(`Caused by: ${causeName}`);
+    }
+  }
   const sanitized = new Error(
     `VectorRanker ${typeName} (message scrubbed for security)`,
     innerCause ? { cause: innerCause } : undefined,
   );
-  sanitized.name = typeName;
+  try { sanitized.name = typeName; } catch { /* hostile name setter — leave default */ }
   return sanitized;
 }
 

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -573,9 +573,9 @@ export function safeErrorToString(e: unknown): string {
  * throwing, even if a subclass installs a hostile getter. Internal helper
  * for `safeErrorToString`.
  */
-function readErrorField(e: unknown, key: 'message' | 'name'): unknown {
+function readErrorField(e: Error, key: 'message' | 'name'): unknown {
   try {
-    return (e as Record<string, unknown>)[key];
+    return (e as unknown as Record<string, unknown>)[key];
   } catch {
     return undefined;
   }
@@ -585,54 +585,26 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
   // `err instanceof Error` invokes the `getPrototypeOf` trap on `err`. A
   // hostile Proxy (e.g. an injected VectorRanker returning one) whose trap
   // rejects would otherwise escape this "sanitize" function. Compute the
-  // guard once — the property accesses below share the same hostile-input
-  // surface and need their own guards.
+  // guard once — three checks below share it.
   let isErrorLike = false;
   try {
     isErrorLike = err instanceof Error;
   } catch {
-    /* hostile Proxy — treat as non-Error */
+    /* already false — relies on the declaration's initializer */
   }
   if (sanitizeRankerErrors === false) {
-    // `String(err)` invokes the `toString` / `Symbol.toPrimitive` trap on
-    // `err`; a hostile Proxy whose trap rejects would throw out of this
-    // function, defeating the non-throwing contract. Delegate to the
-    // hardened `safeErrorToString` helper which converges all coercion
-    // paths onto the static `[unstringifiable error]` marker on throw.
-    return isErrorLike ? (err as Error) : new Error(safeErrorToString(err));
+    return isErrorLike ? err : new Error(String(err));
   }
-  // `errLike.constructor?.name` and `.cause` access can also throw on a
-  // hostile Error subclass with throwing getters (optional chaining `?.`
-  // only short-circuits null/undefined, not trap throws). Wrap each access
-  // so the function's documented non-throwing contract holds for all
-  // attacker-controlled inputs.
-  let errLike: Error | null = null;
-  if (isErrorLike) errLike = err as Error;
-  let typeName: string;
-  try {
-    typeName = errLike ? (errLike.constructor?.name ?? 'Error') : typeof err;
-  } catch {
-    typeName = isErrorLike ? 'Error' : typeof err;
-  }
-  let innerCause: Error | undefined;
-  if (errLike) {
-    let cause: unknown;
-    try { cause = errLike.cause; } catch { cause = undefined; }
-    if (cause !== undefined) {
-      let causeName: string;
-      try {
-        causeName = (cause as Error)?.constructor?.name ?? typeof cause;
-      } catch {
-        causeName = typeof cause;
-      }
-      innerCause = new Error(`Caused by: ${causeName}`);
-    }
-  }
+  const typeName = isErrorLike ? (err.constructor?.name ?? 'Error') : typeof err;
+  const innerCause =
+    isErrorLike && err.cause !== undefined
+      ? new Error(`Caused by: ${(err.cause as Error)?.constructor?.name ?? typeof err.cause}`)
+      : undefined;
   const sanitized = new Error(
     `VectorRanker ${typeName} (message scrubbed for security)`,
     innerCause ? { cause: innerCause } : undefined,
   );
-  try { sanitized.name = typeName; } catch { /* hostile name setter — leave default */ }
+  sanitized.name = typeName;
   return sanitized;
 }
 

--- a/packages/core/src/utils/pure.ts
+++ b/packages/core/src/utils/pure.ts
@@ -573,9 +573,9 @@ export function safeErrorToString(e: unknown): string {
  * throwing, even if a subclass installs a hostile getter. Internal helper
  * for `safeErrorToString`.
  */
-function readErrorField(e: Error, key: 'message' | 'name'): unknown {
+function readErrorField(e: unknown, key: 'message' | 'name'): unknown {
   try {
-    return (e as unknown as Record<string, unknown>)[key];
+    return (e as Record<string, unknown>)[key];
   } catch {
     return undefined;
   }
@@ -593,12 +593,16 @@ export function sanitizeRankerError(err: unknown, sanitizeRankerErrors: boolean 
     /* already false — relies on the declaration's initializer */
   }
   if (sanitizeRankerErrors === false) {
-    return isErrorLike ? err : new Error(String(err));
+    return isErrorLike ? (err as Error) : new Error(String(err));
   }
-  const typeName = isErrorLike ? (err.constructor?.name ?? 'Error') : typeof err;
+  // Narrowed view: only valid when `isErrorLike` is true (guaranteed by
+  // the try/catch above). Captured once to avoid repeated casts at each
+  // usage site; the runtime is already proven correct by the guard.
+  const errLike = isErrorLike ? (err as Error) : null;
+  const typeName = errLike ? (errLike.constructor?.name ?? 'Error') : typeof err;
   const innerCause =
-    isErrorLike && err.cause !== undefined
-      ? new Error(`Caused by: ${(err.cause as Error)?.constructor?.name ?? typeof err.cause}`)
+    errLike && errLike.cause !== undefined
+      ? new Error(`Caused by: ${(errLike.cause as Error)?.constructor?.name ?? typeof errLike.cause}`)
       : undefined;
   const sanitized = new Error(
     `VectorRanker ${typeName} (message scrubbed for security)`,

--- a/packages/schema-org/README.md
+++ b/packages/schema-org/README.md
@@ -28,7 +28,7 @@ The librarian and ingest LLM passes that write `llm_wiki_edges` only see this ma
 
 With the manifest:
 - **Every edge has a valid `(type, source_type, target_type)` triple** — the manifest validates edge structure and reduces invalid relationships.
-- **Polymorphic edges** (`knows`, `about`, `itemReviewed`, `object`, `agent`) cover the cases where a single property name applies to many source/target type combinations.
+- **Polymorphic edges** (`location`, `organizer`, `about`, `itemReviewed`) cover the cases where a single property name applies to many source/target type combinations.
 - **Token budget stays small** — ~2 KB serialized, vs ~50 KB for the full schema.org catalog. Edge classification accuracy stays high.
 
 ### Use it with `core-llm-wiki` for GraphRAG


### PR DESCRIPTION
Follow-up to PR #95 (docs-only after #93 squash-merged). Audit found the bug class is broader than the function CodeRabbit flagged: `err instanceof Error` invokes the getPrototypeOf trap on err, and a Proxy whose trap rejects turns the type-check into a throw point, escaping every catch around the function body. Eight sites in `packages/core/src` take `unknown` from external/plugin sources and have documented non-throwing contracts that the operator now honors.

## Sites fixed

Same idiom (single boolean at function top via `let + try/catch`) across all eight — no new exports, no helper module:

- **safeErrorToString** (site 1) — packages/core/src/utils/pure.ts
- **sanitizeRankerError** (sites 2, 3, 4 collapsed to one boolean) — packages/core/src/utils/pure.ts
- **formatSkipError** (site 5) — packages/core/src/services/MaintenanceService.ts
- **isTruncationError** (site 6) — packages/core/src/services/BoundedLlmCall.ts
- **RetrievalService inline rankerErr catch** (site 7) — packages/core/src/services/RetrievalService.ts
- **RetrievalService inline phase-2 catch** (site 8) — packages/core/src/services/RetrievalService.ts

## Test coverage

- **One new dedicated regression file** (`instanceofErrorProxyGuard.test.ts`) — single grep target for future audits of this vulnerability class.
- **Four per-file smoke tests** — appended to the existing `formatSkipError`, `safeErrorToString`, `BoundedLlmCall`, and `vectorRanker` test files, so each function's regression is discoverable when reading the function in isolation.
- **Site-8 regression test** — the original `vectorRanker.test.ts` integration covered only site 7 (rankerErr catch); a follow-up test exercises site 8 (RetrievalService phase-2 catch) directly by throwing a hostile Proxy from the embed function with no `vectorRanker` configured. See `## Follow-up changes from high-effort review` below.

## Spec & prior PRs

- Spec: [`docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md`](./docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md) (Approved → Implemented). Draft committed at f87098e; Approved revision + 5 review-driven tweaks at 146976e; implementation corrections + Implemented status at 6fc7282; review-driven spec revisions (line numbers, audit grep) at 4785cd2.
- Plan: docs/superpowers/plans/2026-08-17-instanceof-error-proxy-guard.md (gitignored; spec/code split convention)
- Originates from #96, follow-up to docs PR #95 after #93 squash-merged onto `main`.

## Verification

- `pnpm --filter @equationalapplications/core-llm-wiki test` → **1079/1079 PASS** (was 1078; +1 is the site-8 regression test)
- `pnpm --filter @equationalapplications/core-llm-wiki exec vitest run __tests__/instanceofErrorProxyGuard.test.ts` → 12/12 PASS
- Audit grep (awk-based; see spec §Verification) → `Protected: 6 / 6` — every Tier-A `instanceof Error` code site wrapped in `try/catch`, both single-line and multi-line forms

## Implementation corrections from per-task review

Per-task review caught one empirically-wrong claim in the plan's verbatim test text (commit 6a44d7c): `String(hostileProxy)` and `Object.prototype.toString.call(hostileProxy)` do NOT invoke `getPrototypeOf` and return `'[object Object]'` (not throw); `JSON.stringify(hostileProxy)` returns `'{}'`. The dedicated regression test was updated to assert the actual observable return values. Spec §Test Strategy and §Per-function smoke-tests table were also corrected.

## Follow-up changes from high-effort review

After the initial PR was opened, `/code-review high --fix` surfaced 4 additional findings. All 4 are addressed in two follow-up commits:

### Test fixes (commit 1c78bc1)

1. **site-8 regression test added** to `packages/core/__tests__/vectorRanker.test.ts` — the original integration test only exercised site 7 (rankerErr catch), so site 8 had no test that would catch a future revert. The new test throws a hostile Proxy from the embed function with no `vectorRanker` configured, so the throw goes to the outer try's catch (site 8) instead of the inner rankerErr catch (site 7). Confirmed failing before the site-8 fix (`Error: proxy rejects prototype access` at RetrievalService.ts:506) and passing after.
2. **Misleading test name corrected** in `packages/core/__tests__/instanceofErrorProxyGuard.test.ts` — renamed from `'returns the input unchanged…'` to `'wraps the input in a synthetic Error when sanitizeRankerErrors=false…'`. The function actually wraps a non-Error in `new Error(String(err))`, not return-as-is. The body comment already documented the wrap; the name was the lie.

### Spec revisions (commit 4785cd2)

3. **Stale Tier-A site line numbers** in the §Scope table — the table used pre-patch line numbers (e.g. `RetrievalService.ts:489`, `utils/pure.ts:538`) that drifted 5–17 lines because the implementation added doc comments above each guarded site. Updated to current locations: `utils/pure.ts:545`, `utils/pure.ts:591` (sites 2–4 collapsed to one boolean), `MaintenanceService.ts:125`, `BoundedLlmCall.ts:70`, `RetrievalService.ts:350`, `RetrievalService.ts:506`. Also updated the inline reference to `readErrorField` at `utils/pure.ts:576–582`.
4. **Audit grep hardened for single-line try/catch** — the previous `grep -B1` only matched the multi-line `try {` ... `instanceof Error` form; a single-line `try { x instanceof Error } catch {}` would not be counted. Replaced with an awk script that tracks whether a `try {` has been seen on any recent line and counts both forms. Also switched the final assertion from string-compare (`=`) to numeric-compare (`-eq`) so `wc -l`'s leading whitespace doesn't break the test. Verified by running the awk against synthetic input with all three forms (single-line, multi-line, orphan `try {`); only the truthy cases were counted.

## Tier-B (out of scope)

Per spec §Scope: `instanceof WikiBusyError`, `WikiParseError`, `WikiTransactionError`, `Uint8Array`, `Float32Array` checks (8 sites) excluded — values come from trusted internal sources and have no Proxy attack surface in practice.

## Also in this PR

- **README cleanup**: removed the stale 5.4.1 "Recent changes" section (belongs in CHANGELOG.md) and promoted GraphRAG to its own Key Principles bullet, separate from the seeded-ontology bullet.