### PR TITLE
docs: README OKF/v0.2 framing + 5.4.1→5.5.0 cleanup across monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Return JSON: {"facts": [{"title": "...", "body": "...", "tags": ["..."], "confid
 // `ingestDocument` throws `WikiIngestEmptyError` with the full parseFailures.
 ```
 
-**Hosts must update**: a host that today treats `ingestDocument` throwing as the only failure signal will, after release 5.4.1, see a successful return with `parseFailures[]` set when a subset of chunks failed. Inspect `result.failedChunks` and surface `result.parseFailures[]` for observability — do not rely on the throw for partial failures. Only `WikiIngestEmptyError` (every chunk failed) still throws.
+**Hosts must update**: a host that today treats `ingestDocument` throwing as the only failure signal will, after release 5.5.0, see a successful return with `parseFailures[]` set when a subset of chunks failed. Inspect `result.failedChunks` and surface `result.parseFailures[]` for observability — do not rely on the throw for partial failures. Only `WikiIngestEmptyError` (every chunk failed) still throws.
 
 **Duplicate hash handling:** When the same `sourceHash` is already held live under a *different* `sourceRef` (e.g., the same document ingested at another path), `onDuplicateHash` (a third-argument option, not a params field) controls behavior:
 - `'ingest'` (default): No duplicate pre-check; extraction proceeds as before this option existed. A collision detected at commit time (concurrent-writer race caught by the source-ref unique index) still throws `WikiDuplicateHashError`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ expo-llm-wiki is a cross-platform TypeScript and SQLite library for long-term LL
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
-Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export for interoperable knowledge bases.
+Supports [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export for interoperable knowledge bases.
 
 - **Universal Support:** Expo • React • Vite • Vue • Svelte • Node.js
 - **Core Engine:** Pure TypeScript logic with platform-specific adapters.
@@ -234,7 +234,7 @@ LIMIT ?                                                -- opts.maxTraversalNodes
 | **`@equationalapplications/react-llm-wiki`** | Persistent episodic memory | Web (React) |
 | **`@equationalapplications/prisma-outbox`** | Sync SQLite outbox events to Prisma-backed database (transactional outbox pattern) | Node.js |
 | **`@equationalapplications/core-llm-tools`** | Platform-agnostic Gemini tool schemas and capability-based scope injector | Node.js, browser, React Native |
-| **`@equationalapplications/core-okf`** | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. | Node.js, browser, React Native |
+| **`@equationalapplications/core-okf`** | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. | Node.js, browser, React Native |
 | **`@equationalapplications/schema-org-llm-wiki`** | Curated schema.org warm-agent ontology manifest — 9 node types, 28 polymorphic edges, data-only* | Node.js, browser, React Native |
 
 **\*** *These packages provide the core GraphRAG surface area and canonical ontology for warm-agent graph retrieval. See [GraphRAG: SQL-only graph retrieval](#graphrag-sql-only-graph-retrieval) above.*
@@ -486,7 +486,7 @@ await wiki.setup();
 
 ## OKF Import/Export
 
-This library provides full interoperability with [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf). You can parse and produce OKF bundles using the zero-dependency `@equationalapplications/core-okf` primitives, or use the built-in wiki adapters to convert directly between `MemoryDump` and OKF bundles.
+This library provides full interoperability with [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) bundles — first-class OKF v0.2 / `llm-wiki/2` conformance with v0.1 / `llm-wiki/1` back-compat. You can parse and produce OKF bundles using the zero-dependency `@equationalapplications/core-okf` primitives, or use the built-in wiki adapters to convert directly between `MemoryDump` and OKF bundles.
 
 See the full [OKF Import/Export documentation in packages/core](packages/core/README.md#okf-importexport) or view the [core-okf API reference](packages/okf/README.md).
 

--- a/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
+++ b/docs/superpowers/specs/2026-08-17-instanceof-error-proxy-guard-design.md
@@ -1,6 +1,6 @@
 # Defensive `instanceof Error` Guards for Hostile Proxies
 
-Status: Implemented (PR open — awaiting merge).
+Status: Implemented
 Originates: Issue #96 (follow-up to PR #95, which was docs-only after #93 squash-merged onto `main`).
 
 ## Problem

--- a/packages/core-llm-tools/README.md
+++ b/packages/core-llm-tools/README.md
@@ -133,7 +133,7 @@ but is deprecated in favor of `buildAuthorizedToolsArray`.
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [**@equationalapplications/core-llm-tools**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ---

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,7 +49,7 @@ Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fac
 - **Immutable vs mutable facts** — Use `WikiFact.source_type` to distinguish document-sourced facts (`immutable_document`) from derived or user-provided facts (`librarian_inferred`, `user_stated`, `user_confirmed`). Immutable document facts are not rewritten by `runLibrarian()` or `runHeal()` and can only be removed by `forget()` or re-ingesting.
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
 - **Type-safe** — Built with TypeScript, full type exports
-- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export via the [llm-wiki OKF profile (llm-wiki/1)](https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/okf-profile.md).
+- **Interoperability:** Supports [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) v0.1 + v0.2 import and export via the [llm-wiki OKF profiles](https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/okf-profile.md) (default `llm-wiki/2`, back-compat `llm-wiki/1`).
 - **Per-entity seeded ontology** — Optional Strict, Emergent, or Off modes govern LLM graph extraction; seed taxonomies per entity and persist typed facts with inline edges.
 
 ## GraphRAG & Multi-Modal Retrieval
@@ -1157,7 +1157,7 @@ The flowchart shows:
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## OKF v0.2 conformance (llm-wiki/2)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,34 +10,6 @@ Platform-agnostic TypeScript engine for hybrid LLM memory. Features episodic fac
 
 > Inspired by [Andrej Karpathy's LLM Wiki memory spec](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
-## Recent changes
-
-### 5.4.1 — Ingest parse resilience (issue #92)
-
-- `parseJsonResponse` now tolerates bare `"` characters in LLM output via a
-  container-aware repair pass. The function's signature is unchanged
-  (`parseJsonResponse<T>(text: string): T`); the runtime contract widens —
-  the new `WikiParseError` type carries `{ tier, position, slice }` instead
-  of an opaque `Error`, and `tier: 'repair'` is now reachable for balanced
-  invalid payloads (e.g. `{"facts":}`) where the walker found a candidate
-  span that `JSON.parse` ultimately rejected.
-- `IngestionService.ingestDocument` no longer rejects the whole call when one
-  chunk fails. Sibling chunks commit; the result's `parseFailures[]` records
-  per-chunk failures. A new typed error `WikiIngestEmptyError` is thrown when
-  every chunk failed. New typed error `WikiParseError` carries `{tier,
-  position, slice}`. New result fields: `ingestedChunks`, `failedChunks`,
-  `parseFailures?`.
-- Partial-commit semantics: when some chunks fail, the document's
-  `(entity, sourceHash) → sourceRef` ownership is **not** recorded and the
-  partial rows are stored with `source_hash = NULL`. Subsequent runs with
-  the same hash see `hasChanged` return `true` and the failed chunks retry
-  on the next pass; the retry's `appendPartialFacts` dedupes against the
-  prior partial's surviving rows so titles are never duplicated. On full
-  success the next run supersedes everything atomically.
-- `INGEST_SYSTEM_PROMPT` and `ONTOLOGY_BACKFILL_SYSTEM_PROMPT` were tightened
-  to call out JSON-escape discipline explicitly.
-
-**Hosts must update (host-facing migration)**: a host that today treats `ingestDocument` throwing as the only failure signal will, after 5.4.1, see a successful return with `parseFailures[]` set when a subset of chunks failed. Inspect `result.failedChunks` and surface `result.parseFailures[]` for observability — do not rely on the throw for partial failures. Only `WikiIngestEmptyError` (every chunk failed) still throws. Catch `WikiParseError` explicitly if you previously caught `Error` to log parse failures — the new `tier` field replaces the opaque `message`.
 
 ## Features
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -621,7 +621,7 @@ const result = await wiki.runOntologyBackfill(entityId);
 
 ## OKF Import/Export
 
-The core package integrates with `@equationalapplications/core-okf` to seamlessly adapt wiki data dumps to and from Open Knowledge Format (OKF) v0.1 bundles.
+The core package integrates with `@equationalapplications/core-okf` to seamlessly adapt wiki data dumps to and from Open Knowledge Format (OKF) bundles (v0.1 and v0.2; `formatOkfBundle` defaults to the v0.2 / `llm-wiki/2` profile).
 
 ### Exporting an OKF Bundle
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -22,7 +22,7 @@ Local-first LLM memory for Expo and React Native. Combines the core semantic sea
 - **Seeded ontologies** — Enforce strict taxonomies or allow emergent graph relationship extraction (`useOntologyManifest`, `useSetOntologyManifest`; Strict, Emergent, or Off; defaults to Off).
 - **React hooks** — `WikiProvider`, `useMemoryRead`, `useOntologyManifest`, `useSetOntologyManifest`, `useWikiTraversal`, and all other hooks re-exported from `@equationalapplications/expo-llm-wiki`
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
-- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export (with v0.1 / `llm-wiki/1` back-compat).
+- **Interoperability:** Supports [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) v0.1 + v0.2 import and export via the [llm-wiki OKF profiles](https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/okf-profile.md) (default `llm-wiki/2`, back-compat `llm-wiki/1`).
 
 - **GraphRAG on React Native** — `useWikiTraversal` + `formatGraphContext` give you the same SQLite-only graph retrieval as the core package; pair with `@equationalapplications/schema-org-llm-wiki` for the canonical ontology. See [root README: GraphRAG](../../README.md#graphrag-sql-only-graph-retrieval).
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -22,7 +22,7 @@ Local-first LLM memory for Expo and React Native. Combines the core semantic sea
 - **Seeded ontologies** — Enforce strict taxonomies or allow emergent graph relationship extraction (`useOntologyManifest`, `useSetOntologyManifest`; Strict, Emergent, or Off; defaults to Off).
 - **React hooks** — `WikiProvider`, `useMemoryRead`, `useOntologyManifest`, `useSetOntologyManifest`, `useWikiTraversal`, and all other hooks re-exported from `@equationalapplications/expo-llm-wiki`
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
-- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export.
+- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export (with v0.1 / `llm-wiki/1` back-compat).
 
 - **GraphRAG on React Native** — `useWikiTraversal` + `formatGraphContext` give you the same SQLite-only graph retrieval as the core package; pair with `@equationalapplications/schema-org-llm-wiki` for the canonical ontology. See [root README: GraphRAG](../../README.md#graphrag-sql-only-graph-retrieval).
 
@@ -435,7 +435,7 @@ from `@equationalapplications/core-llm-wiki`) with a top-level `sqliteErrorCode`
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## License

--- a/packages/okf/README.md
+++ b/packages/okf/README.md
@@ -75,7 +75,7 @@ const links = extractMarkdownLinks('See [preferences](facts/fact_abc.md) for mor
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [**@equationalapplications/core-okf**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [**@equationalapplications/core-okf**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## OKF v0.2 conformance

--- a/packages/prisma-outbox/README.md
+++ b/packages/prisma-outbox/README.md
@@ -106,7 +106,7 @@ worker.stop();
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [**@equationalapplications/prisma-outbox**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ---

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,7 +22,7 @@ In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., [
 - **Mutation hooks** — `useWikiWrite`, `useWikiIngest`, `useWikiForget`, `useWikiMaintenance`, `useSetOntologyManifest`, etc.
 - **Shared context** — Single `WikiProvider` per app, use anywhere
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
-- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export (with v0.1 / `llm-wiki/1` back-compat).
+- **Interoperability:** Supports [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) v0.1 + v0.2 import and export via the [llm-wiki OKF profiles](https://github.com/equationalapplications/expo-llm-wiki/blob/main/docs/okf-profile.md) (default `llm-wiki/2`, back-compat `llm-wiki/1`).
 
 ## Installation
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,7 +22,7 @@ In-browser LLM memory for React web apps. Bring your own SQLite adapter (e.g., [
 - **Mutation hooks** — `useWikiWrite`, `useWikiIngest`, `useWikiForget`, `useWikiMaintenance`, `useSetOntologyManifest`, etc.
 - **Shared context** — Single `WikiProvider` per app, use anywhere
 - **Full-featured memory** — Facts, tasks, events, maintenance jobs (librarian, heal, reembed, prune)
-- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export.
+- **Interoperability:** Supports [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) import and export (with v0.1 / `llm-wiki/1` back-compat).
 
 ## Installation
 
@@ -539,7 +539,7 @@ The flowchart shows:
 | [**@equationalapplications/react-llm-wiki**](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 | [@equationalapplications/schema-org-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/schema-org/README.md) | Curated schema.org warm-agent ontology manifest |
 
 ## License

--- a/packages/schema-org/README.md
+++ b/packages/schema-org/README.md
@@ -135,7 +135,7 @@ targets `person`, `organization`, `place`, and `event`.
 | [@equationalapplications/react-llm-wiki](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/react/README.md) | Persistent episodic memory for Web |
 | [@equationalapplications/prisma-outbox](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/prisma-outbox/README.md) | Sync SQLite outbox events to Prisma |
 | [@equationalapplications/core-llm-tools](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/core-llm-tools/README.md) | Gemini tool schemas and capability injector |
-| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 primitives — parse and produce interoperable knowledge bundles. |
+| [@equationalapplications/core-okf](https://github.com/equationalapplications/expo-llm-wiki/blob/main/packages/okf/README.md) | Zero-dependency Open Knowledge Format (OKF) v0.1 + v0.2 primitives — parse and produce interoperable knowledge bundles. |
 
 ## License
 


### PR DESCRIPTION
## Summary

Three docs drifts cleaned up across the monorepo (8 files, 4 commits).

### 1. OKF v0.2 framing (commits `20b25a2` + `61a1e1f`)

`formatOkfBundle`'s default profile switched to `llm-wiki/2` (OKF v0.2) in release 5.4.0, but six sibling READMEs still advertised OKF v0.1 only. Updated:

- `README.md` — tagline, monorepo table row, OKF Import/Export section
- `packages/expo/README.md` — Interoperability bullet + table row
- `packages/react/README.md` — same pattern as expo
- `packages/core/README.md` — Interoperability bullet + table row
- `packages/prisma-outbox/README.md` — table row
- `packages/core-llm-tools/README.md` — table row
- `packages/schema-org/README.md` — table row
- `packages/okf/README.md` — table row (the package's own README)

Wording mirrors `packages/core/dist/index.d.ts` (`OkfFormatProfile = 'llm-wiki/1' | 'llm-wiki/2'`, default `llm-wiki/2`).

### 2. 5.4.1 → 5.5.0 (commit `0917586`)

`README.md:590` referenced 'release 5.4.1', but 5.4.1 was never released — tags jump v5.4.0 → v5.5.0. Updated to 5.5.0.

### 3. Remove `## Recent changes` section (commit `0917586`)

`packages/core/README.md` had a 28-line `## Recent changes` section (re-stating the 5.4.1 → 5.5.0 change) which duplicated what CHANGELOG.md + git tags already record authoritatively. Removed the whole section per repo convention (CHANGELOG.md + release tags are the canonical release history surface). The duplicate '5.4.1' reference at line 40 went with it.

### 4. Mark `2026-08-17-instanceof-error-proxy-guard-design` Implemented (commit `068a9c2`)

Originally the purpose of this branch — appended the spec's Status footer to mark the design implemented (PR #97 already shipped the fix). Pre-existing on this branch.

## Verification

- 0 stale 'OKF v0.1 only' claims in any README
- 0 stale '5.4.1' references in any README
- 0 '## Recent changes' sections anywhere; release history lives in CHANGELOG.md + tags only
- All exports documented in READMEs verified against `packages/core/src/index.ts` (WikiMemory, createWiki, formatContext, formatGraphContext, formatOkfBundle, parseOkfBundle, all 7 WikiError classes, etc.)
- All WikiConfig defaults claimed in docs match inline defaults in services
- All prompt variables claimed (`{{currentFacts}}`, `{{documentAnchors}}`, `{{allTasks}}`, `{{recentEvents}}`) verified against `PromptService` / `MaintenanceService`
- Cross-README anchor links (`#prompt-management--overrides`, `#okf-importexport`, `#per-entity-seeded-ontology`, `#the-sql-how-traversal-works-in-one-query`) all resolve

## Out of scope (flagged, not fixed)

- `packages/integration/` package (`private: true`, not user-facing) is intentionally absent from ecosystem tables
- `docs/okf-profile.md` and `docs/superpowers/specs/*` contain 'OKF v0.1' references — these are the normative spec documents that document BOTH profiles by design
- `CHANGELOG.md` retains 'OKF v0.1' references — these are historical release notes referencing the version shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)