### PR TITLE
feat(core): atomic multi-entity manifest seeding via setOntologyManifests

### DIFF
--- a/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
+++ b/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
@@ -2,6 +2,9 @@
 
 **Date:** 2026-09-02
 **Status:** Implemented (2026-09-02) — branch `spec/atomic-multi-entity-manifest-seed`
+**Revised:** 2026-09-02 — review found §3 assumed `entity_manifests` is the only
+source of a manifest; it is not. See *`ifAbsent` and config-seeded manifests* under
+Cross-cutting. Documentation-only amendment; no code changed.
 **Issues:** none filed; raised from consumer review (see Consumer context)
 **Packages:** `@equationalapplications/core-llm-wiki`
 **Consumer context:** `equationalapplications/curated-thoughts` — spec
@@ -270,6 +273,28 @@ This deletes its `getOntology` pre-read loop, its compensating-rollback block,
 and its local empty-manifest constant. Its never-throws contract is preserved by
 catching and reporting failure; it no longer has to *undo* anything, because the
 engine rolled back.
+
+**`ifAbsent` and config-seeded manifests.** §3 defines "already present" as a row in
+`entity_manifests`, and the implementation is faithful to that. But a manifest can
+also come from `WikiConfig.ontology.seedManifests`, and that route persists lazily:
+`OntologyService.getEffectiveState` writes the seed to the table only when resolved
+with a `tx` (ingest, heal); resolved without one it caches in memory, and
+`WikiMemory.getOntologyManifest` returns the seed without persisting it. So for an
+entity configured that way, `ifAbsent` reports `written` and replaces the seed
+before any ingest has run, and reports `skipped` after — the same call, the same
+config, opposite outcomes depending on unrelated activity. A consumer that
+pre-checked with `getOntologyManifest` would see a manifest "present" and then watch
+`ifAbsent` overwrite it.
+
+This does not affect the motivating consumer, which seeds through the API and not
+through `seedManifests`, and it is not worth closing in code: making `ifAbsent`
+consult the config seed would mean the batch could skip an entity that has no row,
+leaving the "seeded" state observable only through configuration — a worse
+invariant than the one it replaces. The rule is instead a documented one: seed an
+entity through the config or through this method, not both. `packages/core/README.md`
+states it at the point of use, alongside a correction to its claim that
+`seedManifests` entries are written "on first access" (only tx-scoped access
+persists them).
 
 **A caveat the consumer must record.** That consumer seeds its two fixed tiers
 during startup and its workspace tier later, once the workspace id resolves —

--- a/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
+++ b/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
@@ -205,7 +205,7 @@ unchanged, including the leading `validateManifest(data.manifest)`.
 
 ### `WikiMemory.setOntologyManifests`
 
-```
+```text
 1. if entries is empty            -> return { written: [], skipped: [] }
 2. reject duplicate entityIds     -> throw, naming the id
 3. validateManifest(each)         -> throw on the first failure

--- a/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
+++ b/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
@@ -1,0 +1,356 @@
+# Spec: Atomic Multi-Entity Manifest Seeding — `WikiMemory.setOntologyManifests`
+
+**Date:** 2026-09-02
+**Status:** Design approved — not yet implemented
+**Issues:** none filed; raised from consumer review (see Consumer context)
+**Packages:** `@equationalapplications/core-llm-wiki`
+**Consumer context:** `equationalapplications/curated-thoughts` — spec
+`2026-09-01-memory-architecture-intent-implementation-design.md` §2.2, whose
+manifest-seed atomicity requirements cannot be met through the public API as it
+stands at 6.2.0.
+
+---
+
+## Problem
+
+A host that seeds ontology manifests for several entities at once has no way to
+make that seed atomic, and no way to make it conflict-safe. Both gaps trace to
+the same root: `setOntologyManifest` owns its transaction and exposes no seam.
+
+```ts
+// WikiMemory.ts (6.2.0)
+async setOntologyManifest(entityId, manifest, options?): Promise<void> {
+  const mode = options?.mode ?? this.ontologyService.resolveMode();
+  await this.db.withTransactionAsync(tx =>
+    this.metadataRepo.setManifest(entityId, { mode, manifest }, tx),
+  );
+  this.ontologyService.invalidateCache(entityId);
+}
+```
+
+**P1 — a multi-entity seed cannot be atomic.** One transaction per call means a
+host seeding N entities performs N independent transactions. A failure partway
+through leaves some entities typed and others not: a partial ontology, which is
+a state no consumer wants and none can distinguish from a completed seed
+without re-reading every entity.
+
+**P2 — consumers cannot supply a transaction, and must not try.** The obvious
+fix — accept a `tx` parameter — is unsafe as an external contract.
+`WikiMemory` wraps the adapter it is constructed with in
+`withSerializedTransactions` (`db/serializedAdapter.ts`) and keeps the wrapped
+handle in `private db`. A consumer therefore holds only the *unwrapped* adapter
+it passed to `createWiki`. A transaction opened on that handle does not
+participate in the serialization mutex, so it can interleave with the engine's
+own transactions. `types.ts` further documents that the outer handle deadlocks
+against the mutex from inside a transaction callback and that
+`tx.withTransactionAsync` throws. Handing consumers a transaction handle
+without also handing them a safe way to obtain one converts an atomicity
+problem into a deadlock-and-race problem.
+
+**P3 — writes are last-writer-wins, not create-if-absent.**
+`MetadataRepository.setManifest` writes:
+
+```sql
+INSERT INTO <prefix>entity_manifests (entity_id, mode, manifest_json, updated_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(entity_id) DO UPDATE SET
+  mode = excluded.mode, manifest_json = excluded.manifest_json, updated_at = excluded.updated_at
+```
+
+That is an upsert. A host wanting "seed only if absent" must read first and
+write second, which leaves a time-of-check-to-time-of-use window: two
+initializers (two app windows, or startup racing a first tool call) both read
+*absent*, both write, and the second silently overwrites the first. When the two
+carry different ontology selections the loser's manifest is destroyed with no
+diagnostic.
+
+The motivating consumer, `curated-thoughts`, states all three properties as
+requirements in its §2.2 — "one transaction for the whole seed", "conflict-safe
+creation … loses the race harmlessly", "once-per-DB … never rewritten" — and
+today satisfies none of them through the API. It approximates the first with a
+compensating rollback that rewrites each already-written manifest back to an
+empty manifest at mode `off`, and the others with a read-then-write.
+
+---
+
+## Solution
+
+One new public method. One internal repository parameter. Additive: no schema
+migration, no new outbox event, no breaking change to any published surface.
+
+| Section | Surface | New / Modified |
+| --- | --- | --- |
+| §1 | `setOntologyManifests(entries, opts?): Promise<{ written; skipped }>` | New public method |
+| §2 | Input validation and rejection rules | Behaviour of §1 |
+| §3 | `opts.ifAbsent` → `ON CONFLICT DO NOTHING` | Behaviour of §1 |
+| §4 | `MetadataRepository.setManifest` gains `opts.ifAbsent`, returns `boolean` | Internal (not exported) |
+| §4 | `setOntologyManifest` (singular) delegates to the batch | Internal refactor; contract unchanged |
+
+The method owns its transaction, taken on the internal serialized adapter.
+Consumers pass data and never see a transaction handle — which is the whole
+point of P2, and the reason a `tx` parameter was rejected.
+
+---
+
+## §1. `WikiMemory.setOntologyManifests`
+
+```ts
+async setOntologyManifests(
+  entries: Array<{
+    entityId: string;
+    manifest: OntologyManifest;
+    mode?: OntologyMode;
+  }>,
+  opts?: { ifAbsent?: boolean },
+): Promise<{ written: string[]; skipped: string[] }>;
+```
+
+Writes every entry's manifest inside a **single transaction**. All succeed or
+none do.
+
+**`mode` is per entry**, not per batch, falling back to
+`ontologyService.resolveMode()` exactly as the singular method does. Each
+manifest is an independent statement about one entity; a batch-level mode would
+couple entities that have no reason to be coupled, and costs nothing to avoid.
+
+**Return value.** `written` names the entities whose row this call actually
+wrote; `skipped` names those left untouched because a manifest was already
+present (only reachable under `ifAbsent`, see §3). Both preserve input order.
+With `ifAbsent` absent or false, `skipped` is always empty.
+
+The return value exists so a caller can report what happened without re-reading.
+The motivating consumer's seed outcome type is exactly
+`{ seeded: string[]; skipped: string[] }`; sourcing it from the return removes
+that consumer's pre-read loop entirely.
+
+**Transaction and lock semantics.** Opens exactly one transaction on the
+internal serialized adapter, and only after every check in §2 has passed. Never
+accepts a transaction handle. Never opens a transaction for an empty batch.
+
+---
+
+## §2. Input validation and rejection rules
+
+All checks run **before** the transaction opens, so a doomed batch never reaches
+the database and never takes the serialization mutex.
+
+| Input | Behaviour |
+| --- | --- |
+| `entries` is empty | Return `{ written: [], skipped: [] }`. No transaction opened. |
+| Duplicate `entityId` within `entries` | Throw. Nothing written. |
+| Any manifest fails `validateManifest` | Throw. Nothing written. No transaction opened. |
+
+**Duplicates are rejected rather than resolved.** Two entries naming one entity
+express ambiguous intent: silently applying the last one hides a caller bug
+whose symptom — a manifest that is not the one the caller thought it wrote —
+surfaces far from its cause. The error names the offending `entityId`.
+
+**Validation runs twice, deliberately.** Once here, once inside
+`MetadataRepository.setManifest`. This is not redundancy to be optimized away:
+the up-front pass is the fail-fast gate that keeps a bad batch away from the
+mutex, and the inner call is the invariant protecting every *other* caller of
+the repository. Removing either weakens something real.
+
+---
+
+## §3. Conflict semantics — `opts.ifAbsent`
+
+```ts
+opts?: { ifAbsent?: boolean }   // default: false
+```
+
+**`false` (default)** — upsert. `ON CONFLICT(entity_id) DO UPDATE`. Identical
+to today's behaviour, so the singular method's contract is unchanged when it
+delegates (§4).
+
+**`true`** — create-if-absent. `ON CONFLICT(entity_id) DO NOTHING`. An entity
+whose manifest already exists is left exactly as it is and reported in
+`skipped`. Written entities are reported in `written`.
+
+This is what makes a seed genuinely conflict-safe. The check and the write
+become one statement inside one transaction, so the TOCTOU window in P3 closes:
+a concurrent initializer loses the race by writing nothing, rather than by
+overwriting a manifest it never read. Neither racer errors, and both observe a
+consistent final state.
+
+**Detecting which happened.** `runAsync` returns `{ changes }`; `changes === 1`
+means the row was inserted, `changes === 0` means the conflict clause fired.
+This is the established idiom in this codebase —
+`EdgeRepository.addIgnoreDuplicate` already classifies an insert-or-skip exactly
+this way.
+
+---
+
+## §4. Implementation
+
+### `MetadataRepository.setManifest`
+
+Gains an options parameter and a return value. The repository is not exported
+from `index.ts`, so this is an internal change with no published effect.
+
+```ts
+async setManifest(
+  entityId: string,
+  data: { mode: OntologyMode; manifest: OntologyManifest },
+  tx: SQLiteAdapter,
+  opts?: { ifAbsent?: boolean },
+): Promise<boolean>   // true = row written, false = conflict, left alone
+```
+
+The conflict clause is selected from `opts.ifAbsent`; everything else is
+unchanged, including the leading `validateManifest(data.manifest)`.
+
+### `WikiMemory.setOntologyManifests`
+
+```
+1. if entries is empty            -> return { written: [], skipped: [] }
+2. reject duplicate entityIds     -> throw, naming the id
+3. validateManifest(each)         -> throw on the first failure
+4. withTransactionAsync:
+     for each entry:
+       mode = entry.mode ?? resolveMode()
+       wrote = setManifest(entry.entityId, { mode, manifest }, tx, { ifAbsent })
+       record into written | skipped
+5. after commit: invalidateCache(entityId) for EVERY entry
+6. return { written, skipped }
+```
+
+**Invalidate every entry, including skipped ones.** A skipped entry means
+another writer won the race, so this instance's cached copy may be stale;
+dropping it is *more* correct than keeping it. Invalidation is also always safe
+regardless of transaction outcome — it removes a cached copy, and the next read
+goes to the database and observes whatever actually committed. (The hazard in
+this area is cache *population* with uncommitted data, which this design never
+does. `OntologyService.getEffectiveState` already declines to read or populate
+the cache when given a `tx`, for the same reason.)
+
+**Ordering.** Invalidation happens after the transaction commits, not inside it.
+Both orderings are correct for the reason above, but invalidating after commit
+keeps the transaction body free of instance-state mutation, so a future retry
+wrapper around the transaction cannot double-apply a side effect.
+
+### `setOntologyManifest` (singular) delegates
+
+```ts
+async setOntologyManifest(entityId, manifest, options?): Promise<void> {
+  await this.setOntologyManifests([{ entityId, manifest, mode: options?.mode }]);
+}
+```
+
+One code path. The singular method's observable contract is unchanged: same
+signature, same upsert semantics, same cache invalidation. It gains fail-fast
+validation (previously validation happened inside the transaction), which is a
+strict improvement and not a behaviour anyone can depend on having been absent.
+
+---
+
+## Cross-cutting
+
+**Back-compatibility.** Purely additive. `setOntologyManifest` keeps its
+signature, its return type, and its semantics. No existing caller changes.
+
+**Versioning.** Minor bump (6.2.0 → 6.3.0) through the existing release flow.
+The new method appears in the generated changelog; nothing is deprecated.
+
+**Consumer sequencing.** `curated-thoughts` cannot adopt an unpublished API, so
+the order is: this PR → minor release → consumer PR. The consumer's pending
+ontology-seed work stays as-is until the release lands.
+
+**What the consumer changes on adoption.** `seedManifestsIfAbsent` collapses to
+one call:
+
+```ts
+const { written, skipped } = await wiki.setOntologyManifests(
+  entityIds.map(entityId => ({ entityId, manifest, mode })),
+  { ifAbsent: true },
+);
+```
+
+This deletes its `getOntology` pre-read loop, its compensating-rollback block,
+and its local empty-manifest constant. Its never-throws contract is preserved by
+catching and reporting failure; it no longer has to *undo* anything, because the
+engine rolled back.
+
+**A caveat the consumer must record.** That consumer seeds its two fixed tiers
+during startup and its workspace tier later, once the workspace id resolves —
+the id does not exist at startup. So it makes **two** atomic calls, not one. Per
+call the guarantee is complete; the phrase "one transaction for the whole seed"
+in its §2.2 needs amending to say so. Failure isolation is unaffected.
+
+---
+
+## Tests
+
+`packages/core/__tests__/`, following the harness in
+`repositories/MetadataRepository.manifest.test.ts` (`openTestDatabase` +
+`setupDatabase`), which gives real SQLite transactions rather than mocks.
+
+**The atomicity test needs care.** An invalid manifest will not exercise
+rollback, because §2 validation means the transaction never opens. A genuine
+test must fail *inside* the transaction after at least one successful write —
+wrap the test adapter so the second `runAsync` throws — and then assert **zero**
+manifests exist, not one.
+
+| # | Test | Pins |
+| --- | --- | --- |
+| 1 | Batch writes every entry; each round-trips via `getManifest` | Basic contract |
+| 2 | Injected failure on the second write leaves **zero** manifests | Atomicity (P1) |
+| 3 | Invalid manifest → throws, `withTransactionAsync` never called, no rows | Fail-fast before the mutex (§2) |
+| 4 | Duplicate `entityId` → throws before any database contact | Ambiguous intent rejected (§2) |
+| 5 | Empty array → no transaction opened, returns empty lists | No-op (§2) |
+| 6 | `ifAbsent`: existing manifest untouched and reported in `skipped`; absent one in `written` | Create-if-absent (§3) |
+| 7 | Two concurrent batches converge on one manifest set; neither errors | Conflict-safety through the mutex (P3) |
+| 8 | Default (no `ifAbsent`) still overwrites an existing manifest | Today's behaviour preserved |
+| 9 | A value cached before the batch reads back new afterwards | Invalidation fires (§4) |
+| 10 | `setOntologyManifest` singular behaves identically, including mode default | Back-compat after delegation (§4) |
+
+---
+
+## Out of Scope
+
+**A public transaction runner on `WikiMemory`.** Considered and rejected. It
+would let consumers compose multi-step atomic operations, but it exposes the
+nested-transaction footgun (`tx.withTransactionAsync` throws) and the
+outer-handle deadlock to every consumer, in exchange for flexibility no current
+consumer has asked for. If a consumer later needs to make a manifest write
+atomic with an unrelated operation, this decision can be revisited without
+breaking the batch API.
+
+**An engine-side API for clearing typed classifications.** The motivating
+consumer also switches ontologies, which requires nulling `okf_type` across
+entries and tasks and deleting manifest-derived edges before reseeding. It does
+this today with raw SQL against a hardcoded `llm_wiki_` prefix, because
+`runOntologyBackfill` is additive-only and no clear API exists. That is a real
+gap and the same species of complaint as this spec, but it is not solvable by
+the same mechanism: the switch path interleaves an unbounded LLM-driven backfill
+loop between the clear and the reseed, and holding a write lock across LLM calls
+would block every other engine operation through the serialization mutex. It
+needs its own design.
+
+**Retrofitting `upsertGraph`'s transaction contract.** `upsertGraph(entityId,
+params, adapter)` requires the caller to supply the adapter it participates in —
+the same shape this spec rejects in P2. That was a deliberate requirement of its
+motivating consumer (a single-writer Lambda with its own transaction scope), so
+it is not presumptively wrong; but the safety analysis in P2 applies to any
+consumer holding only the unwrapped adapter, and the two contracts now differ.
+Worth a look, separately.
+
+**Issue [#86](https://github.com/equationalapplications/expo-llm-wiki/issues/86)
+(`expose upsertGraph`).** Related by root cause — engine capability reachable
+only from inside a method consumers do not call — but a different subsystem with
+a different risk profile. Cross-referenced, not bundled.
+
+---
+
+## References
+
+- Consumer spec: `curated-thoughts` →
+  `docs/superpowers/specs/2026-09-01-memory-architecture-intent-implementation-design.md` §2.2
+- `packages/core/src/WikiMemory.ts` — `setOntologyManifest` (the method being extended)
+- `packages/core/src/repositories/MetadataRepository.ts` — `setManifest` (the upsert in P3)
+- `packages/core/src/services/OntologyService.ts` — `getEffectiveState` (the cache/`tx` convention §4 follows)
+- `packages/core/src/repositories/EdgeRepository.ts` — `addIgnoreDuplicate` (the `changes`-based insert-or-skip idiom §3 reuses)
+- `packages/core/src/types.ts` — `SQLiteAdapter.withTransactionAsync` (the nested-transaction and outer-handle contract behind P2)
+- `packages/core/src/db/serializedAdapter.ts` — `withSerializedTransactions` (the mutex behind P2), applied in `WikiMemory`'s constructor at `WikiMemory.ts:88`
+- `docs/superpowers/specs/2026-07-09-transaction-serialization-spec.md` — the canonical design for that mutex
+- Prior art for house style: `docs/superpowers/specs/2026-08-14-wikimemory-public-api-extensions-design.md`

--- a/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
+++ b/docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md
@@ -1,7 +1,7 @@
 # Spec: Atomic Multi-Entity Manifest Seeding — `WikiMemory.setOntologyManifests`
 
 **Date:** 2026-09-02
-**Status:** Design approved — not yet implemented
+**Status:** Implemented (2026-09-02) — branch `spec/atomic-multi-entity-manifest-seed`
 **Issues:** none filed; raised from consumer review (see Consumer context)
 **Packages:** `@equationalapplications/core-llm-wiki`
 **Consumer context:** `equationalapplications/curated-thoughts` — spec

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -535,7 +535,11 @@ const wikiMemory = new WikiMemory(db, {
 });
 ```
 
-`seedManifests` entries are written to SQLite on first access when no row exists for that entity.
+`seedManifests` entries are written to SQLite the first time an entity's ontology is
+resolved *inside a transaction* (ingest, heal) and no row exists for it. A read outside a
+transaction — including `getOntologyManifest` — resolves the seed without persisting it, so
+a configured entity can report a manifest while still having no row in `entity_manifests`.
+That distinction matters for `ifAbsent` below.
 
 ### Public API
 
@@ -571,13 +575,20 @@ const { written, skipped } = await wikiMemory.setOntologyManifests(
   { ifAbsent: true },
 );
 // written: entities whose manifest this call wrote
-// skipped: entities that already had one (only under `ifAbsent`)
+// skipped: entities that already had a persisted manifest (only under `ifAbsent`)
 ```
 
 `ifAbsent` makes each write create-if-absent rather than an upsert, so a
 concurrent initializer loses the race by writing nothing instead of overwriting
 a manifest it never read. Omit it for replace-on-conflict, which is what
 `setOntologyManifest` does.
+
+**`ifAbsent` tests for a persisted row, not for an effective manifest.** An entity
+whose manifest comes from `WikiConfig.ontology.seedManifests` has no row until an
+ingest materializes one, so `ifAbsent` writes over the configured seed and reports
+the entity in `written`; after an ingest has run for that entity the same call
+reports it in `skipped`. Don't mix the two seeding routes for one entity: seed it
+through the config, or through this method, not both.
 
 The method takes data, never a transaction handle: `WikiMemory` serializes
 transactions on the adapter it is given, so a transaction opened on the adapter

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -559,6 +559,30 @@ await wikiMemory.setOntologyManifest('team-alpha', {
 }, { mode: 'strict' });
 ```
 
+Seed several entities atomically — all manifests are written in one transaction,
+so a failure partway through leaves none of them behind:
+
+```typescript
+const { written, skipped } = await wikiMemory.setOntologyManifests(
+  [
+    { entityId: 'tier_fact', manifest, mode: 'strict' },
+    { entityId: 'tier_wisdom', manifest, mode: 'strict' },
+  ],
+  { ifAbsent: true },
+);
+// written: entities whose manifest this call wrote
+// skipped: entities that already had one (only under `ifAbsent`)
+```
+
+`ifAbsent` makes each write create-if-absent rather than an upsert, so a
+concurrent initializer loses the race by writing nothing instead of overwriting
+a manifest it never read. Omit it for replace-on-conflict, which is what
+`setOntologyManifest` does.
+
+The method takes data, never a transaction handle: `WikiMemory` serializes
+transactions on the adapter it is given, so a transaction opened on the adapter
+you passed to `createWiki` would not participate in that serialization.
+
 ### Fact Shape Extensions
 
 In **Strict** and **Emergent** modes, librarian and ingest JSON may include typed facts with inline edges:

--- a/packages/core/__tests__/repositories/MetadataRepository.manifest.test.ts
+++ b/packages/core/__tests__/repositories/MetadataRepository.manifest.test.ts
@@ -60,4 +60,91 @@ describe('MetadataRepository — entity manifests', () => {
       expect(merged.edge_types.find(e => e.type === 'supplies')).toBeDefined();
     });
   });
+
+  const otherManifest: OntologyManifest = {
+    node_types: [{ type: 'team', description: 'A team.' }],
+    edge_types: [],
+  };
+
+  it('setManifest returns true when it writes a new row', async () => {
+    const wrote = await db.withTransactionAsync(async (tx) =>
+      repo.setManifest('entity1', { mode: 'strict', manifest: sampleManifest }, tx),
+    );
+    expect(wrote).toBe(true);
+  });
+
+  it('setManifest upserts by default and returns true', async () => {
+    await db.withTransactionAsync(async (tx) => {
+      await repo.setManifest('entity1', { mode: 'strict', manifest: sampleManifest }, tx);
+    });
+
+    const wrote = await db.withTransactionAsync(async (tx) =>
+      repo.setManifest('entity1', { mode: 'emergent', manifest: otherManifest }, tx),
+    );
+
+    expect(wrote).toBe(true);
+    expect(await repo.getManifest('entity1')).toEqual({
+      mode: 'emergent',
+      manifest: otherManifest,
+    });
+  });
+
+  it('setManifest with ifAbsent leaves an existing row alone and returns false', async () => {
+    await db.withTransactionAsync(async (tx) => {
+      await repo.setManifest('entity1', { mode: 'strict', manifest: sampleManifest }, tx);
+    });
+
+    const wrote = await db.withTransactionAsync(async (tx) =>
+      repo.setManifest(
+        'entity1',
+        { mode: 'emergent', manifest: otherManifest },
+        tx,
+        { ifAbsent: true },
+      ),
+    );
+
+    expect(wrote).toBe(false);
+    expect(await repo.getManifest('entity1')).toEqual({
+      mode: 'strict',
+      manifest: sampleManifest,
+    });
+  });
+
+  it('setManifest with ifAbsent writes when no row exists and returns true', async () => {
+    const wrote = await db.withTransactionAsync(async (tx) =>
+      repo.setManifest(
+        'entity2',
+        { mode: 'strict', manifest: sampleManifest },
+        tx,
+        { ifAbsent: true },
+      ),
+    );
+
+    expect(wrote).toBe(true);
+    expect(await repo.getManifest('entity2')).toEqual({
+      mode: 'strict',
+      manifest: sampleManifest,
+    });
+  });
+
+  it('setManifest still validates the manifest under ifAbsent', async () => {
+    await expect(
+      db.withTransactionAsync(async (tx) =>
+        repo.setManifest(
+          'entity3',
+          {
+            mode: 'strict',
+            manifest: {
+              node_types: [],
+              edge_types: [
+                { type: 'x', source_type: 'ghost', target_type: 'ghost', description: '' },
+              ],
+            },
+          },
+          tx,
+          { ifAbsent: true },
+        ),
+      ),
+    ).rejects.toThrow(/unknown node type/i);
+  });
 });

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -142,4 +142,70 @@ describe('WikiMemory.setOntologyManifests', () => {
     expect(spy).toHaveBeenCalledWith('tier_wisdom');
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  /** Wrap an adapter to count how many transactions were opened. */
+  function countingTransactions(inner: SQLiteAdapter): {
+    adapter: SQLiteAdapter;
+    count: () => number;
+  } {
+    let opened = 0;
+    const adapter: SQLiteAdapter = {
+      ...inner,
+      async withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+        opened += 1;
+        return inner.withTransactionAsync(fn);
+      },
+    };
+    return { adapter, count: () => opened };
+  }
+
+  it('returns empty lists for an empty batch without opening a transaction', async () => {
+    const counting = countingTransactions(db);
+    const wiki = await makeWiki(counting.adapter);
+    const before = counting.count();
+
+    const result = await wiki.setOntologyManifests([]);
+
+    expect(result).toEqual({ written: [], skipped: [] });
+    expect(counting.count()).toBe(before);
+  });
+
+  it('rejects a duplicate entityId before touching the database', async () => {
+    const wiki = await makeWiki(db);
+
+    await expect(
+      wiki.setOntologyManifests([
+        { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+        { entityId: 'tier_fact', manifest: manifestB, mode: 'strict' },
+      ]),
+    ).rejects.toThrow(/duplicate entityid.*tier_fact/i);
+
+    expect(await manifestCount(db)).toBe(0);
+  });
+
+  it('rejects an invalid manifest before opening a transaction', async () => {
+    const counting = countingTransactions(db);
+    const wiki = await makeWiki(counting.adapter);
+    const before = counting.count();
+
+    await expect(
+      wiki.setOntologyManifests([
+        { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+        {
+          entityId: 'tier_wisdom',
+          // edge endpoint references a node type this manifest never declares
+          manifest: {
+            node_types: [],
+            edge_types: [
+              { type: 'x', source_type: 'ghost', target_type: 'ghost', description: '' },
+            ],
+          },
+          mode: 'strict',
+        },
+      ]),
+    ).rejects.toThrow(/unknown node type/i);
+
+    expect(counting.count()).toBe(before);
+    expect(await manifestCount(db)).toBe(0);
+  });
 });

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -281,7 +281,12 @@ describe('WikiMemory.setOntologyManifests', () => {
     });
   });
 
-  it('two concurrent ifAbsent batches converge on one manifest set, neither erroring', async () => {
+  it('two overlapping ifAbsent batches on ONE instance converge, neither erroring', async () => {
+    // Scope note: both calls go through the same WikiMemory, so the per-instance
+    // mutex in `withSerializedTransactions` runs them back to back — this pins
+    // idempotent convergence, NOT a cross-instance race. It cannot distinguish
+    // the atomic `DO NOTHING` write from a check-then-write; the test below
+    // ('decides the conflict in a single statement') is what pins that.
     const wiki = await makeWiki(db);
     const entries = [
       { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' as const },
@@ -293,13 +298,80 @@ describe('WikiMemory.setOntologyManifests', () => {
       wiki.setOntologyManifests(entries, { ifAbsent: true }),
     ]);
 
-    // Serialized by the transaction mutex: one batch writes both, the other
-    // skips both. Neither throws, and the loser destroys nothing.
+    // One batch writes both, the other skips both. Neither throws, and the
+    // loser destroys nothing.
     const written = [...first.written, ...second.written].sort();
     const skipped = [...first.skipped, ...second.skipped].sort();
     expect(written).toEqual(['tier_fact', 'tier_wisdom']);
     expect(skipped).toEqual(['tier_fact', 'tier_wisdom']);
     expect(await manifestCount(db)).toBe(2);
+  });
+
+  /**
+   * Wrap an adapter to count reads of `entity_manifests`.
+   *
+   * `withTransactionAsync` is overridden for the same reason as in
+   * `failOnNthManifestWrite`: the base test adapter hands ITSELF to the
+   * callback, so without this the repository would receive the unwrapped
+   * adapter and the counters would never move.
+   */
+  function countingReads(inner: SQLiteAdapter): {
+    adapter: SQLiteAdapter;
+    reads: () => number;
+  } {
+    let reads = 0;
+    const count = (sql: string) => {
+      if (sql.includes('entity_manifests') && sql.trimStart().toUpperCase().startsWith('SELECT')) {
+        reads += 1;
+      }
+    };
+    const wrapped: SQLiteAdapter = {
+      ...inner,
+      async getFirstAsync<T>(sql: string, args?: unknown[]) {
+        count(sql);
+        return inner.getFirstAsync<T>(sql, args);
+      },
+      async getAllAsync<T>(sql: string, args?: unknown[]) {
+        count(sql);
+        return inner.getAllAsync<T>(sql, args);
+      },
+      async withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+        return inner.withTransactionAsync(() => fn(wrapped));
+      },
+    };
+    return { adapter: wrapped, reads: () => reads };
+  }
+
+  it('ifAbsent decides the conflict in a single statement, with no prior read', async () => {
+    // THE atomicity guarantee. `ifAbsent` must compile to one
+    // `INSERT ... ON CONFLICT DO NOTHING`, letting SQLite decide the winner —
+    // never a read-then-write, which reopens the TOCTOU window that `ifAbsent`
+    // exists to close. A separate-connection race can't be simulated on the
+    // single shared in-memory connection these tests use (a second concurrent
+    // BEGIN just errors), so pin the property that makes such a race safe:
+    // the write consults no prior read.
+    const counting = countingReads(db);
+    const wiki = await makeWiki(counting.adapter);
+
+    // Pre-existing row, so the second call is the conflict case: a
+    // check-then-write implementation MUST read here to learn it should skip.
+    await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+    ]);
+    const before = counting.reads();
+
+    const result = await wiki.setOntologyManifests(
+      [{ entityId: 'tier_fact', manifest: manifestB, mode: 'emergent' }],
+      { ifAbsent: true },
+    );
+
+    expect(result).toEqual({ written: [], skipped: ['tier_fact'] });
+    expect(counting.reads() - before).toBe(0);
+    // And the losing write left the existing row untouched.
+    expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+      mode: 'strict',
+      manifest: manifestA,
+    });
   });
 
   it('invalidates the cache for SKIPPED entries too, not just written ones', async () => {

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -18,6 +18,7 @@ const manifestB: OntologyManifest = {
   edge_types: [],
 };
 
+/** Spin up a `WikiMemory` against an in-memory test DB with a stub LLM provider. */
 async function makeWiki(db: SQLiteAdapter): Promise<WikiMemory> {
   const wiki = new WikiMemory(db, {
     llmProvider: {

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -296,4 +296,56 @@ describe('WikiMemory.setOntologyManifests', () => {
     expect(spy).toHaveBeenCalledWith('tier_wisdom');
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  describe('setOntologyManifest (singular) back-compat', () => {
+    it('writes a manifest with an explicit mode', async () => {
+      const wiki = await makeWiki(db);
+
+      await wiki.setOntologyManifest('tier_fact', manifestA, { mode: 'strict' });
+
+      expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+        mode: 'strict',
+        manifest: manifestA,
+      });
+    });
+
+    it('falls back to the resolved mode when options are omitted', async () => {
+      const wiki = await makeWiki(db);
+
+      await wiki.setOntologyManifest('tier_fact', manifestA);
+
+      expect((await wiki.getOntologyManifest('tier_fact'))?.mode).toBe('off');
+    });
+
+    it('overwrites an existing manifest (upsert semantics, unchanged)', async () => {
+      const wiki = await makeWiki(db);
+      await wiki.setOntologyManifest('tier_fact', manifestA, { mode: 'strict' });
+
+      await wiki.setOntologyManifest('tier_fact', manifestB, { mode: 'emergent' });
+
+      expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+        mode: 'emergent',
+        manifest: manifestB,
+      });
+    });
+
+    it('rejects an invalid manifest', async () => {
+      const wiki = await makeWiki(db);
+
+      await expect(
+        wiki.setOntologyManifest('tier_fact', {
+          node_types: [],
+          edge_types: [
+            { type: 'x', source_type: 'ghost', target_type: 'ghost', description: '' },
+          ],
+        }),
+      ).rejects.toThrow(/unknown node type/i);
+    });
+
+    it('resolves to undefined', async () => {
+      const wiki = await makeWiki(db);
+      const result = await wiki.setOntologyManifest('tier_fact', manifestA);
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WikiMemory } from '../src/WikiMemory';
+import { openTestDatabase } from './helpers/sqliteAdapter';
+import { setupDatabase } from '../src/db/schema';
+import type { OntologyManifest, SQLiteAdapter } from '../src/types';
+
+const PREFIX = 'llm_wiki_';
+
+const manifestA: OntologyManifest = {
+  node_types: [{ type: 'person', description: 'An individual.' }],
+  edge_types: [
+    { type: 'knows', source_type: 'person', target_type: 'person', description: 'Acquaintance.' },
+  ],
+};
+
+const manifestB: OntologyManifest = {
+  node_types: [{ type: 'team', description: 'A team.' }],
+  edge_types: [],
+};
+
+async function makeWiki(db: SQLiteAdapter): Promise<WikiMemory> {
+  const wiki = new WikiMemory(db, {
+    llmProvider: {
+      generateText: async () => JSON.stringify({ facts: [] }),
+      embed: async () => new Float32Array([0]),
+    },
+  });
+  await wiki.setup();
+  return wiki;
+}
+
+/** Count manifest rows without going through the engine. */
+async function manifestCount(db: SQLiteAdapter): Promise<number> {
+  const row = await db.getFirstAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM ${PREFIX}entity_manifests`,
+  );
+  return row?.n ?? 0;
+}
+
+/**
+ * Wrap an adapter so the Nth write to `entity_manifests` throws, simulating a
+ * failure partway through a batch.
+ *
+ * `withTransactionAsync` is overridden too, and deliberately: the base test
+ * adapter passes ITSELF as the `tx` handle, so without this override the
+ * callback would receive the unwrapped adapter and the injected failure would
+ * never fire inside the transaction.
+ */
+function failOnNthManifestWrite(db: SQLiteAdapter, n: number): SQLiteAdapter {
+  let writes = 0;
+  const wrapped: SQLiteAdapter = {
+    ...db,
+    async runAsync(sql: string, args?: unknown[]) {
+      if (sql.includes('entity_manifests')) {
+        writes += 1;
+        if (writes === n) throw new Error('injected mid-batch failure');
+      }
+      return db.runAsync(sql, args);
+    },
+    async withTransactionAsync<T>(fn: (tx: SQLiteAdapter) => Promise<T>): Promise<T> {
+      return db.withTransactionAsync(() => fn(wrapped));
+    },
+  };
+  return wrapped;
+}
+
+describe('WikiMemory.setOntologyManifests', () => {
+  let db: SQLiteAdapter;
+
+  beforeEach(async () => {
+    db = openTestDatabase();
+    await setupDatabase(db, PREFIX);
+  });
+
+  it('writes every entry and reports them as written', async () => {
+    const wiki = await makeWiki(db);
+
+    const result = await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+      { entityId: 'tier_wisdom', manifest: manifestB, mode: 'strict' },
+    ]);
+
+    expect(result).toEqual({ written: ['tier_fact', 'tier_wisdom'], skipped: [] });
+    expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+      mode: 'strict',
+      manifest: manifestA,
+    });
+    expect(await wiki.getOntologyManifest('tier_wisdom')).toEqual({
+      mode: 'strict',
+      manifest: manifestB,
+    });
+  });
+
+  it('falls back to the resolved mode when an entry omits one', async () => {
+    const wiki = await makeWiki(db);
+
+    await wiki.setOntologyManifests([{ entityId: 'tier_fact', manifest: manifestA }]);
+
+    const stored = await wiki.getOntologyManifest('tier_fact');
+    // No ontologyConfig is supplied, so resolveMode() yields 'off'.
+    expect(stored?.mode).toBe('off');
+  });
+
+  it('is atomic: a failure partway through leaves ZERO manifests', async () => {
+    // Fail on the SECOND manifest write, so the first has already succeeded
+    // inside the transaction. Without a single enclosing transaction this
+    // leaves one row behind; with one, it leaves none.
+    const failing = failOnNthManifestWrite(db, 2);
+    const wiki = await makeWiki(failing);
+
+    await expect(
+      wiki.setOntologyManifests([
+        { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+        { entityId: 'tier_wisdom', manifest: manifestB, mode: 'strict' },
+      ]),
+    ).rejects.toThrow(/injected mid-batch failure/);
+
+    expect(await manifestCount(db)).toBe(0);
+  });
+
+  it('invalidates the ontology cache for every entry after commit', async () => {
+    // White-box on purpose. The cache has no public observer: the only public
+    // reader, `getOntologyManifest`, queries the repository directly and never
+    // consults `OntologyService`'s cache, so a black-box assertion here would
+    // pass whether or not invalidation happened. The internal readers that DO
+    // use the cache (ingest, prompt assembly) go through
+    // `OntologyService.getEffectiveState`. `ontologyService` is `private` and
+    // is not exposed on `WikiMemoryTestAccess`, so reach it by cast —
+    // TypeScript `private` is compile-time only.
+    const wiki = await makeWiki(db);
+    const ontologyService = (wiki as unknown as {
+      ontologyService: { invalidateCache: (entityId: string) => void };
+    }).ontologyService;
+    const spy = vi.spyOn(ontologyService, 'invalidateCache');
+
+    await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+      { entityId: 'tier_wisdom', manifest: manifestB, mode: 'strict' },
+    ]);
+
+    expect(spy).toHaveBeenCalledWith('tier_fact');
+    expect(spy).toHaveBeenCalledWith('tier_wisdom');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -30,6 +30,22 @@ async function makeWiki(db: SQLiteAdapter): Promise<WikiMemory> {
   return wiki;
 }
 
+/**
+ * Read the raw `mode` column for an entity, bypassing the engine.
+ *
+ * Deliberately not `getOntologyManifest`: that reader pipes the row through
+ * `OntologyService.resolveMode(row.mode)`, so asserting on its result conflates
+ * what the WRITE persisted with what the READ resolved. These mode-fallback
+ * tests are about the write path, so they assert on the column itself.
+ */
+async function storedMode(db: SQLiteAdapter, entityId: string): Promise<string | undefined> {
+  const row = await db.getFirstAsync<{ mode: string }>(
+    `SELECT mode FROM ${PREFIX}entity_manifests WHERE entity_id = ?`,
+    [entityId],
+  );
+  return row?.mode;
+}
+
 /** Count manifest rows without going through the engine. */
 async function manifestCount(db: SQLiteAdapter): Promise<number> {
   const row = await db.getFirstAsync<{ n: number }>(
@@ -93,13 +109,29 @@ describe('WikiMemory.setOntologyManifests', () => {
   });
 
   it('falls back to the resolved mode when an entry omits one', async () => {
+    // No ontologyConfig: resolveMode() yields 'off'.
     const wiki = await makeWiki(db);
 
     await wiki.setOntologyManifests([{ entityId: 'tier_fact', manifest: manifestA }]);
 
-    const stored = await wiki.getOntologyManifest('tier_fact');
-    // No ontologyConfig is supplied, so resolveMode() yields 'off'.
-    expect(stored?.mode).toBe('off');
+    expect(await storedMode(db, 'tier_fact')).toBe('off');
+  });
+
+  it('falls back to ontologyConfig.mode (not just to "off") when an entry omits one', async () => {
+    // ontologyConfig.mode overrides the hard-coded 'off' default — the entry
+    // inherits the configured mode instead of 'off'.
+    const wiki = new WikiMemory(db, {
+      config: { ontology: { mode: 'strict' } },
+      llmProvider: {
+        generateText: async () => JSON.stringify({ facts: [] }),
+        embed: async () => new Float32Array([0]),
+      },
+    });
+    await wiki.setup();
+
+    await wiki.setOntologyManifests([{ entityId: 'tier_fact', manifest: manifestA }]);
+
+    expect(await storedMode(db, 'tier_fact')).toBe('strict');
   });
 
   it('is atomic: a failure partway through leaves ZERO manifests', async () => {

--- a/packages/core/__tests__/setOntologyManifests.test.ts
+++ b/packages/core/__tests__/setOntologyManifests.test.ts
@@ -208,4 +208,92 @@ describe('WikiMemory.setOntologyManifests', () => {
     expect(counting.count()).toBe(before);
     expect(await manifestCount(db)).toBe(0);
   });
+
+  it('ifAbsent leaves an existing manifest alone and reports it as skipped', async () => {
+    const wiki = await makeWiki(db);
+    await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+    ]);
+
+    const result = await wiki.setOntologyManifests(
+      [
+        { entityId: 'tier_fact', manifest: manifestB, mode: 'emergent' },
+        { entityId: 'tier_wisdom', manifest: manifestB, mode: 'emergent' },
+      ],
+      { ifAbsent: true },
+    );
+
+    expect(result).toEqual({ written: ['tier_wisdom'], skipped: ['tier_fact'] });
+    // The pre-existing manifest is untouched, mode included.
+    expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+      mode: 'strict',
+      manifest: manifestA,
+    });
+  });
+
+  it('without ifAbsent an existing manifest is still overwritten', async () => {
+    const wiki = await makeWiki(db);
+    await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+    ]);
+
+    const result = await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestB, mode: 'emergent' },
+    ]);
+
+    expect(result).toEqual({ written: ['tier_fact'], skipped: [] });
+    expect(await wiki.getOntologyManifest('tier_fact')).toEqual({
+      mode: 'emergent',
+      manifest: manifestB,
+    });
+  });
+
+  it('two concurrent ifAbsent batches converge on one manifest set, neither erroring', async () => {
+    const wiki = await makeWiki(db);
+    const entries = [
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' as const },
+      { entityId: 'tier_wisdom', manifest: manifestB, mode: 'strict' as const },
+    ];
+
+    const [first, second] = await Promise.all([
+      wiki.setOntologyManifests(entries, { ifAbsent: true }),
+      wiki.setOntologyManifests(entries, { ifAbsent: true }),
+    ]);
+
+    // Serialized by the transaction mutex: one batch writes both, the other
+    // skips both. Neither throws, and the loser destroys nothing.
+    const written = [...first.written, ...second.written].sort();
+    const skipped = [...first.skipped, ...second.skipped].sort();
+    expect(written).toEqual(['tier_fact', 'tier_wisdom']);
+    expect(skipped).toEqual(['tier_fact', 'tier_wisdom']);
+    expect(await manifestCount(db)).toBe(2);
+  });
+
+  it('invalidates the cache for SKIPPED entries too, not just written ones', async () => {
+    // A skipped entry means another writer won the race, so this instance's
+    // cached copy may be stale — dropping it is more correct than keeping it.
+    // This pins that decision, which is otherwise invisible.
+    const wiki = await makeWiki(db);
+    await wiki.setOntologyManifests([
+      { entityId: 'tier_fact', manifest: manifestA, mode: 'strict' },
+    ]);
+
+    const ontologyService = (wiki as unknown as {
+      ontologyService: { invalidateCache: (entityId: string) => void };
+    }).ontologyService;
+    const spy = vi.spyOn(ontologyService, 'invalidateCache');
+
+    const result = await wiki.setOntologyManifests(
+      [
+        { entityId: 'tier_fact', manifest: manifestB, mode: 'emergent' },
+        { entityId: 'tier_wisdom', manifest: manifestB, mode: 'emergent' },
+      ],
+      { ifAbsent: true },
+    );
+
+    expect(result.skipped).toEqual(['tier_fact']);
+    expect(spy).toHaveBeenCalledWith('tier_fact');   // skipped, still invalidated
+    expect(spy).toHaveBeenCalledWith('tier_wisdom');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -687,6 +687,52 @@ export class WikiMemory {
     this.ontologyService.invalidateCache(entityId);
   }
 
+  /**
+   * Write several entities' ontology manifests in a single transaction.
+   *
+   * All succeed or none do. The transaction is opened on this instance's
+   * serialized adapter — callers pass data, never a transaction handle, because
+   * a consumer holds the unwrapped adapter and a transaction opened on it would
+   * bypass the serialization mutex applied in the constructor.
+   *
+   * Returns which entities were written. `skipped` is only ever non-empty under
+   * `opts.ifAbsent`.
+   */
+  async setOntologyManifests(
+    entries: Array<{
+      entityId: string;
+      manifest: OntologyManifest;
+      mode?: OntologyMode;
+    }>,
+    opts?: { ifAbsent?: boolean },
+  ): Promise<{ written: string[]; skipped: string[] }> {
+    const written: string[] = [];
+    const skipped: string[] = [];
+
+    await this.db.withTransactionAsync(async (tx) => {
+      for (const entry of entries) {
+        const mode = entry.mode ?? this.ontologyService.resolveMode();
+        const wrote = await this.metadataRepo.setManifest(
+          entry.entityId,
+          { mode, manifest: entry.manifest },
+          tx,
+        );
+        (wrote ? written : skipped).push(entry.entityId);
+      }
+    });
+
+    // After commit, and for EVERY entry: a skipped entry means another writer
+    // won the race, so this instance's cached copy may be stale — dropping it
+    // is more correct than keeping it. Invalidation is safe regardless of the
+    // transaction's outcome, because it only removes a cached copy and the next
+    // read goes to the database.
+    for (const entry of entries) {
+      this.ontologyService.invalidateCache(entry.entityId);
+    }
+
+    return { written, skipped };
+  }
+
   /** Append a verification event to a fact. Does NOT touch `updated_at`. */
   async writeOkfTrust(entryId: string, entityId: string, verified: { by: string; at: string }[]): Promise<void> {
     return this.okfTrustWrites.writeOkfTrust(entryId, entityId, verified);

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -675,17 +675,17 @@ export class WikiMemory {
    * Seeds or replaces an entity's ontology manifest and optional mode override.
    * Validates manifest invariants (unique type slugs, edge endpoints reference node types).
    * Invalidates the in-memory ontology cache for this entity.
+   *
+   * Delegates to `setOntologyManifests` so there is a single write path. The
+   * observable contract is unchanged: same upsert semantics, same cache
+   * invalidation, same `void` result.
    */
   async setOntologyManifest(
     entityId: string,
     manifest: OntologyManifest,
     options?: { mode?: OntologyMode },
   ): Promise<void> {
-    const mode = options?.mode ?? this.ontologyService.resolveMode();
-    await this.db.withTransactionAsync(tx =>
-      this.metadataRepo.setManifest(entityId, { mode, manifest }, tx),
-    );
-    this.ontologyService.invalidateCache(entityId);
+    await this.setOntologyManifests([{ entityId, manifest, mode: options?.mode }]);
   }
 
   /**

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -698,6 +698,15 @@ export class WikiMemory {
    *
    * Returns which entities were written. `skipped` is only ever non-empty under
    * `opts.ifAbsent`.
+   *
+   * Sharp edge: `ifAbsent` checks for a PERSISTED row, not for an effective
+   * manifest. An entity whose manifest currently comes from
+   * `WikiConfig.ontology.seedManifests` has no row until the seed is
+   * materialized on first access that supplies a transaction (in practice, an
+   * ingest). Until then `ifAbsent` treats the entity as absent, writes the new
+   * manifest over the configured seed, and reports it in `written`; the same
+   * call after the seed has been materialized reports it in `skipped`. See the
+   * `ifAbsent` notes in the package README.
    */
   async setOntologyManifests(
     entries: Array<{
@@ -746,11 +755,14 @@ export class WikiMemory {
       }
     });
 
-    // After commit, and for EVERY entry: a skipped entry means another writer
-    // won the race, so this instance's cached copy may be stale — dropping it
-    // is more correct than keeping it. Invalidation is safe regardless of the
-    // transaction's outcome, because it only removes a cached copy and the next
-    // read goes to the database.
+    // After a successful commit, and for EVERY entry rather than just the
+    // written ones: under `ifAbsent` a skipped entry means another writer won
+    // the race, so this instance's cached copy may be stale and dropping it is
+    // more correct than keeping it. A failed transaction throws above and never
+    // reaches this loop, which is fine — a rolled-back batch changed nothing,
+    // so the cache is still consistent with the database. Invalidating is cheap
+    // either way: it only drops a cached copy, and the next read reloads from
+    // the database.
     for (const entry of entries) {
       this.ontologyService.invalidateCache(entry.entityId);
     }

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -740,6 +740,7 @@ export class WikiMemory {
           entry.entityId,
           { mode, manifest: entry.manifest },
           tx,
+          { ifAbsent: opts?.ifAbsent === true },
         );
         (wrote ? written : skipped).push(entry.entityId);
       }

--- a/packages/core/src/WikiMemory.ts
+++ b/packages/core/src/WikiMemory.ts
@@ -32,6 +32,7 @@ import { PromptService } from './services/PromptService';
 import { OntologyService } from './services/OntologyService';
 import { GraphTraversalService } from './services/GraphTraversalService';
 import { OkfTrustWritesRepository } from './db/okf-trust-writes';
+import { validateManifest } from './utils/ontology';
 import type { OntologyManifest, OntologyMode, GraphTraversalOptions, GraphNeighborhood, OntologyBackfillResult, HealResult, IngestDocumentResult } from './types';
 
 export { WikiBusyError, WikiTransactionError, PrunePartialFailureError, HOOK_TIMEOUT_MARKER, WikiStrictOntologyViolation, WikiSourceRefHashCollision, WikiParseError, WikiIngestEmptyError } from './types';
@@ -706,6 +707,29 @@ export class WikiMemory {
     }>,
     opts?: { ifAbsent?: boolean },
   ): Promise<{ written: string[]; skipped: string[] }> {
+    // Nothing to do — and deliberately no transaction, so an empty batch never
+    // takes the serialization mutex.
+    if (entries.length === 0) return { written: [], skipped: [] };
+
+    // Two entries naming one entity express ambiguous intent. Applying the last
+    // one silently would hide a caller bug whose symptom — a manifest that is
+    // not the one the caller believed it wrote — surfaces far from its cause.
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      if (seen.has(entry.entityId)) {
+        throw new Error(`Duplicate entityId in batch: ${entry.entityId}`);
+      }
+      seen.add(entry.entityId);
+    }
+
+    // Validate every manifest BEFORE opening the transaction, so a doomed batch
+    // never reaches the database and never takes the mutex. `setManifest`
+    // validates again inside the transaction; that is the invariant protecting
+    // every other repository caller, and is not redundant with this gate.
+    for (const entry of entries) {
+      validateManifest(entry.manifest);
+    }
+
     const written: string[] = [];
     const skipped: string[] = [];
 

--- a/packages/core/src/repositories/MetadataRepository.ts
+++ b/packages/core/src/repositories/MetadataRepository.ts
@@ -168,19 +168,36 @@ export class MetadataRepository extends BaseRepository {
     };
   }
 
+  /**
+   * Write an entity's manifest.
+   *
+   * `opts.ifAbsent` selects the conflict behaviour:
+   * - omitted / `false` — upsert. An existing row is replaced.
+   * - `true` — create-if-absent. An existing row is left exactly as it is.
+   *
+   * Returns whether this call actually wrote a row. Under `ifAbsent` a `false`
+   * result means another writer got there first; the check and the write are one
+   * statement, so there is no window between them.
+   */
   async setManifest(
     entityId: string,
     data: { mode: OntologyMode; manifest: OntologyManifest },
     tx: SQLiteAdapter,
-  ): Promise<void> {
+    opts?: { ifAbsent?: boolean },
+  ): Promise<boolean> {
     validateManifest(data.manifest);
     const executor = this.getExecutor(tx);
-    await executor.runAsync(
+    const conflictClause = opts?.ifAbsent
+      ? 'ON CONFLICT(entity_id) DO NOTHING'
+      : `ON CONFLICT(entity_id) DO UPDATE SET
+           mode = excluded.mode, manifest_json = excluded.manifest_json, updated_at = excluded.updated_at`;
+    const result = await executor.runAsync(
       `INSERT INTO ${this.prefix}entity_manifests (entity_id, mode, manifest_json, updated_at)
        VALUES (?, ?, ?, ?)
-       ON CONFLICT(entity_id) DO UPDATE SET mode = excluded.mode, manifest_json = excluded.manifest_json, updated_at = excluded.updated_at`,
+       ${conflictClause}`,
       [entityId, data.mode, JSON.stringify(data.manifest), Date.now()],
     );
+    return result.changes > 0;
   }
 
   async mergeManifestUpdates(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@ungap/structured-clone': ^1.3.1
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   fast-uri@>=2.0.0 <3.0.0: 2.4.4
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
@@ -3246,8 +3246,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastembed@2.1.0:
     resolution: {integrity: sha512-oQkpcRHBppJ3+a3w9dU0uytSY0N1cnEa/iVMc8AXEd+tvT529GekOEFhNviJy89R3lvQXF6cdIMTXHj1Gi00xQ==}
@@ -8299,7 +8299,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9352,7 +9352,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastembed@2.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
   '@ungap/structured-clone': ^1.3.1
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   fast-uri@>=2.0.0 <3.0.0: 2.4.4
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1


### PR DESCRIPTION
Add `WikiMemory.setOntologyManifests` for atomic, conflict-safe seeding of several ontology manifests in one transaction, and make the singular `setOntologyManifest` delegate to it. `opts.ifAbsent` switches the underlying upsert to `ON CONFLICT DO NOTHING`, closing the TOCTOU window that makes two concurrent initializers silently overwrite each other's manifests.

See [`docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md`](docs/superpowers/specs/2026-09-02-atomic-multi-entity-manifest-seed-design.md) for design and rationale.

- New public method `setOntologyManifests(entries, opts?)` returning `{ written, skipped }`
- `MetadataRepository.setManifest` gains `opts.ifAbsent` and reports whether it wrote
- Input validation (duplicates, manifest shape) runs before the transaction opens
- Singular `setOntologyManifest` delegates; observable contract unchanged
- README documents the method and the `ifAbsent` interaction with `seedManifests`
- 12 new tests in `__tests__/setOntologyManifests.test.ts`; 6 added to the existing repository test

No schema migration. No new outbox event. Singular method's signature, return type, and semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187MubfgYcykMfyoLb2zXwD