### PR TITLE
feat(core): embedding marker lifecycle (#121, #129)

### DIFF
--- a/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
+++ b/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
@@ -1,0 +1,447 @@
+# Embedding Marker Lifecycle & Scopelab Test Hygiene — Design
+
+**Status:** Approved, not yet implemented (2026-09-04)
+
+**Issues addressed:** #121 (markers survive provider/dimension change), #129
+(deferred #125/#126 self-review findings), #123 (executor off deprecated
+injector helper), #122 (scopelab suite needs built dist), #124 (index on
+`embedding_failed_at` — **closed without code**, §3)
+
+**Extends:** `2026-09-04-embedding-failure-and-scope-hygiene-design.md`
+(Status: Implemented), whose §3 shipped the marker system this spec now
+completes and whose §6 deferred the #123 migration as an explicit non-goal.
+
+---
+
+## 1. Why these five travel together
+
+Four of the five are follow-ups filed out of the same self-review round on
+2026-09-04 (PRs #125–#128); the fifth (#124) is a performance question raised
+in the same round. They share a deferral trail, not code. Bundling them in one
+spec keeps that trail auditable in one place; §7 splits them into independent
+PRs because their blast radii differ sharply — one changes host-observable
+embedding semantics, two touch only a demo app.
+
+Investigation (2026-09-04) verified every file:line claim below against `main`
+@ `2684121`. **Three investigation findings materially changed the shape of the
+work versus the issue text** — §3 (#124 has no query to optimize), §4.2 (#129's
+`EmbeddingMarkerKind` item is already done), and §4.3 (#129 names a method that
+does not exist; the real fix has two sites). Each is recorded where it applies.
+
+---
+
+## 2. #121 — Markers survive a provider or dimension change
+
+### 2.1 Problem
+
+Marker state is cleared in exactly one place: a successful
+`EntryRepository.updateEmbeddingBlob` (`packages/core/src/repositories/EntryRepository.ts:885-897`)
+sets `embedding_failed_at = NULL`, `embedding_failure_kind = NULL`,
+`embedding_attempts = 0`. Nothing else ever clears it.
+
+So a fact that reached `MAX_EMBED_ATTEMPTS` (5) or took a single
+`float32_overflow` under provider A stays permanently excluded under provider B.
+`classifyReembedRow` (`packages/core/src/services/MaintenanceService.ts:82-102`)
+returns `'permanent'` for those rows on every subsequent sweep. Permanently
+failed rows have **no embedding at all**, so they are invisible to vector
+retrieval — they are exactly the rows a new provider is most likely to fix.
+The only escape today is `runReembed({ force: true })`, which a host is
+unlikely to discover.
+
+### 2.2 Decision: reset on dimension promotion, plus a callability guard
+
+Approach chosen (issue option 1) over provider-identity tracking (option 2) and
+docs-only (option 3). Option 2 would need a host-supplied provider fingerprint
+in `WikiOptions` and new metadata bookkeeping, to cover only the
+same-dimension-swap case that `force: true` already handles. Not worth the
+machinery.
+
+**Investigation finding that makes option 1 viable.** It is not obvious that
+dimension promotion is even reachable while permanently-failed rows exist.
+It is: `countStaleEmbeddings` (`EntryRepository.ts:658-670`) counts a row stale
+only when it has a **wrong-dimension blob** or a legacy `embedding` value —
+
+```sql
+(embedding_blob IS NOT NULL AND (CAST(length(embedding_blob) AS INTEGER) / 4) != ?)
+OR (embedding_blob IS NULL AND embedding IS NOT NULL)
+```
+
+A permanently-failed row has `embedding_blob IS NULL` and `embedding IS NULL`,
+so it is **not** counted stale and does not block promotion. Promotion therefore
+fires, and the reset hung off it actually runs.
+
+### 2.3 Change
+
+`EmbeddingService.reconcileEmbeddingDimension`
+(`packages/core/src/services/EmbeddingService.ts:46-56`) currently promotes and
+clears the mismatch key. Add a marker reset to the promotion branch, so the
+three writes are one logical event:
+
+```ts
+if (residualCount === 0) {
+  await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, this.db);
+  await this.metadataRepo.clearDimensionMismatch(this.db);
+  await this.entryRepo.clearEmbeddingFailureMarkers();
+}
+```
+
+New DAO method on `EntryRepository`, mirroring `markEmbeddingFailure`'s
+discipline (no `updated_at` touch, no outbox event — embedding lifecycle is
+local state, not replicated; spec §3.5 of the parent design):
+
+```ts
+async clearEmbeddingFailureMarkers(tx?: SQLiteAdapter): Promise<number> {
+  const executor = this.getExecutor(tx);
+  const result = await executor.runAsync(
+    `UPDATE ${this.prefix}entries
+        SET embedding_failed_at = NULL,
+            embedding_failure_kind = NULL,
+            embedding_attempts = 0
+      WHERE embedding_failed_at IS NOT NULL`,
+  );
+  return result.changes;
+}
+```
+
+**`float32_overflow` is cleared too.** The parent spec calls it terminal because
+retrying is "the same deterministic arithmetic on the same vector" — but after a
+dimension change it is a *different model producing a different vector*, so the
+premise no longer holds. Clearing all kinds is correct here and is the one place
+where the terminal classification is deliberately overridden.
+
+Revived rows are not embedded inside `reconcileEmbeddingDimension`; they become
+eligible and are re-embedded on the **next** sweep. `runReembed` calls
+`reconcileEmbeddingDimension` at the end of its loop
+(`MaintenanceService.ts:414-416`), after candidates were already classified, so
+same-sweep revival would be a surprise re-entrancy. Next-sweep is the honest
+contract and gets documented on `runReembed`.
+
+### 2.4 Config errors must not burn attempts
+
+Raised in the #121 comment thread: `provider_error` is the catch-all for
+*anything* thrown in the embed phase (`EmbeddingService.ts:104-108`), so host
+misconfiguration counts toward `MAX_EMBED_ATTEMPTS` and can permanently exclude
+facts that were never the provider's fault.
+
+**Root cause found in investigation, with a targeted fix.** The guard at
+`EmbeddingService.ts:65-66` tests truthiness, not callability:
+
+```ts
+const embedFn = this.options.llmProvider.embed;
+if (!embedFn) return { ok: false, kind: 'no_provider' };
+```
+
+A truthy non-function (`embed: true`, an object, a malformed wrapper) passes
+this guard, reaches `await embedFn(text)`, throws `TypeError`, and is marked
+`provider_error` — burning an attempt per sweep until the fact is permanently
+excluded. Change to:
+
+```ts
+if (typeof embedFn !== 'function') return { ok: false, kind: 'no_provider' };
+```
+
+`no_provider` never marks (parent spec §3.3), so a misconfigured host now
+accumulates no marker state at all. The same guard exists in
+`MaintenanceService.runReembed` (`MaintenanceService.ts:345-346`) and gets the
+same treatment, so a bad config short-circuits the sweep rather than iterating.
+
+**Explicitly rejected:** a broader "non-`Error` throws don't count toward the
+ceiling" rule. It would add `instanceof Error` control flow, which #96's
+hostile-runtime audit specifically warns against (a Proxy `getPrototypeOf` trap
+can throw), and providers legitimately throw non-`Error` values — a rejected
+string from a fetch wrapper is a real provider failure that *should* count.
+The callability guard fixes the actual reported cause without either hazard.
+
+### 2.5 Residual, documented
+
+A **same-dimension provider swap** (1536-d model A → 1536-d model B) never sets
+`embedding_dimension_mismatch`, so promotion never fires and markers survive.
+`runReembed({ force: true })` remains the escape hatch. This is now a documented
+decision on `runReembed`'s doc comment, not a discovered limitation — which was
+the issue's stated goal.
+
+---
+
+## 3. #124 — Close without code (premise does not hold)
+
+The issue proposes a partial index on `embedding_failed_at` for "the
+`runReembed` candidate scan". Investigation: **no SQL anywhere filters on that
+column.** `findAllForReembed` (`EntryRepository.ts:944-955`) is:
+
+```sql
+SELECT * FROM entries WHERE deleted_at IS NULL          -- (+ AND entity_id = ? )
+```
+
+It fetches every live row and classification happens **in JavaScript**, via
+`classifyReembedRow` inside the loop (`MaintenanceService.ts:397-407`). SQLite
+would never consult the proposed index; it would be dead weight in migration v12
+plus write cost on every entry insert.
+
+**Action: close #124 as wontfix**, with a comment recording the actual query
+shape and noting that if sweep cost on large corpora ever matters, the fix is
+keyset batching of `findAllForReembed` (or pushing the disposition filter into
+SQL first, which would *then* justify the index) — not an index against a scan
+that does not filter.
+
+---
+
+## 4. #129 — Self-review follow-ups
+
+### 4.1 Stale marker survives an import carrying a valid blob (item 1)
+
+**Two investigation corrections to the issue text.** The issue names
+`EntryRepository.upsertFact` — no such method exists. The real sites are
+`upsert` (`EntryRepository.ts:154`, ON CONFLICT at `:187-202`) and
+`upsertForImport` (`:325`, ON CONFLICT at `:343-367`). **Both** are affected,
+not one: `upsert` sets `embedding_blob` via a `CASE WHEN excluded.embedding_blob
+IS NULL` guard and `upsertForImport` sets it unconditionally, and neither
+touches the marker columns. So a row locally marked failed, then written with a
+valid blob, ends up with a valid embedding **and** `embedding_failed_at IS NOT
+NULL`.
+
+Behaviorally inert today — a default `runReembed` sweep re-embeds everything and
+self-heals the marker, and classification gates on blob validity first
+(`MaintenanceService.ts:386-395`) — but contradictory as a diagnostic, and it
+silently inflates the `permanentlyFailed` counter a host may be watching.
+
+Fix: extend both SET clauses so a real incoming blob clears the markers.
+
+```sql
+embedding_failed_at    = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failed_at END,
+embedding_failure_kind = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failure_kind END,
+embedding_attempts     = CASE WHEN excluded.embedding_blob IS NOT NULL THEN 0    ELSE embedding_attempts     END
+```
+
+Note the asymmetry this preserves: an import with **no** blob leaves existing
+marker state alone, matching `upsert`'s existing "absent means don't touch"
+semantics for `embedding_blob` itself. Pinned by tests either way.
+
+### 4.2 Export `EmbeddingMarkerKind` (item 2) — already done, no change
+
+`EmbeddingMarkerKind` is declared at `packages/core/src/types.ts:875` and
+`packages/core/src/index.ts:4` is `export * from './types'`. The type is
+**already importable from the package root**; the issue's premise (that only
+`EmbedFactResult` and `EmbedFailureKind` are exported, via the explicit
+re-export on `index.ts:21`) mistook explicit re-export for reachability.
+
+**Action: tick the checkbox with an explanatory comment.** No redundant explicit
+export line — it would add a second maintenance point for zero reachability gain.
+
+### 4.3 `storage_error` from the dimension write (item 3)
+
+The taxonomy names both DAO writes in the storage domain, but the test at
+`packages/core/__tests__/services/EmbeddingService.test.ts:141-149` only rejects
+`updateEmbeddingBlob`. `storeEmbeddingDimension` (`EmbeddingService.ts:113`) is
+inside the same `try` and is equally a `storage_error` source. Add one test that
+rejects a `metadataRepo` write reached through `storeEmbeddingDimension` and
+asserts `{ ok: false, kind: 'storage_error' }` **and**
+`markEmbeddingFailure` not called (D3: storage errors never mark).
+
+### 4.4 Widen the `findAllForReembed` return type (item 4)
+
+It is typed `Promise<Array<WikiFact & { embedding_blob?: Uint8Array | null }>>`
+while its `SELECT *` also returns the three marker columns at runtime. That
+mismatch forces a `row as unknown as {…}` double cast at
+`MaintenanceService.ts:397-402` — a cast that would keep compiling if the
+columns were dropped. Introduce an exported type and return it:
+
+```ts
+export type ReembedCandidateRow = WikiFact & {
+  embedding_blob?: Uint8Array | null;
+  embedding_failed_at?: number | null;
+  embedding_failure_kind?: string | null;
+  embedding_attempts?: number | null;
+};
+```
+
+Both casts in `runReembed` then drop out (the `embedding_blob` cast at
+`MaintenanceService.ts:386` too), making the column dependency visible to the
+compiler.
+
+### 4.5 Jitter (item 5) — no change
+
+Rows failing in one sweep share `failed_at` and `attempts`, so a whole corpus
+becomes retry-eligible on the same tick. Fine for an on-device library with
+host-initiated sweeps. Recorded here so the reasoning survives: if retries ever
+fan out to a rate-limited API, add ±20% jitter inside `embedRetryDelayMs`
+(`MaintenanceService.ts:68-72`). No code now.
+
+---
+
+## 5. #123 — Migrate the scopelab executor off the deprecated helper
+
+### 5.1 Change
+
+`buildAuthorizedSchemaArray` is `@deprecated`
+(`packages/core-llm-tools/src/injector.ts:10-28`); its only production consumer
+is `apps/scopelab/src/lib/llm/function-caller.ts:33`. Migrate to
+`buildAuthorizedToolsArray` (`injector.ts:41-68`), which returns the full Gemini
+`tools[]` array, then delete the deprecated helper, its export
+(`core-llm-tools/src/index.ts:11`) and its dedicated tests.
+
+**Investigation finding — the call site needs more than a rename.** The two
+helpers return different shapes, and `function-caller.ts` uses the return value
+twice:
+
+1. **Request body** (`function-caller.ts:52`) currently wraps the schema array:
+   `tools: authorizedScopes.length ? [{ functionDeclarations: authorizedScopes }] : undefined`.
+   `buildAuthorizedToolsArray` already returns that wrapper, so the body becomes
+   `tools: authorizedTools.length ? authorizedTools : undefined`.
+2. **`advertisedNames`** (`function-caller.ts:76`) currently maps the flat schema
+   array. It must now flatten the `functionDeclarations` group instead:
+
+```ts
+const advertisedNames = new Set(
+  authorizedTools.flatMap(entry =>
+    'functionDeclarations' in entry ? entry.functionDeclarations.map(d => d.name) : []
+  )
+)
+```
+
+This also drops the `(s: any)` cast and the `s.name ?? s.function?.name`
+fallback, which was defensive against a shape that `GeminiToolEntry` now types
+precisely.
+
+**Behavior is unchanged for scopelab**: the two helpers differ only in their
+treatment of `kind: 'built_in'` manifests, and scopelab registers none
+(no `built_in` / `builtIn` / `google_search` anywhere under `apps/scopelab/src`).
+The fail-closed execution check at `function-caller.ts:77-82` is untouched — it
+still requires membership in `advertisedNames` **and** `isAuthorizedScope(t.scope)
+|| enabledScopes.includes(t.scope)`.
+
+### 5.2 Ride-alongs (from the #123 comment)
+
+**Loop the scope-sync execution test over every authorized scope.**
+`apps/scopelab/src/lib/llm/__tests__/scope-sync.test.ts:59-79` exercises only
+`AUTHORIZED_SCOPES[0]`. With a single-member list nothing distinguishes a
+re-hardcoded `['core']` from the imported guard; once the list grows, a reverted
+literal in `function-caller.ts` would still pass. Wrap the execution test in
+`for (const scope of AUTHORIZED_SCOPES)` so growth is covered automatically.
+This migration is the natural moment — the file is already being touched.
+
+**Freeze the exported array.** `packages/core-llm-tools/src/scopes.ts:13` is
+`as const satisfies readonly AgentScope[]` — compile-time only. A JS consumer
+(or TS via `any`) can `push()` at runtime and silently widen always-on
+authorization for every downstream `isAuthorizedScope` check in the process.
+Freeze so the runtime contract matches the type, in line with #96's posture:
+
+```ts
+export const AUTHORIZED_SCOPES = Object.freeze(['core'] as const) satisfies readonly AgentScope[];
+```
+
+Pinned by a test asserting a `push` attempt does not widen the array.
+
+---
+
+## 6. #122 — Scopelab tests must not depend on built dist
+
+### 6.1 Problem
+
+`pnpm --filter scopelab test` fails on a fresh clone with "Failed to resolve
+entry" until workspace packages are built. Cause: scopelab has **no vitest
+config**, so vitest inherits `apps/scopelab/vite.config.ts`, and workspace deps
+resolve through each package's `exports` map to `dist/`
+(`packages/core-llm-tools/package.json`). Nothing builds them first — the
+scopelab suite is not in a `pnpm -r` build-then-test ordering.
+
+### 6.2 Change (issue option 2)
+
+Add `apps/scopelab/vitest.config.ts` aliasing both workspace deps to source:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@equationalapplications/core-llm-tools': resolve(__dirname, '../../packages/core-llm-tools/src/index.ts'),
+      '@equationalapplications/core-llm-wiki': resolve(__dirname, '../../packages/core/src/index.ts'),
+    },
+  },
+  test: { environment: 'node' },
+})
+```
+
+Chosen over a `pretest` build script: it removes the dist dependency entirely
+rather than papering over it, eliminates stale-dist false positives (a suite
+passing against a `dist/` older than `src/`), keeps the feedback loop fast, and
+drops the PWA and wasm-copy plugins from the test path, where they do nothing.
+
+Because a dedicated `vitest.config.ts` takes precedence over `vite.config.ts`,
+it must carry any test-relevant settings; the current suites need none beyond
+the environment.
+
+**Verification is the point of this PR**: after the change, `rm -rf
+packages/*/dist` and run `pnpm --filter scopelab test` green from a clean tree.
+
+---
+
+## 7. PR breakdown
+
+| PR | Branch | Scope | Depends on |
+|----|--------|-------|------------|
+| **PR-0** | `docs/marker-lifecycle-spec` | This spec | — |
+| **PR-A** | `feat/marker-lifecycle` | §2 (#121 in full), §4.1/§4.3/§4.4 (#129 items 1, 3, 4) | PR-0 |
+| **PR-B** | `refactor/scopelab-executor` | §5 (#123 + both ride-alongs) | PR-0 |
+| **PR-C** | `fix/scopelab-vitest-source` | §6 (#122) | PR-0 |
+
+**Issue closures without code** (§3, §4.2), done independently of any PR:
+close #124 wontfix; tick #129 item 2 with the reachability explanation.
+
+**Why this split.** PR-A is the only PR that changes host-observable embedding
+semantics and the only one touching `packages/core` — it deserves review
+attention that scopelab plumbing would dilute. PR-B and PR-C both touch
+`apps/scopelab` but disjoint files (`function-caller.ts` + `scope-sync.test.ts`
+vs. a new `vitest.config.ts`), so they can run as parallel worktrees. PR-B is
+the only one that changes a published package's API surface (removing the
+deprecated export from `core-llm-tools`), which is a semver-minor concern worth
+isolating.
+
+#129's five items are deliberately **not** their own PR: items 1, 3 and 4 are
+marker-lifecycle correctness that belongs beside #121's reset in one reviewer
+context; item 2 is a no-op; item 5 is a decision to record, not code.
+
+**Merge discipline:** merge commits only, never squash — squashing breaks
+semantic-release changelogs in this repo. Spec and code land in separate
+commits. Within PR-A, the spec Status revision is appended, never replacing the
+record.
+
+---
+
+## 8. Testing
+
+TDD throughout: each behavior below gets a failing test first.
+
+**PR-A**
+- `clearEmbeddingFailureMarkers` clears all three columns for marked rows and
+  leaves unmarked rows untouched; returns the changed count.
+- `reconcileEmbeddingDimension` clears markers **only** on the promotion branch
+  (residual 0), not when promotion is blocked (residual > 0) and not when no
+  mismatch key is set.
+- A `float32_overflow` row is revived by promotion, and becomes `'attempt'` on
+  the next sweep (regression pin for the §2.3 override).
+- A permanently-failed row (no blob) does not block promotion — pins the
+  `countStaleEmbeddings` reachability the whole design rests on.
+- `embed: <truthy non-function>` yields `{ ok: false, kind: 'no_provider' }`,
+  writes **no** marker, and does not increment `embedding_attempts`; the same
+  input makes `runReembed` return all-zero counters without iterating.
+- `upsert` and `upsertForImport` each: an incoming valid blob clears markers on
+  a marked row; an incoming null blob leaves markers intact.
+- `storage_error` raised from `storeEmbeddingDimension` (§4.3).
+- `ReembedCandidateRow` is a typecheck-level change — `pnpm typecheck` with the
+  casts removed is the assertion.
+
+**PR-B**
+- Existing `function-caller.test.ts` and `scope-sync.test.ts` stay green through
+  the migration (they are the behavior-equivalence proof).
+- Scope-sync execution test loops all `AUTHORIZED_SCOPES` members.
+- `AUTHORIZED_SCOPES.push(...)` does not widen the array.
+- Grep gate: no `buildAuthorizedSchemaArray` reference survives outside git
+  history.
+
+**PR-C**
+- `rm -rf packages/*/dist && pnpm --filter scopelab test` is green.
+
+Each PR is green on its own package suite before review; a full-repo `pnpm test`
+runs before PR-A merges, since it is the only PR changing behavior hosts observe.

--- a/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
+++ b/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
@@ -408,8 +408,11 @@ attention that scopelab plumbing would dilute. PR-B and PR-C both touch
 `apps/scopelab` but disjoint files (`function-caller.ts` + `scope-sync.test.ts`
 vs. a new `vitest.config.ts`), so they can run as parallel worktrees. PR-B is
 the only one that changes a published package's API surface (removing the
-deprecated export from `core-llm-tools`), which is a semver-minor concern worth
-isolating.
+deprecated export from `core-llm-tools`), which is a **semver-major** concern
+worth isolating: `buildAuthorizedSchemaArray` was a public export, so removing
+it breaks any consumer still importing it. PR-B lands as a `!`-marked
+Conventional Commit (`refactor(core-llm-tools)!:`) so semantic-release cuts a
+major for the package rather than a minor.
 
 #129's five items are deliberately **not** their own PR: items 1, 3 and 4 are
 marker-lifecycle correctness that belongs beside #121's reset in one reviewer

--- a/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
+++ b/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
@@ -2,6 +2,8 @@
 
 **Status:** Approved, not yet implemented (2026-09-04)
 
+**Status (2026-09-04):** §2, §4.1, §4.3, §4.4 implemented via `feat/marker-lifecycle` (2026-09-04), pending merge. §5, §6 pending in their own PRs.
+
 **Issues addressed:** #121 (markers survive provider/dimension change), #129
 (deferred #125/#126 self-review findings), #123 (executor off deprecated
 injector helper), #122 (scopelab suite needs built dist), #124 (index on

--- a/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
+++ b/docs/superpowers/specs/2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md
@@ -77,15 +77,26 @@ fires, and the reset hung off it actually runs.
 `EmbeddingService.reconcileEmbeddingDimension`
 (`packages/core/src/services/EmbeddingService.ts:46-56`) currently promotes and
 clears the mismatch key. Add a marker reset to the promotion branch, so the
-three writes are one logical event:
+three writes are one logical event — and commit them in one transaction, so
+they are one event in the database too:
 
 ```ts
 if (residualCount === 0) {
-  await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, this.db);
-  await this.metadataRepo.clearDimensionMismatch(this.db);
-  await this.entryRepo.clearEmbeddingFailureMarkers();
+  await this.db.withTransactionAsync(async (tx) => {
+    await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, tx);
+    await this.metadataRepo.clearDimensionMismatch(tx);
+    await this.entryRepo.clearEmbeddingFailureMarkers(tx);
+  });
 }
 ```
+
+**Why one transaction.** Committed separately, a failure after
+`clearDimensionMismatch` succeeds would leave the markers set with no
+`embedding_dimension_mismatch` key left to re-trigger promotion — the rows
+strand until someone runs `runReembed({ force: true })`. Opening a transaction
+here is safe because both callers — `runReembed` and `importDump`'s dimension
+reconciliation — invoke `reconcileEmbeddingDimension` outside their own
+transactions, and the adapter does not support nesting (`types.ts:25`).
 
 New DAO method on `EntryRepository`, mirroring `markEmbeddingFailure`'s
 discipline (no `updated_at` touch, no outbox event — embedding lifecycle is

--- a/packages/core/__tests__/embeddingFailureMarkers.test.ts
+++ b/packages/core/__tests__/embeddingFailureMarkers.test.ts
@@ -94,4 +94,39 @@ describe('EntryRepository embedding failure markers', () => {
     const after = await getMarkerRow(db, 'f5');
     expect(after?.updated_at).toBe(before?.updated_at);
   });
+
+  it('clearEmbeddingFailureMarkers resets all three columns on marked rows', async () => {
+    const { repo, db } = await makeWikiWithFact('f1');
+    await repo.markEmbeddingFailure('f1', 'float32_overflow', 1000);
+
+    const changed = await repo.clearEmbeddingFailureMarkers();
+
+    expect(changed).toBe(1);
+    const row = await getMarkerRow(db, 'f1');
+    expect(row?.embedding_failed_at).toBeNull();
+    expect(row?.embedding_failure_kind).toBeNull();
+    expect(row?.embedding_attempts).toBe(0);
+  });
+
+  it('clearEmbeddingFailureMarkers leaves unmarked rows untouched and reports 0', async () => {
+    const { repo, db } = await makeWikiWithFact('f1');
+    const before = await getMarkerRow(db, 'f1');
+
+    const changed = await repo.clearEmbeddingFailureMarkers();
+
+    expect(changed).toBe(0);
+    const after = await getMarkerRow(db, 'f1');
+    expect(after?.updated_at).toBe(before?.updated_at);
+  });
+
+  it('clearEmbeddingFailureMarkers does not touch updated_at on a marked row', async () => {
+    const { repo, db } = await makeWikiWithFact('f1');
+    const before = await getMarkerRow(db, 'f1');
+    await repo.markEmbeddingFailure('f1', 'provider_error', 1000);
+
+    await repo.clearEmbeddingFailureMarkers();
+
+    const after = await getMarkerRow(db, 'f1');
+    expect(after?.updated_at).toBe(before?.updated_at);
+  });
 });

--- a/packages/core/__tests__/embeddingFailureMarkers.test.ts
+++ b/packages/core/__tests__/embeddingFailureMarkers.test.ts
@@ -130,6 +130,41 @@ describe('EntryRepository embedding failure markers', () => {
     expect(after?.updated_at).toBe(before?.updated_at);
   });
 
+  it('dimension promotion commits all three writes atomically', async () => {
+    // The promotion is one logical event: canonical dimension, mismatch key,
+    // and marker clear. If the marker clear fails after the mismatch key is
+    // gone, nothing is left to re-trigger promotion and the markers strand
+    // until `force: true`. Pin the rollback, not just the happy path.
+    const { wiki, db, repo } = await makeWikiWithFact('f1');
+    await repo.markEmbeddingFailure('f1', 'float32_overflow', 1000);
+
+    const metadataRepo = (wiki as any).metadataRepo;
+    const embeddingService = (wiki as any).embeddingService;
+    await metadataRepo.setMeta('embedding_dimension', '3', db);
+    await metadataRepo.setMeta('embedding_dimension_mismatch', '4', db);
+
+    const original = repo.clearEmbeddingFailureMarkers.bind(repo);
+    repo.clearEmbeddingFailureMarkers = async () => {
+      throw new Error('boom');
+    };
+
+    await expect(embeddingService.reconcileEmbeddingDimension()).rejects.toThrow('boom');
+
+    // Every write rolled back: mismatch key intact, dimension un-promoted,
+    // markers still set — so the next promotion attempt still has its trigger.
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBe('4');
+    expect(await metadataRepo.getMeta('embedding_dimension')).toBe('3');
+    const row = await getMarkerRow(db, 'f1');
+    expect(row?.embedding_failure_kind).toBe('float32_overflow');
+
+    // And the same promotion succeeds once the failure clears.
+    repo.clearEmbeddingFailureMarkers = original;
+    await embeddingService.reconcileEmbeddingDimension();
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBeNull();
+    expect(await metadataRepo.getMeta('embedding_dimension')).toBe('4');
+    expect((await getMarkerRow(db, 'f1'))?.embedding_failure_kind).toBeNull();
+  });
+
   it('upsert with a valid blob clears stale markers', async () => {
     const { repo, db } = await makeWikiWithFact('f1');
     await repo.markEmbeddingFailure('f1', 'provider_error', 1000);

--- a/packages/core/__tests__/embeddingFailureMarkers.test.ts
+++ b/packages/core/__tests__/embeddingFailureMarkers.test.ts
@@ -129,4 +129,70 @@ describe('EntryRepository embedding failure markers', () => {
     const after = await getMarkerRow(db, 'f1');
     expect(after?.updated_at).toBe(before?.updated_at);
   });
+
+  it('upsert with a valid blob clears stale markers', async () => {
+    const { repo, db } = await makeWikiWithFact('f1');
+    await repo.markEmbeddingFailure('f1', 'provider_error', 1000);
+
+    const fact = {
+      id: 'f1', entity_id: 'e1', title: 'T2', body: 'B2', tags: [],
+      confidence: 'certain', source_type: 'user_stated',
+      source_hash: null, source_ref: null,
+      created_at: 1_700_000_000_000, updated_at: 1_700_000_000_000,
+      last_accessed_at: null, access_count: 0, deleted_at: null, okf_type: 'fact',
+      embedding_blob: new Uint8Array(new Float32Array([1, 0, 0]).buffer),
+    } as any;
+    await db.withTransactionAsync(async (tx) => { await repo.upsert(fact, tx); });
+
+    const row = await getMarkerRow(db, 'f1');
+    expect(row?.embedding_failed_at).toBeNull();
+    expect(row?.embedding_failure_kind).toBeNull();
+    expect(row?.embedding_attempts).toBe(0);
+  });
+
+  it('upsert WITHOUT a blob leaves existing markers intact', async () => {
+    const { repo, db } = await makeWikiWithFact('f1');
+    await repo.markEmbeddingFailure('f1', 'provider_error', 1000);
+
+    const fact = {
+      id: 'f1', entity_id: 'e1', title: 'T3', body: 'B3', tags: [],
+      confidence: 'certain', source_type: 'user_stated',
+      source_hash: null, source_ref: null,
+      created_at: 1_700_000_000_000, updated_at: 1_700_000_000_000,
+      last_accessed_at: null, access_count: 0, deleted_at: null, okf_type: 'fact',
+      embedding_blob: null,
+    } as any;
+    await db.withTransactionAsync(async (tx) => { await repo.upsert(fact, tx); });
+
+    const row = await getMarkerRow(db, 'f1');
+    expect(row?.embedding_failed_at).toBe(1000);
+    expect(row?.embedding_failure_kind).toBe('provider_error');
+    expect(row?.embedding_attempts).toBe(1);
+  });
+
+  it('importDump carrying a valid blob clears a stale marker (upsertForImport)', async () => {
+    const { wiki, repo, db } = await makeWikiWithFact('f1');
+    await repo.markEmbeddingFailure('f1', 'float32_overflow', 1000);
+
+    await wiki.importDump({
+      generatedAt: 1_700_000_001_000,
+      entities: {
+        e1: {
+          facts: [{
+            id: 'f1', entity_id: 'e1', title: 'T', body: 'B', tags: [],
+            confidence: 'certain', source_type: 'user_stated',
+            source_hash: null, source_ref: null,
+            created_at: 1_700_000_000_000, updated_at: 1_700_000_001_000,
+            last_accessed_at: null, access_count: 0, deleted_at: null, okf_type: 'fact',
+            embedding_blob: new Uint8Array(new Float32Array([1, 0, 0]).buffer),
+          }],
+          tasks: [], events: [], edges: [], summary: '',
+        },
+      },
+    } as any);
+
+    const row = await getMarkerRow(db, 'f1');
+    expect(row?.embedding_failed_at).toBeNull();
+    expect(row?.embedding_attempts).toBe(0);
+  });
 });

--- a/packages/core/__tests__/embeddingFailureMarkers.test.ts
+++ b/packages/core/__tests__/embeddingFailureMarkers.test.ts
@@ -193,6 +193,7 @@ describe('EntryRepository embedding failure markers', () => {
 
     const row = await getMarkerRow(db, 'f1');
     expect(row?.embedding_failed_at).toBeNull();
+    expect(row?.embedding_failure_kind).toBeNull();
     expect(row?.embedding_attempts).toBe(0);
   });
 });

--- a/packages/core/__tests__/runReembed.test.ts
+++ b/packages/core/__tests__/runReembed.test.ts
@@ -139,6 +139,40 @@ describe('runReembed()', () => {
     expect(err).toBeInstanceOf(WikiBusyError);
     expect(err.operation).toBe('forget');
   });
+
+  it('a permanently-failed row does not block dimension promotion, and is revived by it', async () => {
+    // Provider returns 3-d vectors; a stored dimension of 4 forces a mismatch.
+    const { wiki, db } = makeWiki(async () => [1, 0, 0]);
+    await wiki.setup();
+    await insertFact(db, 'f-ok', 'user-1');
+    await insertFact(db, 'f-dead', 'user-1');
+    await db.runAsync(`INSERT OR REPLACE INTO llm_wiki_meta (key, value) VALUES ('embedding_dimension', '4')`);
+    // f-dead is terminally marked: float32_overflow is permanent by classification.
+    await db.runAsync(
+      `UPDATE llm_wiki_entries
+          SET embedding_failed_at = 1, embedding_failure_kind = 'float32_overflow', embedding_attempts = 1
+        WHERE id = 'f-dead'`,
+    );
+
+    // Sweep 1: f-ok embeds (setting the mismatch key), f-dead is classified permanent.
+    const first = await wiki.runReembed();
+    expect(first.permanentlyFailed).toBe(1);
+    expect(first.embedded).toBe(1);
+
+    // Promotion happened despite the marked row, and cleared its marker.
+    const markerRow = await db.getFirstAsync<{ embedding_failed_at: number | null }>(
+      `SELECT embedding_failed_at FROM llm_wiki_entries WHERE id = 'f-dead'`,
+    );
+    expect(markerRow?.embedding_failed_at).toBeNull();
+
+    // Sweep 2: the revived row is attempted and embeds.
+    const second = await wiki.runReembed();
+    expect(second.permanentlyFailed).toBe(0);
+    const blobRow = await db.getFirstAsync<{ embedding_blob: Uint8Array | null }>(
+      `SELECT embedding_blob FROM llm_wiki_entries WHERE id = 'f-dead'`,
+    );
+    expect(blobRow?.embedding_blob).not.toBeNull();
+  });
 });
 
 describe('runReembed() retry orchestration', () => {

--- a/packages/core/__tests__/runReembed.test.ts
+++ b/packages/core/__tests__/runReembed.test.ts
@@ -173,6 +173,22 @@ describe('runReembed()', () => {
     );
     expect(blobRow?.embedding_blob).not.toBeNull();
   });
+
+  it('a non-callable embed short-circuits the sweep without marking anything', async () => {
+    const { wiki, db } = makeWiki(undefined);
+    (wiki as any).options.llmProvider.embed = {} as any;
+    await wiki.setup();
+    await insertFact(db, 'f1', 'user-1');
+
+    const result = await wiki.runReembed();
+
+    expect(result).toEqual({ embedded: 0, skipped: 0, failed: 0, deferred: 0, permanentlyFailed: 0 });
+    const row = await db.getFirstAsync<{ embedding_failed_at: number | null; embedding_attempts: number }>(
+      `SELECT embedding_failed_at, embedding_attempts FROM llm_wiki_entries WHERE id = 'f1'`,
+    );
+    expect(row?.embedding_failed_at).toBeNull();
+    expect(row?.embedding_attempts).toBe(0);
+  });
 });
 
 describe('runReembed() retry orchestration', () => {

--- a/packages/core/__tests__/services/EmbeddingService.test.ts
+++ b/packages/core/__tests__/services/EmbeddingService.test.ts
@@ -149,6 +149,20 @@ describe('EmbeddingService', () => {
       expect(mockEntryRepo.markEmbeddingFailure).not.toHaveBeenCalled();
     });
 
+    it('storage_error: a failing dimension write is classified but NOT marked', async () => {
+      // Good vector from the provider, but storeEmbeddingDimension's metadata
+      // write throws. Same failure domain as the blob write (spec §4.3, D3).
+      mockOptions.llmProvider.embed!.mockResolvedValue([0.1, 0.2, 0.3]);
+      mockMetadataRepo.getMeta.mockResolvedValue(null);
+      mockMetadataRepo.setMeta.mockRejectedValueOnce(new Error('meta write failed'));
+
+      const res = await embeddingService.tryEmbedFact({ id: 'f1', entity_id: 'e1', title: 'T', body: 'B', tags: [] });
+
+      expect(res).toEqual({ ok: false, kind: 'storage_error' });
+      expect(mockEntryRepo.markEmbeddingFailure).not.toHaveBeenCalled();
+      expect(mockEntryRepo.updateEmbeddingBlob).not.toHaveBeenCalled();
+    });
+
     it('success returns the dimension', async () => {
       mockOptions.llmProvider.embed!.mockResolvedValue([0.1, 0.2, 0.3]);
       const res = await embeddingService.tryEmbedFact(fact);

--- a/packages/core/__tests__/services/EmbeddingService.test.ts
+++ b/packages/core/__tests__/services/EmbeddingService.test.ts
@@ -11,7 +11,13 @@ describe('EmbeddingService', () => {
   let embeddingService: EmbeddingService;
 
   beforeEach(() => {
-    mockDb = {}; // Pass-through for tx queries
+    // withTransactionAsync runs the callback with the adapter itself as the tx
+    // handle: these unit tests assert call arguments, not commit semantics, and
+    // the real rollback behaviour is covered against a live SQLite adapter in
+    // __tests__/embeddingFailureMarkers.test.ts.
+    mockDb = {
+      withTransactionAsync: async (fn: (tx: unknown) => Promise<unknown>) => fn(mockDb),
+    };
 
     mockOptions = {
       llmProvider: {

--- a/packages/core/__tests__/services/EmbeddingService.test.ts
+++ b/packages/core/__tests__/services/EmbeddingService.test.ts
@@ -28,6 +28,7 @@ describe('EmbeddingService', () => {
       updateEmbeddingBlob: vi.fn().mockResolvedValue(undefined),
       markEmbeddingFailure: vi.fn().mockResolvedValue(undefined),
       countStaleEmbeddings: vi.fn().mockResolvedValue(0),
+      clearEmbeddingFailureMarkers: vi.fn().mockResolvedValue(0),
     };
 
     mockMetadataRepo = {
@@ -253,6 +254,37 @@ describe('EmbeddingService', () => {
       await embeddingService.notifyEmbeddingPersistedOrThrow('e1', 'f1', null);
 
       expect(mockOptions.vectorRanker!.onEmbeddingPersisted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconcileEmbeddingDimension marker reset (spec §2.3)', () => {
+    it('clears markers when the new dimension is promoted', async () => {
+      mockMetadataRepo.getMeta.mockResolvedValue('1536');
+      mockEntryRepo.countStaleEmbeddings.mockResolvedValue(0);
+
+      await embeddingService.reconcileEmbeddingDimension();
+
+      expect(mockMetadataRepo.setMeta).toHaveBeenCalledWith('embedding_dimension', '1536', expect.anything());
+      expect(mockMetadataRepo.clearDimensionMismatch).toHaveBeenCalled();
+      expect(mockEntryRepo.clearEmbeddingFailureMarkers).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT clear markers when promotion is blocked by residual stale rows', async () => {
+      mockMetadataRepo.getMeta.mockResolvedValue('1536');
+      mockEntryRepo.countStaleEmbeddings.mockResolvedValue(3);
+
+      await embeddingService.reconcileEmbeddingDimension();
+
+      expect(mockMetadataRepo.setMeta).not.toHaveBeenCalledWith('embedding_dimension', '1536', expect.anything());
+      expect(mockEntryRepo.clearEmbeddingFailureMarkers).not.toHaveBeenCalled();
+    });
+
+    it('does NOT clear markers when no mismatch key is set', async () => {
+      mockMetadataRepo.getMeta.mockResolvedValue(null);
+
+      await embeddingService.reconcileEmbeddingDimension();
+
+      expect(mockEntryRepo.clearEmbeddingFailureMarkers).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/__tests__/services/EmbeddingService.test.ts
+++ b/packages/core/__tests__/services/EmbeddingService.test.ts
@@ -287,4 +287,27 @@ describe('EmbeddingService', () => {
       expect(mockEntryRepo.clearEmbeddingFailureMarkers).not.toHaveBeenCalled();
     });
   });
+
+  describe('non-callable embed provider (spec §2.4)', () => {
+    it('returns no_provider and writes NO marker when embed is a truthy non-function', async () => {
+      (mockOptions.llmProvider as any).embed = { not: 'a function' };
+      const fact = { id: 'f1', entity_id: 'e1', title: 'T', body: 'B', tags: [] };
+
+      const res = await embeddingService.tryEmbedFact(fact);
+
+      expect(res).toEqual({ ok: false, kind: 'no_provider' });
+      expect(mockEntryRepo.markEmbeddingFailure).not.toHaveBeenCalled();
+      expect(mockEntryRepo.updateEmbeddingBlob).not.toHaveBeenCalled();
+    });
+
+    it('still returns no_provider when embed is undefined', async () => {
+      (mockOptions.llmProvider as any).embed = undefined;
+      const fact = { id: 'f1', entity_id: 'e1', title: 'T', body: 'B', tags: [] };
+
+      const res = await embeddingService.tryEmbedFact(fact);
+
+      expect(res).toEqual({ ok: false, kind: 'no_provider' });
+      expect(mockEntryRepo.markEmbeddingFailure).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -16,6 +16,19 @@ export type EntryRowWithEmbeddings = EntryRowMetadata & {
   embedding: string | null;
 };
 
+/**
+ * One row of the reembed candidate scan. `findAllForReembed` does `SELECT *`,
+ * so the marker columns come back at runtime; naming them here makes that
+ * dependency visible to the compiler instead of hiding it behind a cast in
+ * MaintenanceService.runReembed (spec §4.4).
+ */
+export type ReembedCandidateRow = WikiFact & {
+  embedding_blob?: Uint8Array | null;
+  embedding_failed_at?: number | null;
+  embedding_failure_kind?: string | null;
+  embedding_attempts?: number | null;
+};
+
 function mapRowToFact(row: any): WikiFact {
   const tags: string[] = (() => {
     if (Array.isArray(row.tags)) return row.tags;
@@ -976,7 +989,7 @@ export class EntryRepository extends BaseRepository {
     return row?.count ?? 0;
   }
 
-  async findAllForReembed(entityId?: string, tx?: SQLiteAdapter): Promise<Array<WikiFact & { embedding_blob?: Uint8Array | null }>> {
+  async findAllForReembed(entityId?: string, tx?: SQLiteAdapter): Promise<ReembedCandidateRow[]> {
     const executor = this.getExecutor(tx);
     if (entityId !== undefined) {
       return executor.getAllAsync(

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -923,6 +923,28 @@ export class EntryRepository extends BaseRepository {
     );
   }
 
+  /**
+   * Clear marker state for every marked row. Called when the embedding
+   * dimension is promoted: a new model produces different vectors, so past
+   * failures — including `float32_overflow`, which is otherwise terminal —
+   * no longer predict future ones (spec §2.3).
+   *
+   * Same discipline as markEmbeddingFailure: no `updated_at` touch and no
+   * outbox event, because embedding lifecycle is local state, not replicated.
+   * Returns the number of rows cleared.
+   */
+  async clearEmbeddingFailureMarkers(tx?: SQLiteAdapter): Promise<number> {
+    const executor = this.getExecutor(tx);
+    const result = await executor.runAsync(
+      `UPDATE ${this.prefix}entries
+          SET embedding_failed_at = NULL,
+              embedding_failure_kind = NULL,
+              embedding_attempts = 0
+        WHERE embedding_failed_at IS NOT NULL`,
+    );
+    return result.changes;
+  }
+
   async hasLegacySourceTypes(tx?: SQLiteAdapter): Promise<boolean> {
     const executor = this.getExecutor(tx);
     const row = await executor.getFirstAsync<{ one: number }>(

--- a/packages/core/src/repositories/EntryRepository.ts
+++ b/packages/core/src/repositories/EntryRepository.ts
@@ -150,6 +150,13 @@ export class EntryRepository extends BaseRepository {
    * New-row INSERTs still bind a value so the column is populated; if the
    * caller supplied nothing, the schema DEFAULT 'stable' applies when the
    * bind is bound as 'stable' explicitly here.
+   *
+   * Marker discipline (spec §4.1): a conflict carrying a real
+   * `embedding_blob` clears the embedding failure markers, because the row now
+   * HAS a valid embedding and a surviving marker would be a self-contradictory
+   * diagnostic that inflates runReembed's permanentlyFailed counter. A conflict
+   * with no blob leaves marker state alone, matching the "absent means don't
+   * touch" semantics used for embedding_blob itself.
    */
   async upsert(fact: WikiFact, tx: SQLiteAdapter): Promise<{ changes: number; lastInsertRowId: number }> {
     const executor = this.getExecutor(tx);
@@ -199,6 +206,9 @@ export class EntryRepository extends BaseRepository {
         deleted_at = excluded.deleted_at,
         embedding_blob = CASE WHEN excluded.embedding_blob IS NULL THEN embedding_blob ELSE excluded.embedding_blob END,
         embedding = NULL,
+        embedding_failed_at = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failed_at END,
+        embedding_failure_kind = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failure_kind END,
+        embedding_attempts = CASE WHEN excluded.embedding_blob IS NOT NULL THEN 0 ELSE embedding_attempts END,
         okf_type = excluded.okf_type`,
       [
         fact.id,
@@ -356,6 +366,9 @@ export class EntryRepository extends BaseRepository {
         deleted_at = excluded.deleted_at,
         embedding_blob = excluded.embedding_blob,
         embedding = NULL,
+        embedding_failed_at = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failed_at END,
+        embedding_failure_kind = CASE WHEN excluded.embedding_blob IS NOT NULL THEN NULL ELSE embedding_failure_kind END,
+        embedding_attempts = CASE WHEN excluded.embedding_blob IS NOT NULL THEN 0 ELSE embedding_attempts END,
         okf_type = excluded.okf_type,
         lifecycle_status = excluded.lifecycle_status,
         stale_after = excluded.stale_after,

--- a/packages/core/src/services/EmbeddingService.ts
+++ b/packages/core/src/services/EmbeddingService.ts
@@ -42,7 +42,19 @@ export class EmbeddingService {
     }
   }
 
-  /** Promotes embedding_dimension_mismatch to canonical embedding_dimension when safe. */
+  /**
+   * Promotes embedding_dimension_mismatch to canonical embedding_dimension when
+   * safe, and clears embedding failure markers as part of the same event.
+   *
+   * Marker reset (spec §2.3): a promoted dimension means a different model is
+   * producing the vectors, so prior failures no longer predict future ones.
+   * `float32_overflow` is cleared too — it is terminal only because retrying is
+   * the same arithmetic on the same vector, and after a model change it is not.
+   *
+   * Revived rows are NOT embedded here. They become eligible and are picked up
+   * by the NEXT sweep, because runReembed calls this after its candidates were
+   * already classified; same-sweep revival would be re-entrant.
+   */
   async reconcileEmbeddingDimension(): Promise<void> {
     const mismatchValue = await this.metadataRepo.getMeta('embedding_dimension_mismatch');
     if (!mismatchValue) return;
@@ -52,6 +64,7 @@ export class EmbeddingService {
     if (residualCount === 0) {
       await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, this.db);
       await this.metadataRepo.clearDimensionMismatch(this.db);
+      await this.entryRepo.clearEmbeddingFailureMarkers();
     }
   }
 

--- a/packages/core/src/services/EmbeddingService.ts
+++ b/packages/core/src/services/EmbeddingService.ts
@@ -51,6 +51,8 @@ export class EmbeddingService {
    * `float32_overflow` is cleared too — it is terminal only because retrying is
    * the same arithmetic on the same vector, and after a model change it is not.
    *
+   * All three writes commit atomically; see the transaction note inline.
+   *
    * Revived rows are NOT embedded here. They become eligible and are picked up
    * by the NEXT sweep, because runReembed calls this after its candidates were
    * already classified; same-sweep revival would be re-entrant.
@@ -62,9 +64,18 @@ export class EmbeddingService {
     const newDim = parseInt(mismatchValue, 10);
     const residualCount = await this.entryRepo.countStaleEmbeddings(newDim);
     if (residualCount === 0) {
-      await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, this.db);
-      await this.metadataRepo.clearDimensionMismatch(this.db);
-      await this.entryRepo.clearEmbeddingFailureMarkers();
+      // One transaction for the whole promotion (spec §2.3): the three writes
+      // are a single logical event. Committed separately, a failure after
+      // clearDimensionMismatch would leave markers set with no mismatch key
+      // left to re-trigger promotion, stranding those rows until `force: true`.
+      // Safe to open here — both callers (runReembed, importDump's dimension
+      // reconciliation) invoke this outside their own transactions, and the
+      // adapter does not support nesting.
+      await this.db.withTransactionAsync(async (tx) => {
+        await this.metadataRepo.setMeta('embedding_dimension', mismatchValue, tx);
+        await this.metadataRepo.clearDimensionMismatch(tx);
+        await this.entryRepo.clearEmbeddingFailureMarkers(tx);
+      });
     }
   }
 

--- a/packages/core/src/services/EmbeddingService.ts
+++ b/packages/core/src/services/EmbeddingService.ts
@@ -76,7 +76,11 @@ export class EmbeddingService {
     tags: string | string[];
   }): Promise<EmbedFactResult> {
     const embedFn = this.options.llmProvider.embed;
-    if (!embedFn) return { ok: false, kind: 'no_provider' };
+    // Callability, not truthiness: a truthy non-function would pass a `!embedFn`
+    // guard, throw TypeError at the call, and be marked `provider_error` —
+    // burning an attempt per sweep until a host config error permanently
+    // excluded the fact. `no_provider` never marks. (spec §2.4)
+    if (typeof embedFn !== 'function') return { ok: false, kind: 'no_provider' };
     let tagsStr: string;
     if (Array.isArray(fact.tags)) {
       tagsStr = fact.tags.join(' ');

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -338,6 +338,19 @@ export class MaintenanceService {
     }
   }
 
+  /**
+   * Re-embed facts, honouring per-row failure markers and exponential backoff.
+   *
+   * Marker lifecycle (spec §2): markers are cleared by a successful embed, by
+   * an upsert carrying a valid blob, and by an embedding-dimension promotion.
+   * A promotion revives rows for the NEXT sweep, not this one — reconciliation
+   * runs after candidates were already classified.
+   *
+   * Residual, by design: swapping to a provider with the SAME dimension never
+   * sets embedding_dimension_mismatch, so promotion never fires and markers
+   * survive the swap. Use `runReembed({ force: true })` to clear that state —
+   * `force` bypasses classification entirely and retries every row.
+   */
   async runReembed(
     entityId?: string,
     opts?: { force?: boolean; skipExisting?: boolean },

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -343,7 +343,12 @@ export class MaintenanceService {
     opts?: { force?: boolean; skipExisting?: boolean },
   ): Promise<ReembedResult> {
     const embedFn = this.options.llmProvider.embed;
-    if (!embedFn) return { embedded: 0, skipped: 0, failed: 0, deferred: 0, permanentlyFailed: 0 };
+    // Same callability guard as EmbeddingService.tryEmbedFact (spec §2.4): a
+    // misconfigured provider short-circuits the sweep instead of iterating and
+    // marking every row.
+    if (typeof embedFn !== 'function') {
+      return { embedded: 0, skipped: 0, failed: 0, deferred: 0, permanentlyFailed: 0 };
+    }
 
     const op = entityId ? 'reembed' : 'global_reembed';
     this.jobManager.acquireLock(op, entityId ?? '*');

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -388,7 +388,7 @@ export class MaintenanceService {
 
       try {
         for (const row of rows) {
-          const existingBlob = (row as WikiFact & { embedding_blob?: Uint8Array | null }).embedding_blob;
+          const existingBlob = row.embedding_blob;
           const blobIsValid = !!existingBlob && existingBlob.byteLength > 0 && existingBlob.byteLength % 4 === 0;
 
           if (effectiveSkip && blobIsValid) {
@@ -399,15 +399,7 @@ export class MaintenanceService {
             }
           }
 
-          const disposition = classifyReembedRow(
-            row as unknown as {
-              embedding_failed_at?: number | null;
-              embedding_failure_kind?: string | null;
-              embedding_attempts?: number | null;
-            },
-            now,
-            force,
-          );
+          const disposition = classifyReembedRow(row, now, force);
           if (disposition === 'defer') { deferred++; continue; }
           if (disposition === 'permanent') { permanentlyFailed++; continue; }
 


### PR DESCRIPTION
Implements §2, §4.1, §4.3 and §4.4 of the marker lifecycle spec.

- Markers are cleared on embedding-dimension promotion, including
  `float32_overflow` — terminal only because retrying is the same arithmetic
  on the same vector, which stops being true after a model change.
- A truthy non-function `embed` is now `no_provider` instead of
  `provider_error`, so host misconfiguration no longer burns
  MAX_EMBED_ATTEMPTS.
- An upsert carrying a valid blob clears stale markers, in both `upsert` and
  `upsertForImport`.
- `findAllForReembed` returns `ReembedCandidateRow`, removing two casts.

Closes #121. Ticks items 1, 3 and 4 of #129.

Residual documented on `runReembed`: a same-dimension provider swap still
needs `runReembed({ force: true })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp35Kwxp3NLx3vqk6bxErm