### PR TITLE
fix(ci): retry release-phase detection through GitHub's merge-commit association lag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,36 @@ jobs:
           # drop a release PR that was created earlier but merged most
           # recently), and removes the need to bind github.sha into a jq
           # filter via shell interpolation.
-          MATCH=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
-            --jq '[.[] | select(.merged_at != null) | select(.base.ref == "main") | select(.head.ref | test("^release/v")) | .head.ref] | .[0] // empty')
+          #
+          # GitHub populates the merge-commit -> PR association
+          # asynchronously: on the 6.5.0 release (issue #140) the first
+          # query ran ~2s after the merge push, missed the association, and
+          # Phase 2 was skipped entirely - the workflow went green while
+          # publishing nothing. Retry while NO merged-into-main PR is
+          # associated with the commit yet; once any PR appears the
+          # association table has caught up, so a non-release answer is
+          # final. Direct (non-merge) pushes never gain associations, so
+          # they skip the retry window instead of burning it.
+          IS_MERGE=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}" --jq 'if (.parents | length) >= 2 then "true" else "false" end')
+          MATCH=""
+          QUERY_START=$(date +%s)
+          while true; do
+            RESULT=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+              --jq '{associated: [.[] | select(.merged_at != null) | select(.base.ref == "main") | .head.ref], release: ([.[] | select(.merged_at != null) | select(.base.ref == "main") | select(.head.ref | test("^release/v")) | .head.ref] | .[0] // "")}')
+            MATCH=$(echo "$RESULT" | jq -r '.release')
+            if [ "$(echo "$RESULT" | jq '.associated | length')" -gt 0 ]; then
+              break
+            fi
+            if [ "$IS_MERGE" != "true" ]; then
+              break
+            fi
+            if [ $(( $(date +%s) - QUERY_START )) -ge 60 ]; then
+              echo "::warning::No merged-PR association for ${COMMIT_SHA} after 60s; classifying as phase 1. If this was a release PR merge, re-run the workflow once the association exists (see issue #140)."
+              break
+            fi
+            echo "Commit ${COMMIT_SHA} is a merge commit with no PR association yet (GitHub association lag) - retrying in 5s."
+            sleep 5
+          done
 
           if [ -n "$MATCH" ]; then
             echo "phase=2" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

On the 6.5.0 release, the Release workflow's detect job queried `repos/{repo}/commits/{sha}/pulls` about **2 seconds** after the release PR's merge push. GitHub had not yet associated the merge commit with its PR, so the query returned nothing → `phase=1` → **Phase 2 skipped, workflow green, nothing published**. Recovery required a manual re-run once the association existed. Filed as #140.

First release under the merge-commit flow (#137) is what exposed it; the race exists for any query timing, but the merge push is the one case where the answer changes the run's entire behavior.

## The fix

Retry the association query while **no** merged-into-main PR is associated with the commit yet:

- **Association present** → classify immediately (any answer — release or not — is final, since the association table has caught up). Feature merges and re-runs of already-associated commits never wait.
- **Association absent + merge commit** → the exact race: retry every 5s, bounded at 60s, then warn with the recovery instruction and classify phase 1.
- **Association absent + not a merge commit** (direct push) → never gains associations; skip the window entirely.

Verified against real data:
- `a6864779` (#139 release merge): `{associated:[release/v6.5.0], release:release/v6.5.0}` → phase 2 on first query
- `e30cc0c` (#136 feature merge): `{associated:[fix/release-orphan-tag-heuristic], release:""}` → phase 1 on first query, no wait

Also considered (see #140): a `pull_request`-closed trigger for Phase 2 (no association lookup at all) — larger structural change to how Phase 2 gets its SHA; the retry is the minimal fix for the observed failure.

## Verification

- YAML parse OK (3 jobs intact); `bash -n` on the detect step OK.
- No source/package changes — typecheck/lint/tests unaffected (CI will confirm).

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)