### PR TITLE
build(release): recognize '!' breaking-change markers via conventionalcommits preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,10 +2,15 @@
   "branches": ["main"],
   "repositoryUrl": "https://github.com/equationalapplications/expo-llm-wiki",
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
     ["@semantic-release/changelog", {
-      "changelogFile": "CHANGELOG.md"
+      "changelogFile": "CHANGELOG.md",
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/npm", {
       "npmPublish": false

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^19.2.18",
     "@vitest/coverage-v8": "4.1.5",
     "better-sqlite3": "^12.11.1",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "expo-sqlite": "^57.0.1",
     "react": "19.2.8",
     "semantic-release": "^25.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      conventional-changelog-conventionalcommits:
+        specifier: ^8.0.0
+        version: 8.0.0
       expo-sqlite:
         specifier: ^57.0.1
         version: 57.0.1(expo@57.0.11)(react-native@0.86.2(@babel/core@7.29.6)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
@@ -2934,6 +2937,10 @@ packages:
 
   conventional-changelog-angular@8.3.1:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@8.0.0:
+    resolution: {integrity: sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
@@ -7675,7 +7682,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -8379,6 +8386,7 @@ snapshots:
   '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -8524,7 +8532,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.5(@types/node@26.4.1)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.4.1)(esbuild@0.28.1)(terser@5.51.2)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.5(@types/node@20.19.43)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.43)(esbuild@0.28.1)(terser@5.51.2)(tsx@4.23.11)(yaml@2.9.0))
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -9001,7 +9009,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -9010,7 +9018,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -9140,6 +9148,10 @@ snapshots:
   content-type@2.1.0: {}
 
   conventional-changelog-angular@8.3.1:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@8.0.0:
     dependencies:
       compare-func: 2.0.0
 
@@ -10305,7 +10317,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10322,7 +10334,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -12333,7 +12345,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@8.3.0: {}
+  undici-types@8.3.0:
+    optional: true
 
   undici@6.28.0: {}
 


### PR DESCRIPTION
## Why

The angular preset's parser admits no `!` (`headerPattern: /^(\w*)(?:\((.*)\))?: (.*)$/`, `noteKeywords: ['BREAKING CHANGE']`), so `ff21a4a "refactor(core-llm-tools)!: remove deprecated buildAuthorizedSchemaArray"` parsed as type-undefined and contributed nothing — the public-API removal shipped as **6.5.0, a minor** (issue #138).

## The change

- `.releaserc.json`: `commit-analyzer`, `release-notes-generator`, and `changelog` all use `preset: "conventionalcommits"` (changelog included so CHANGELOG.md sections stay consistent with release notes).
- `conventional-changelog-conventionalcommits` added as a root devDependency, **pinned to v8**: `release-notes-generator@14.1.1` pins `conventional-changelog-writer ^8`, and preset v10 embeds a guard template that raises `requires conventional-changelog-writer@9 or newer` under writer 8. v8 is the newest compatible major.

## Validation (real commits, real plugin versions)

Against the actual `v6.4.0..e846b36` range (44 commits) using the repo's installed plugins:

- `analyzeCommits({preset: 'conventionalcommits'})` → **major** (the 6.5.0 release would have been 7.0.0 under this config)
- `generateNotes` renders `### ⚠ BREAKING CHANGES` with *core-llm-tools: remove deprecated buildAuthorizedSchemaArray*
- Release heading format is `## [7.0.0](…)` — compatible with release.yml's heading-level-agnostic CHANGELOG extraction awk (`^#+ +\\[?`)

## Note

This does not retro-bump 6.5.0 — `ff21a4a` is now inside the v6.5.0 range. The preset protects future `!` commits only. A follow-up `7.0.0` (or documenting 6.5.0 as containing the removal) is a maintainer decision.

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)