### PR TITLE
ci(test): gate scopelab's fresh-clone vitest-source property

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Fresh-clone gate for scopelab's vitest source aliases (#131, issue
+      # #135): this is the ONLY test run that executes before `pnpm run
+      # build`, so it is the only place where the workspace deps resolve
+      # through apps/scopelab/vitest.config.ts aliases rather than built
+      # dist/ output. If a future change reintroduces a workspace import
+      # that is not source-aliased there, this step fails the way it
+      # failed pre-#131 ("Failed to resolve entry" from unresolved dist/
+      # imports) instead of shipping broken for real fresh clones while
+      # every CI run stays green on the pre-built tree.
+      - run: pnpm --filter scopelab test
+
       # Supply-chain gate (audit 2026-08-24, L-4). Fails the build on new
       # high/critical advisories. Known-unpatched exceptions are allowlisted
       # by GHSA id below with a tracking comment — keep this list minimal.


### PR DESCRIPTION
## Why

`apps/scopelab/vitest.config.ts` aliases workspace deps to source specifically so `pnpm --filter scopelab test` passes on a fresh clone without a prior build (#131 / #122). But `test.yml` runs `pnpm run build` before `pnpm test` — so every CI run has `dist/` populated and the alias set is never actually exercised. A future workspace import that isn't source-aliased would only fail for real fresh clones, not in CI (issue #135, flagged in #131 review ruling 6).

## The change

One step, placed immediately after `pnpm install --frozen-lockfile` and **before anything builds**:

```yaml
- run: pnpm --filter scopelab test
```

At that point in the job no `dist/` exists anywhere, so the workspace deps resolve exclusively through the vitest aliases — exactly the fresh-clone property. If the alias set regresses, this fails the way it failed pre-#131 (`Failed to resolve entry` from unresolved `dist/` imports) instead of passing vacuously on the pre-built tree.

## Verification

- YAML parse OK; step order confirmed (install → scopelab gate → audit → build → typecheck → test).
- Property proven on current main: clean worktree of `origin/main`, frozen install, no `dist/` anywhere → `pnpm --filter scopelab test` passes 14/14 via source aliases alone. The gate is green today and catches future regressions.

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)