### PR TITLE
fix(core): defer embedding-dimension promotion during reembed sweeps

### DIFF
--- a/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
+++ b/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
@@ -1,0 +1,218 @@
+# Reembed Lock Scope: Defer-While-Sweeping Promotion — Design
+
+**Status:** Approved, not yet implemented (2026-09-05)
+
+**Issue addressed:** #134 (marker clear during dimension promotion is not
+transactional with a concurrent sweep)
+
+**Extends:** `2026-09-04-marker-lifecycle-and-scopelab-hygiene-design.md`
+(spec §2 — marker lifecycle), whose §2 shipped the promotion-clears-markers
+behavior this spec now makes concurrency-safe, and
+`2026-09-04-embedding-failure-and-scope-hygiene-design.md`, which shipped the
+marker system itself.
+
+---
+
+## 1. Problem and scope decision
+
+Issue #134 (filed from the #133 review) describes two concurrency gaps:
+
+1. A row classified `permanent` by `runReembed`'s per-row loop has its
+   markers cleared mid-sweep by a concurrent `upsert`/`upsertForImport`
+   carrying a valid blob; the next sweep re-embeds a row the previous sweep
+   had excluded. Bounded cost: one extra embed attempt.
+2. A concurrent `importDump` triggers dimension promotion
+   (`reconcileEmbeddingDimension`) while a separate `runReembed` sweep is in
+   flight against the same DB.
+
+The issue framed both as open lock-granularity questions ("row-level?
+whole-DB? per-entity against reembed only?") requiring a spec-level decision.
+This spec records that decision.
+
+### 1.1 Concurrency model (constraint agreed 2026-09-05)
+
+The `JobManager` is an in-process, in-memory lock table constructed per
+`WikiMemory` instance (`WikiMemory.ts:112`). Its existence as the sole
+serialization point dictates the contract: **one `WikiMemory` instance per
+database**. Cross-instance or multi-JS-context access to one SQLite file is
+out of scope — no in-memory lock can enforce anything there, and the design
+does not try. If that requirement ever arises, it needs SQLite-level
+guarantees, not wider `JobManager` keys.
+
+The correctness bar is **bounded redundant work**, matching the issue's own
+framing: a mid-sweep clear may cost one redundant embed attempt, but no
+interleaving may lose data, strand rows, or un-bound the work.
+
+### 1.2 Investigation finding: the issue's gap 1 is already closed; gap 2 is one granularity mismatch
+
+Verification against the code (2026-09-05) materially narrows the issue:
+
+- **Same-row upsert during a sweep cannot happen in the single-instance
+  model.** Every marker-mutating write path checks reembed activity at lock
+  acquisition: `ingest` blocks on `_isReembedActive(entityId)`
+  (`JobManager.ts:243`), and `acquireImportLocks` checks every imported
+  entity (`JobManager.ts:415`). `_isReembedActive` covers both the
+  per-entity and the global reembed key (`JobManager.ts:115-118`). Since a
+  sweep holds its lock for the whole loop
+  (`MaintenanceService.ts:367`), an `upsert`/`upsertForImport` carrying a
+  blob for a row in the swept entity cannot start mid-sweep. Gap 1's
+  upsert-for-same-entity scenario is reachable only via gap 2's escape hatch
+  (below) or by violating the single-instance contract.
+- **The one mutation that escapes those checks is global while its locks are
+  entity-scoped.** `reconcileEmbeddingDimension` calls
+  `clearEmbeddingFailureMarkers` with no entity filter
+  (`EntryRepository.ts:962-970`), wiping markers for **all** entities inside
+  the promotion transaction (`EmbeddingService.ts:74-78`). Both of its
+  callers can hold entity-scoped locks only: `runReembed(entityId)` holds
+  `reembed:<A>`, and `importDump` of entity B passes
+  `acquireImportLocks([B])` while a sweep on entity A is in flight. The
+  promotion then erases A's rows — including classifications the in-flight
+  sweep just made. **Both issue gaps collapse into this one granularity
+  mismatch.**
+- **Latent hole (not in the issue):** `tryAcquireAutoHealLock`
+  (`JobManager.ts:359-365`) checks only the heal self-key, so an auto-heal
+  pass can run during a sweep. It is benign today only because heal upserts
+  exclusively blob-less new facts and the marker-clear in `upsert`/
+  `upsertForImport` is guarded by
+  `CASE WHEN excluded.embedding_blob IS NOT NULL`
+  (`EntryRepository.ts:222-224, 382-384`). A future edit that lets heal
+  carry blobs would silently reopen gap 1. §4.3 makes the exclusion
+  structural instead of accidental.
+
+---
+
+## 2. Decision: the lock-scope rule
+
+The rule this spec records (also to be stated in `runReembed`'s docstring):
+
+> **A marker mutation is legal while a reembed sweep is in flight if and
+> only if it cannot resurrect a row that sweep has classified.**
+>
+> - Mutation scoped to entities *not* under an active sweep key: legal
+>   (existing entity-scoped `ingest`/`import` lock checks enforce this).
+> - The one global mutation (`reconcileEmbeddingDimension`'s
+>   promotion-transaction marker clear): legal only by **deferring** —
+>   never by widening a lock.
+
+Deferral works because `embedding_dimension_mismatch` is sticky: skipping
+the promotion leaves the key set, and the promotion deterministically
+completes at the next sweep tail (`runReembed` calls
+`reconcileEmbeddingDimension` after its loop, `MaintenanceService.ts:424-426`)
+or the next importDump reconciliation. No state is lost by waiting; a
+promotion that lands one sweep later has identical semantics to one that
+lands mid-sweep, minus the resurrected-row race.
+
+Approaches considered and rejected:
+
+- **Global mutual exclusion** (import/ingest block on *any* active reembed):
+  trivially correct, but importDump of entity B would throw `WikiBusyError`
+  because a network-bound sweep on entity A is running — user-visible
+  failures for zero added safety, since same-row mutation is already blocked.
+- **Per-row freshness re-check** (sweep re-reads markers before each embed):
+  tolerates multi-instance, but adds a SELECT per attempted row, leaves the
+  `embedding_dimension` metadata flip racing the sweep, and sidesteps the
+  lock-scope question rather than deciding it. Reconsider only if the
+  single-instance constraint is ever lifted.
+
+---
+
+## 3. Changes
+
+### 3.1 `JobManager.isAnyReembedActive(): boolean`
+
+New public, read-only query: true when the global reembed key is held **or**
+any `<prefix>:<entity>:reembed` key is held. Implementation is a thin public
+wrapper over the existing `_isAnyMaintenanceActiveWithSuffix(':reembed')`
+(`JobManager.ts:129-135`) plus the global-key check — the same predicate
+`global_reembed` acquisition already uses (`JobManager.ts:210`). No new lock
+types, no lock widening, no side effects.
+
+### 3.2 Gate the `importDump` promotion call site
+
+`ImportExportService.ts:524`: before calling
+`this.embeddingService.reconcileEmbeddingDimension()`, check
+`this.jobManager.isAnyReembedActive()`. If true, skip the call and log at
+info level: `[WikiMemory] importDump: embedding-dimension promotion
+deferred; a reembed sweep is in flight`. The
+mismatch key is already set at that point in every path that reaches the
+call, so the deferred promotion is guaranteed to fire later.
+
+The gate lives at the call site, not inside `reconcileEmbeddingDimension`:
+the sweep's own tail call would see its *own* lock and defer forever unless a
+reentrancy flag were threaded through, and the two existing call sites are
+the complete caller set. `EmbeddingService` keeps no `JobManager` reference —
+no constructor churn, no wiring reorder in `WikiMemory.ts`. The contract is
+documented on `reconcileEmbeddingDimension`'s docstring instead:
+
+> Callers must not invoke while a reembed sweep is in flight unless they hold
+> that sweep's lock. External callers gate on `JobManager.isAnyReembedActive()`
+> and defer; `runReembed`'s tail call is exempt (it holds the sweep lock).
+
+### 3.3 `tryAcquireAutoHealLock` refuses during sweeps
+
+`JobManager.ts:359-365`: return false when `isAnyReembedActive()` is true.
+Effect: auto-heal passes started from `write()` skip while a sweep runs and
+retry on a later write — the existing checkpoint-holdback semantics
+(`WriteService.maybeRunHeal`) already make a skipped pass safe. This converts
+heal's current accidental safety (§1.2, latent hole) into a stated invariant.
+
+### 3.4 Documentation
+
+- `runReembed`'s docstring ("Residual, by design" paragraph,
+  `MaintenanceService.ts:341-353`) gains the §2 lock-scope rule.
+- `reconcileEmbeddingDimension`'s docstring gains the caller contract (§3.2).
+
+---
+
+## 4. Error handling and observability
+
+Deferral is not an error. No `WikiBusyError` is thrown by any change in this
+spec; no public return shape changes (`importDump`'s result and
+`reconcileEmbeddingDimension`'s `void` are unchanged). The deferral is
+observable via the info-level log and via `embedding_dimension_mismatch`
+remaining set. Callers cannot distinguish "promoted" from "deferred" in
+return values — deliberate; promotion is eventual and polling it would add
+API surface for no action a caller could take.
+
+---
+
+## 5. Testing
+
+Unit tests (vitest, `packages/core`):
+
+1. `isAnyReembedActive()` — false when idle; true for per-entity reembed
+   key; true for global reembed key; false again after release; true when
+   only a non-reembed maintenance key (e.g. prune) is held.
+2. importDump promotion deferral — with a reembed lock held (per-entity and
+   global variants), importDump's reconciliation leaves
+   `embedding_dimension_mismatch` set and leaves pre-existing failure
+   markers intact; after the lock is released and a sweep tail runs, the
+   promotion completes and markers clear.
+3. Sweep tail promotion unaffected — `runReembed` holding its own lock still
+   promotes in the same call (guards against the §3.2 gate ever migrating
+   into `reconcileEmbeddingDimension` and self-deadlocking).
+4. Auto-heal — `tryAcquireAutoHealLock` returns false while any reembed is
+   active, true after release; an existing write→auto-heal flow still
+   converges once the sweep ends.
+
+---
+
+## 6. Out of scope
+
+- Multi-instance / multi-JS-context concurrency (§1.1).
+- Per-row freshness re-checks (§2, rejected approach).
+- Same-dimension provider swap leaving markers stranded — documented
+  residual of spec §2, still escaped via `runReembed({ force: true })`.
+- Any change to `storeEmbeddingDimension`'s mismatch bookkeeping
+  (`EmbeddingService.ts:27-50`); the metadata writes it performs during a
+  sweep are per-dimension values, not marker mutations, and are outside the
+  §2 rule.
+
+---
+
+## 7. Implementation shape
+
+Single PR against `packages/core`: §3.1 + §3.2 + §3.3 + §3.4 land together
+(the rule, its enforcement, and its documentation are one atomic decision);
+§5's tests in the same PR. Closes #134 on merge. Commit message must keep
+any breaking-change wording out of line-start position (repo convention).

--- a/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
+++ b/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
@@ -13,6 +13,18 @@ changed — §2's rule and §3's changes stand as approved.
 gate, §3.3 auto-heal exclusion, §3.4 docstrings all landed with tests in
 `__tests__/jobs.test.ts` and `__tests__/reembedLockScope.test.ts`.
 
+**Status (2026-09-05, post-implementation review):** Corrected docs, no code
+change. §2's "the promotion deterministically completes at the next sweep
+tail" overstates liveness: the tail is conditional — `runReembed` calls
+`reconcileEmbeddingDimension` only `if (embedded > 0)`, so a sweep that
+embeds nothing (all rows skipped/deferred/permanently-failed) runs no tail
+reconciliation. The accurate promise: a deferred promotion completes at a
+later importDump reconciliation or at the next *productive* sweep tail (one
+that embeds > 0 rows). The pending state is harmless — it is exactly the
+pre-import state — and the sticky mismatch key preserves promotion intent
+through any number of unproductive sweeps. §2's original text stands as the
+approved record; importDump's gate comment now states the condition.
+
 **Issue addressed:** #134 (marker clear during dimension promotion is not
 transactional with a concurrent sweep)
 

--- a/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
+++ b/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
@@ -2,6 +2,13 @@
 
 **Status:** Approved, not yet implemented (2026-09-05)
 
+**Status (2026-09-05, self-review):** Corrected before implementation. §1.2
+gained the per-entity-sweep confinement finding; §3.2's deferral-safety
+argument was wrong as first written (the mismatch key is *not* set on every
+path) and now argues both reachable states; §3.2 records why the gate has no
+TOCTOU; §5 test 2 dropped an unreachable global-reembed variant. No decision
+changed — §2's rule and §3's changes stand as approved.
+
 **Issue addressed:** #134 (marker clear during dimension promotion is not
 transactional with a concurrent sweep)
 
@@ -69,6 +76,14 @@ Verification against the code (2026-09-05) materially narrows the issue:
   promotion then erases A's rows — including classifications the in-flight
   sweep just made. **Both issue gaps collapse into this one granularity
   mismatch.**
+- **The defect is confined to per-entity sweeps.** `_isReembedActive` returns
+  true for the *global* reembed key regardless of entity
+  (`JobManager.ts:115-118`), so `acquireImportLocks` already throws
+  `WikiBusyError` for any import attempted during a `runReembed()` with no
+  entityId. Only `runReembed(entityId)` — which holds solely `reembed:<A>` —
+  leaves the window open, and only for an import of some entity B ≠ A. This
+  boundary matters for testing: an importDump-level test of the global
+  variant cannot reach the promotion call site at all (§5).
 - **Latent hole (not in the issue):** `tryAcquireAutoHealLock`
   (`JobManager.ts:359-365`) checks only the heal self-key, so an auto-heal
   pass can run during a sweep. It is benign today only because heal upserts
@@ -125,7 +140,9 @@ any `<prefix>:<entity>:reembed` key is held. Implementation is a thin public
 wrapper over the existing `_isAnyMaintenanceActiveWithSuffix(':reembed')`
 (`JobManager.ts:129-135`) plus the global-key check — the same predicate
 `global_reembed` acquisition already uses (`JobManager.ts:210`). No new lock
-types, no lock widening, no side effects.
+types, no lock widening, no side effects. `JobManager` is not re-exported
+from `packages/core/src/index.ts`, so the new method adds no public API
+surface and `publicExports.test.ts` needs no update.
 
 ### 3.2 Gate the `importDump` promotion call site
 
@@ -133,9 +150,26 @@ types, no lock widening, no side effects.
 `this.embeddingService.reconcileEmbeddingDimension()`, check
 `this.jobManager.isAnyReembedActive()`. If true, skip the call and log at
 info level: `[WikiMemory] importDump: embedding-dimension promotion
-deferred; a reembed sweep is in flight`. The
-mismatch key is already set at that point in every path that reaches the
-call, so the deferred promotion is guaranteed to fire later.
+deferred; a reembed sweep is in flight`.
+
+Deferring is safe in both of the states reachable at that line, for two
+different reasons. Where `embedding_dimension_mismatch` is set, the key is
+sticky and the promotion fires at the next sweep tail or import. Where it is
+*not* set — the `canonicalDim === null` fresh-DB branch, in which
+`storeEmbeddingDimension` writes the canonical dimension and the
+`staleMismatchValue` guard writes nothing — `reconcileEmbeddingDimension`
+returns immediately at its own `if (!mismatchValue) return;`
+(`EmbeddingService.ts:61-62`). Skipping it there defers a no-op. Nothing is
+lost in either case.
+
+**The gate is free of a TOCTOU of its own, non-obviously.** Line 524 executes
+inside `doImportEntity`, within the `try` block that holds the global import
+key (`ImportExportService.ts:65-72`), and `acquireLock` rejects every
+operation except `global_import` while that key is held
+(`JobManager.ts:168-170`). No sweep can therefore start between the
+`isAnyReembedActive()` check and the promotion transaction. Do not add
+re-checking or locking here on suspicion of a race; there is none while that
+invariant holds.
 
 The gate lives at the call site, not inside `reconcileEmbeddingDimension`:
 the sweep's own tail call would see its *own* lock and defer forever unless a
@@ -183,11 +217,17 @@ Unit tests (vitest, `packages/core`):
 1. `isAnyReembedActive()` — false when idle; true for per-entity reembed
    key; true for global reembed key; false again after release; true when
    only a non-reembed maintenance key (e.g. prune) is held.
-2. importDump promotion deferral — with a reembed lock held (per-entity and
-   global variants), importDump's reconciliation leaves
-   `embedding_dimension_mismatch` set and leaves pre-existing failure
+2. importDump promotion deferral — hold a **per-entity** reembed lock for
+   entity A, then importDump entity B: the reconciliation leaves
+   `embedding_dimension_mismatch` set and leaves A's pre-existing failure
    markers intact; after the lock is released and a sweep tail runs, the
    promotion completes and markers clear.
+
+   Do **not** write the global-reembed variant of this test at the importDump
+   level: `acquireImportLocks` throws `WikiBusyError` before the promotion
+   call site is reached (§1.2), so such a test would assert on an unreachable
+   path. Cover the global key through test 1 instead, which exercises
+   `isAnyReembedActive()` directly.
 3. Sweep tail promotion unaffected — `runReembed` holding its own lock still
    promotes in the same call (guards against the §3.2 gate ever migrating
    into `reconcileEmbeddingDimension` and self-deadlocking).
@@ -204,7 +244,7 @@ Unit tests (vitest, `packages/core`):
 - Same-dimension provider swap leaving markers stranded — documented
   residual of spec §2, still escaped via `runReembed({ force: true })`.
 - Any change to `storeEmbeddingDimension`'s mismatch bookkeeping
-  (`EmbeddingService.ts:27-50`); the metadata writes it performs during a
+  (`EmbeddingService.ts:27-42`); the metadata writes it performs during a
   sweep are per-dimension values, not marker mutations, and are outside the
   §2 rule.
 

--- a/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
+++ b/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
@@ -127,9 +127,10 @@ The rule this spec records (also to be stated in `runReembed`'s docstring):
 
 Deferral works because `embedding_dimension_mismatch` is sticky: skipping
 the promotion leaves the key set, and the promotion deterministically
-completes at the next sweep tail (`runReembed` calls
-`reconcileEmbeddingDimension` after its loop, `MaintenanceService.ts:424-426`)
-or the next importDump reconciliation. No state is lost by waiting; a
+completes at the next *productive* sweep tail (`runReembed` calls
+`reconcileEmbeddingDimension` after its loop, and only when it embedded
+> 0 rows — a sweep that embeds nothing runs no tail reconciliation,
+`MaintenanceService.ts:424-426`) or the next importDump reconciliation. No state is lost by waiting; a
 promotion that lands one sweep later has identical semantics to one that
 lands mid-sweep, minus the resurrected-row race.
 
@@ -170,7 +171,8 @@ deferred; a reembed sweep is in flight`.
 
 Deferring is safe in both of the states reachable at that line, for two
 different reasons. Where `embedding_dimension_mismatch` is set, the key is
-sticky and the promotion fires at the next sweep tail or import. Where it is
+sticky and the promotion fires at the next *productive* sweep tail or
+import. Where it is
 *not* set — the `canonicalDim === null` fresh-DB branch, in which
 `storeEmbeddingDimension` writes the canonical dimension and the
 `staleMismatchValue` guard writes nothing — `reconcileEmbeddingDimension`

--- a/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
+++ b/docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md
@@ -9,6 +9,10 @@ path) and now argues both reachable states; §3.2 records why the gate has no
 TOCTOU; §5 test 2 dropped an unreachable global-reembed variant. No decision
 changed — §2's rule and §3's changes stand as approved.
 
+**Status (2026-09-05):** Implemented. §3.1 `isAnyReembedActive`, §3.2 importDump
+gate, §3.3 auto-heal exclusion, §3.4 docstrings all landed with tests in
+`__tests__/jobs.test.ts` and `__tests__/reembedLockScope.test.ts`.
+
 **Issue addressed:** #134 (marker clear during dimension promotion is not
 transactional with a concurrent sweep)
 

--- a/packages/core/__tests__/jobs.test.ts
+++ b/packages/core/__tests__/jobs.test.ts
@@ -203,3 +203,27 @@ describe('isAnyReembedActive', () => {
     expect(jm.isAnyReembedActive()).toBe(false);
   });
 });
+
+describe('tryAcquireAutoHealLock vs reembed sweeps', () => {
+  it('refuses the lock while a per-entity sweep is in flight', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('reembed', 'e1');
+    expect(jm.tryAcquireAutoHealLock('e1')).toBe(false);
+    jm.releaseLock('reembed', 'e1');
+    expect(jm.tryAcquireAutoHealLock('e1')).toBe(true);
+  });
+
+  it('refuses the lock during a global sweep, for any entity', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('global_reembed', '*');
+    expect(jm.tryAcquireAutoHealLock('e-other')).toBe(false);
+    jm.releaseLock('global_reembed', '*');
+    expect(jm.tryAcquireAutoHealLock('e-other')).toBe(true);
+  });
+
+  it('still refuses a second concurrent auto-heal on the same entity', () => {
+    const jm = new JobManager('llm_wiki_');
+    expect(jm.tryAcquireAutoHealLock('e1')).toBe(true);
+    expect(jm.tryAcquireAutoHealLock('e1')).toBe(false);
+  });
+});

--- a/packages/core/__tests__/jobs.test.ts
+++ b/packages/core/__tests__/jobs.test.ts
@@ -174,3 +174,32 @@ describe('ontologyBackfill lock', () => {
     }
   });
 });
+
+describe('isAnyReembedActive', () => {
+  it('is false on a fresh JobManager', () => {
+    const jm = new JobManager('llm_wiki_');
+    expect(jm.isAnyReembedActive()).toBe(false);
+  });
+
+  it('is true while a per-entity reembed lock is held, false after release', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('reembed', 'e1');
+    expect(jm.isAnyReembedActive()).toBe(true);
+    jm.releaseLock('reembed', 'e1');
+    expect(jm.isAnyReembedActive()).toBe(false);
+  });
+
+  it('is true while a global reembed lock is held, false after release', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('global_reembed', '*');
+    expect(jm.isAnyReembedActive()).toBe(true);
+    jm.releaseLock('global_reembed', '*');
+    expect(jm.isAnyReembedActive()).toBe(false);
+  });
+
+  it('ignores non-reembed maintenance locks', () => {
+    const jm = new JobManager('llm_wiki_');
+    jm.acquireLock('prune', 'e1');
+    expect(jm.isAnyReembedActive()).toBe(false);
+  });
+});

--- a/packages/core/__tests__/reembedLockScope.test.ts
+++ b/packages/core/__tests__/reembedLockScope.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { WikiMemory } from '../src/WikiMemory';
+import { openTestDatabase } from './helpers/sqliteAdapter';
+import type { SQLiteAdapter } from '../src/types';
+
+const stubOptions = { llmProvider: { generateText: async () => '{}' } } as const;
+const PREFIX = 'llm_wiki_';
+
+/** A 3-dim float32 blob, matching the canonical dimension the tests set. */
+const BLOB_3D = new Uint8Array(new Float32Array([1, 0, 0]).buffer);
+
+function fact(id: string, entityId: string, blob?: Uint8Array) {
+  return {
+    id,
+    entity_id: entityId,
+    title: 'T',
+    body: 'B',
+    tags: [],
+    confidence: 'certain',
+    source_type: 'user_stated',
+    source_hash: null,
+    source_ref: null,
+    created_at: 1_700_000_000_000,
+    updated_at: 1_700_000_000_000,
+    last_accessed_at: null,
+    access_count: 0,
+    deleted_at: null,
+    okf_type: 'fact',
+    ...(blob ? { embedding_blob: blob } : {}),
+  };
+}
+
+function dumpFor(entityId: string, blob?: Uint8Array) {
+  return {
+    generatedAt: 1_700_000_000_000,
+    entities: {
+      [entityId]: {
+        facts: [fact(`f-${entityId}`, entityId, blob)],
+        tasks: [],
+        events: [],
+        edges: [],
+        summary: '',
+      },
+    },
+  } as any;
+}
+
+async function getMarkerRow(db: SQLiteAdapter, factId: string) {
+  return db.getFirstAsync<{
+    embedding_failed_at: number | null;
+    embedding_failure_kind: string | null;
+    embedding_attempts: number;
+  }>(
+    `SELECT embedding_failed_at, embedding_failure_kind, embedding_attempts
+       FROM ${PREFIX}entries WHERE id = ?`,
+    [factId],
+  );
+}
+
+/**
+ * Entity A holds a marked, blob-less fact and the DB is primed so that an
+ * import of entity B (carrying a 3-dim blob) reaches the promotion call site:
+ * canonical dimension 3 == the imported blob's dimension.
+ */
+async function primed() {
+  const db = openTestDatabase();
+  const wiki = new WikiMemory(db, stubOptions);
+  await wiki.setup();
+
+  await wiki.importDump(dumpFor('A'));
+
+  const repo = (wiki as any).entryRepo;
+  const metadataRepo = (wiki as any).metadataRepo;
+  const jobManager = (wiki as any).jobManager;
+
+  await repo.markEmbeddingFailure('f-A', 'float32_overflow', 1000);
+  await metadataRepo.setMeta('embedding_dimension', '3', db);
+  await metadataRepo.setMeta('embedding_dimension_mismatch', '3', db);
+
+  return { wiki, db, metadataRepo, jobManager };
+}
+
+describe('reembed lock scope — importDump promotion deferral', () => {
+  it('promotes normally when no sweep is in flight (baseline)', async () => {
+    const { wiki, db, metadataRepo } = await primed();
+
+    await wiki.importDump(dumpFor('B', BLOB_3D));
+
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBeNull();
+    expect((await getMarkerRow(db, 'f-A'))?.embedding_failure_kind).toBeNull();
+  });
+
+  it('defers promotion while a per-entity sweep on another entity is in flight', async () => {
+    const { wiki, db, metadataRepo, jobManager } = await primed();
+
+    jobManager.acquireLock('reembed', 'A');
+    try {
+      await wiki.importDump(dumpFor('B', BLOB_3D));
+    } finally {
+      jobManager.releaseLock('reembed', 'A');
+    }
+
+    // Promotion intent preserved, and the in-flight sweep's classification
+    // for entity A survives untouched.
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBe('3');
+    const row = await getMarkerRow(db, 'f-A');
+    expect(row?.embedding_failed_at).toBe(1000);
+    expect(row?.embedding_failure_kind).toBe('float32_overflow');
+  });
+
+  it('completes the deferred promotion on the next import once the sweep ends', async () => {
+    const { wiki, db, metadataRepo, jobManager } = await primed();
+
+    jobManager.acquireLock('reembed', 'A');
+    try {
+      await wiki.importDump(dumpFor('B', BLOB_3D));
+    } finally {
+      jobManager.releaseLock('reembed', 'A');
+    }
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBe('3');
+
+    // Sticky key means the very next reconciliation finishes the job.
+    await wiki.importDump(dumpFor('B', BLOB_3D));
+
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBeNull();
+    expect((await getMarkerRow(db, 'f-A'))?.embedding_failure_kind).toBeNull();
+  });
+});
+
+describe('reembed lock scope — a sweep tail still promotes under its own lock', () => {
+  it('promotes at the end of runReembed even though the sweep lock is held', async () => {
+    const db = openTestDatabase();
+    const wiki = new WikiMemory(db, {
+      llmProvider: {
+        generateText: async () => '{}',
+        embed: async () => [1, 0, 0],
+      },
+    } as any);
+    await wiki.setup();
+
+    // f-A is permanently marked; f-A2 is embeddable, so the sweep reaches
+    // `embedded > 0` and runs its tail reconciliation.
+    await wiki.importDump({
+      generatedAt: 1_700_000_000_000,
+      entities: {
+        A: {
+          facts: [fact('f-A', 'A'), fact('f-A2', 'A')],
+          tasks: [], events: [], edges: [], summary: '',
+        },
+      },
+    } as any);
+
+    const repo = (wiki as any).entryRepo;
+    const metadataRepo = (wiki as any).metadataRepo;
+    await repo.markEmbeddingFailure('f-A', 'float32_overflow', 1000);
+    await metadataRepo.setMeta('embedding_dimension', '3', db);
+    await metadataRepo.setMeta('embedding_dimension_mismatch', '3', db);
+
+    const result = await wiki.runReembed('A');
+
+    expect(result.embedded).toBeGreaterThan(0);
+    expect(await metadataRepo.getMeta('embedding_dimension_mismatch')).toBeNull();
+    expect((await getMarkerRow(db, 'f-A'))?.embedding_failure_kind).toBeNull();
+  });
+});

--- a/packages/core/__tests__/reembedLockScope.test.ts
+++ b/packages/core/__tests__/reembedLockScope.test.ts
@@ -93,6 +93,9 @@ describe('reembed lock scope — importDump promotion deferral', () => {
   it('defers promotion while a per-entity sweep on another entity is in flight', async () => {
     const { wiki, db, metadataRepo, jobManager } = await primed();
 
+    // Deliberate simulation: holding the raw lock instead of running a real
+    // runReembed — the importDump gate reads only the lock table, so an
+    // acquired 'reembed' lock is indistinguishable from a live sweep to it.
     jobManager.acquireLock('reembed', 'A');
     try {
       await wiki.importDump(dumpFor('B', BLOB_3D));

--- a/packages/core/__tests__/services/ImportExportService.test.ts
+++ b/packages/core/__tests__/services/ImportExportService.test.ts
@@ -65,6 +65,7 @@ describe('ImportExportService', () => {
     mockJobManager = {
       acquireImportLocks: vi.fn(),
       releaseImportLocks: vi.fn(),
+      isAnyReembedActive: vi.fn().mockReturnValue(false),
     };
 
     mockEmbeddingService = {

--- a/packages/core/src/services/EmbeddingService.ts
+++ b/packages/core/src/services/EmbeddingService.ts
@@ -60,7 +60,11 @@ export class EmbeddingService {
    * Caller contract (spec 2026-09-05 §3.2): callers must not invoke this while
    * a reembed sweep is in flight unless they hold that sweep's lock, because
    * the marker clear spans every entity. `runReembed`'s tail call is exempt —
-   * it holds the sweep lock, so nothing else can be running. External callers
+   * by the tail, the sweep's classification phase is complete, so the clear
+   * cannot resurrect a row THIS sweep classified; any overlap with a
+   * concurrent import's entity-scoped, blob-guarded writes (an importDump of a
+   * different entity can run during a per-entity sweep) is bounded redundant
+   * work. External callers
    * gate on `JobManager.isAnyReembedActive()` and defer. This service
    * deliberately holds no `JobManager` reference: gating here instead of at
    * the call site would make `runReembed`'s own tail call see its own lock and

--- a/packages/core/src/services/EmbeddingService.ts
+++ b/packages/core/src/services/EmbeddingService.ts
@@ -56,6 +56,15 @@ export class EmbeddingService {
    * Revived rows are NOT embedded here. They become eligible and are picked up
    * by the NEXT sweep, because runReembed calls this after its candidates were
    * already classified; same-sweep revival would be re-entrant.
+   *
+   * Caller contract (spec 2026-09-05 §3.2): callers must not invoke this while
+   * a reembed sweep is in flight unless they hold that sweep's lock, because
+   * the marker clear spans every entity. `runReembed`'s tail call is exempt —
+   * it holds the sweep lock, so nothing else can be running. External callers
+   * gate on `JobManager.isAnyReembedActive()` and defer. This service
+   * deliberately holds no `JobManager` reference: gating here instead of at
+   * the call site would make `runReembed`'s own tail call see its own lock and
+   * defer forever.
    */
   async reconcileEmbeddingDimension(): Promise<void> {
     const mismatchValue = await this.metadataRepo.getMeta('embedding_dimension_mismatch');

--- a/packages/core/src/services/ImportExportService.ts
+++ b/packages/core/src/services/ImportExportService.ts
@@ -525,7 +525,9 @@ export class ImportExportService {
           // entity, but this import holds only entity-scoped locks — so it can
           // erase classifications a concurrent runReembed(otherEntity) just
           // made. Defer instead of widening the lock: the mismatch key is
-          // sticky, so the next sweep tail or import completes the promotion.
+          // sticky, so a later import or a productive sweep tail (one that
+          // embeds > 0 rows — MaintenanceService runs the tail reconciliation
+          // only `if (embedded > 0)`) completes the promotion.
           // Spec 2026-09-05-reembed-lock-scope-design.md §3.2.
           if (this.jobManager.isAnyReembedActive()) {
             console.info(

--- a/packages/core/src/services/ImportExportService.ts
+++ b/packages/core/src/services/ImportExportService.ts
@@ -521,7 +521,19 @@ export class ImportExportService {
               this.db,
             );
           }
-          await this.embeddingService.reconcileEmbeddingDimension();
+          // Dimension promotion clears embedding failure markers for EVERY
+          // entity, but this import holds only entity-scoped locks — so it can
+          // erase classifications a concurrent runReembed(otherEntity) just
+          // made. Defer instead of widening the lock: the mismatch key is
+          // sticky, so the next sweep tail or import completes the promotion.
+          // Spec 2026-09-05-reembed-lock-scope-design.md §3.2.
+          if (this.jobManager.isAnyReembedActive()) {
+            console.info(
+              '[WikiMemory] importDump: embedding-dimension promotion deferred; a reembed sweep is in flight',
+            );
+          } else {
+            await this.embeddingService.reconcileEmbeddingDimension();
+          }
         } else {
           await this.metadataRepo.setMeta(
             'embedding_dimension_mismatch',

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -117,6 +117,24 @@ export class JobManager {
            this.activeMaintenanceJobs.has(this._globalReembedKey());
   }
 
+  /**
+   * True while any reembed sweep is in flight — per-entity or global.
+   *
+   * Read-only; acquires nothing. Callers that mutate embedding failure
+   * markers across ALL entities (the dimension-promotion clear) must gate on
+   * this and defer, rather than resurrect rows an in-flight sweep already
+   * classified. See spec 2026-09-05-reembed-lock-scope-design.md §2.
+   *
+   * The global key `${prefix}:reembed` also ends in ':reembed', so the suffix
+   * scan alone would already match it. The explicit check is kept because it
+   * documents the intent and survives any future change to the global key's
+   * format.
+   */
+  isAnyReembedActive(): boolean {
+    return this.activeMaintenanceJobs.has(this._globalReembedKey()) ||
+           this._isAnyMaintenanceActiveWithSuffix(':reembed');
+  }
+
   private _isImportActiveFor(entityId: string): boolean {
     return this.activeMaintenanceJobs.has(this._importKey(entityId)) ||
            this.activeMaintenanceJobs.has(this._globalImportKey());

--- a/packages/core/src/services/JobManager.ts
+++ b/packages/core/src/services/JobManager.ts
@@ -371,10 +371,23 @@ export class JobManager {
   }
 
   /**
-   * Auto-heal historically only gated on the heal self-key. Keep that behavior
-   * for write() auto-trigger paths while preserving stricter checks in acquireLock().
+   * Auto-heal historically only gated on the heal self-key. Keep that
+   * permissiveness for write() auto-trigger paths — stricter checks stay in
+   * acquireLock() — with one exception: reembed sweeps, which are excluded
+   * structurally rather than by accident (see below).
    */
   tryAcquireAutoHealLock(entityId: string): boolean {
+    // Heal must not run during a sweep. It is safe today only because heal
+    // upserts blob-less facts and the marker clear is guarded by
+    // `CASE WHEN excluded.embedding_blob IS NOT NULL` — an accident of the
+    // current SQL, not a stated rule. Make the exclusion structural so a
+    // future heal that carries blobs cannot silently resurrect rows an
+    // in-flight sweep classified. Spec 2026-09-05 §3.3.
+    //
+    // A refused pass is not lost work: WriteService.maybeRunHeal holds its
+    // checkpoint back, so the next write retries.
+    if (this.isAnyReembedActive()) return false;
+
     const healKey = this._healKey(entityId);
     if (this.activeMaintenanceJobs.has(healKey)) return false;
     this.activeMaintenanceJobs.add(healKey);

--- a/packages/core/src/services/MaintenanceService.ts
+++ b/packages/core/src/services/MaintenanceService.ts
@@ -350,6 +350,15 @@ export class MaintenanceService {
    * sets embedding_dimension_mismatch, so promotion never fires and markers
    * survive the swap. Use `runReembed({ force: true })` to clear that state —
    * `force` bypasses classification entirely and retries every row.
+   *
+   * Lock scope (spec 2026-09-05 §2): a marker mutation is legal while a sweep
+   * is in flight if and only if it cannot resurrect a row the sweep has
+   * classified. Mutations scoped to entities not under an active sweep key are
+   * legal — the entity-scoped ingest/import lock checks enforce that. The one
+   * mutation that spans every entity, `reconcileEmbeddingDimension`'s marker
+   * clear, is made legal by DEFERRING (importDump gates on
+   * `JobManager.isAnyReembedActive()`), never by widening a lock. Auto-heal is
+   * excluded from sweeps for the same reason.
    */
   async runReembed(
     entityId?: string,


### PR DESCRIPTION
Closes #134.

`reconcileEmbeddingDimension` clears embedding failure markers for every
entity, but its callers hold only entity-scoped locks. An `importDump` of
entity B could therefore erase classifications made by an in-flight
`runReembed('A')`, resurrecting rows that sweep had excluded.

**Decision (spec §2):** a marker mutation is legal during a sweep iff it
cannot resurrect a row the sweep classified. The one global mutation defers
instead of widening a lock.

- `JobManager.isAnyReembedActive()` — read-only predicate, no new lock types
- `importDump` gates on it and skips the promotion; the sticky
  `embedding_dimension_mismatch` key means the next sweep tail or import
  completes it
- `tryAcquireAutoHealLock` refuses during sweeps, making an accidental
  safety property structural

No public API change, no lock widening, no new `WikiBusyError` paths.

Spec: `docs/superpowers/specs/2026-09-05-reembed-lock-scope-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)